### PR TITLE
Sort non-n6 `spatial` entries by ID, not by label (RPB-47)

### DIFF
--- a/test/tests/ApplicationTest.java
+++ b/test/tests/ApplicationTest.java
@@ -115,7 +115,7 @@ public class ApplicationTest {
 				Json.newObject().put("label", "Stadtbezirk 8"),
 				Json.newObject().put("label", "Stadtbezirk 9"),
 				Json.newObject().put("label", "Stadtbezirk 10") };
-		Arrays.sort(in, Classification.comparator);
+		Arrays.sort(in, Classification.comparator(Classification::labelText));
 		Assert.assertArrayEquals(correct, in);
 	}
 
@@ -143,7 +143,7 @@ public class ApplicationTest {
 				Json.newObject().put("label", "Stadtbezirk VIII"),
 				Json.newObject().put("label", "Stadtbezirk IX"),
 				Json.newObject().put("label", "Stadtbezirk X") };
-		Arrays.sort(in, Classification.comparator);
+		Arrays.sort(in, Classification.comparator(Classification::labelText));
 		Assert.assertArrayEquals(correct, in);
 	}
 


### PR DESCRIPTION
Except for n6 itself, which is the first entry on the top level

Will resolve https://jira.hbz-nrw.de/browse/RPB-47