### PR TITLE
Add script to delete non-aliased indices, keeping newest (RPB-137)

### DIFF
--- a/deleteOldIndices.sh
+++ b/deleteOldIndices.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Delete matching non-aliased indices, but keep the newest
+
+HOST="localhost"
+INDICES=("gnd-rppd-*" "resources-rpb-*")
+
+for INDEX in "${INDICES[@]}"
+do
+    curl -s -S -X GET "$HOST:9200/_cluster/state?filter_path=metadata.indices.$INDEX.aliases&pretty" |
+    jq -r '.metadata.indices | to_entries[] | select(.value.aliases | length == 0) | .key' | # no alias
+    sort | head -n -1 | # don't include the newest index
+    awk -v HOST="$HOST" '{print HOST":9200/"$1"?pretty"}' |
+    xargs -L 1 curl -s -S -v -X DELETE
+done


### PR DESCRIPTION
See https://jira.hbz-nrw.de/browse/RPB-137.

Tested today with our cluster, when running again after deletion expected output is `curl: no URL specified!`. Running it tomorrow, it should delete one `gnd-rppd-*` and one `resources-rpb-*` index (when configuring `HOST` to a node in our cluster).