### PR TITLE
Index into lobid resources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.11.11"
 resolvers += Resolver.mavenLocal
 
 libraryDependencies ++= Seq(
+  "org.metafacture" % "metafacture-elasticsearch" % "5.3.1",
   "org.metafacture" % "metafacture-io" % "5.3.1",
   "org.metafacture" % "metafacture-strings" % "5.3.1",
   "org.metafacture" % "metafacture-json" % "5.3.1",

--- a/conf/rpb2lobid.flux
+++ b/conf/rpb2lobid.flux
@@ -1,0 +1,14 @@
+default outfile = "bulk.ndjson";
+FLUX_DIR + "RPB-Export_HBZ_Titel_Test.txt";
+| open-file(encoding="IBM437")
+| as-lines
+| rpb.Decode
+| fix(FLUX_DIR + "rpb.fix")
+| batch-reset(batchsize="1000")
+| encode-json(prettyPrinting="true")
+| json-to-elasticsearch-bulk(idkey="id", type="resource", index="resources-smalltest")
+| write(outfile)
+;
+
+// then upload via curl:
+//curl -XPOST --header 'Content-Type: application/x-ndjson' --data-binary @bulk.ndjson 'http://weywot3.hbz-nrw.de:9200/_bulk'


### PR DESCRIPTION
Provides a `bulk.jsonld` that is uploaded with curl into an existing test index of an small test set based on MAB-XML `lobid-resources`.
~~Note the workaround to overcome the `$append` problem in `fix` script (when used with `copy_field` or `add_field` if the latter is not in a `do_list`). I assume this is a known bug.~~

You can't , as known for https://alma.lobid.org/resources, properly use the web frontend on the new documents , see e.g. https://test.lobid.org/resources/search?q=Kuchen .
You have to append the `&format=json` to get data:
https://test.lobid.org/resources/search?q=Kuchen&format=json (or (same resource): https://test.lobid.org/resources/search?q=RPB929t123951&format=json )

The other MAB-XML `lobid-resources` data is shown properly, e.g. https://test.lobid.org/resources/search?q=*.