### PR TITLE
Add containedIn, add details to bibliographicCitation

### DIFF
--- a/app/controllers/nwbib/Lobid.java
+++ b/app/controllers/nwbib/Lobid.java
@@ -138,7 +138,7 @@ public class Lobid {
 
 		if (requestHolder.getQueryParameters().get("q") == null
 				&& requestHolder.getQueryParameters().get("word") == null) {
-			requestHolder.setQueryParameter("word", "*");
+			requestHolder.setQueryParameter("q", "*");
 		}
 		Logger.debug("Request URL {}, query params {} ", requestHolder.getUrl(),
 				requestHolder.getQueryParameters());
@@ -147,18 +147,19 @@ public class Lobid {
 
 	private static WSRequest setupWordParameter(final String q,
 			final String rpbspatial, String word, WSRequest requestHolder) {
+		String searchParam = "q";
 		if (!q.trim().isEmpty() && rpbspatial.isEmpty())
-			return requestHolder.setQueryParameter("word", preprocess(q));
+			return requestHolder.setQueryParameter(searchParam, preprocess(q));
 		else if (!q.trim().isEmpty() && !rpbspatial.isEmpty())
-			return requestHolder.setQueryParameter("word",
+			return requestHolder.setQueryParameter(searchParam,
 					preprocess(q) + " AND " + setUprpbspatial(rpbspatial));
 		else if (!word.isEmpty() && rpbspatial.isEmpty())
-			return requestHolder.setQueryParameter("word", preprocess(word));
+			return requestHolder.setQueryParameter(searchParam, preprocess(word));
 		else if (!word.isEmpty() && !rpbspatial.trim().isEmpty()) {
-			return requestHolder.setQueryParameter("word",
+			return requestHolder.setQueryParameter(searchParam,
 					preprocess(word) + " AND " + setUprpbspatial(rpbspatial));
 		} else if (!rpbspatial.trim().isEmpty())
-			return requestHolder.setQueryParameter("word",
+			return requestHolder.setQueryParameter(searchParam,
 					setUprpbspatial(rpbspatial));
 		return requestHolder;
 	}

--- a/app/views/tags/result_doc.scala.html
+++ b/app/views/tags/result_doc.scala.html
@@ -264,7 +264,7 @@
   @withPrefixedLink("URN", "https://nbn-resolving.org/", doc \ "urn")
   @result_field("Umfang", "extent", doc, TableRow.VALUES)
   @result_field("Quelle", "bibliographicCitation", doc, TableRow.VALUES)
-  @result_field("In", "containedIn", doc, TableRow.LINKS)
+  @labelled("In", "containedIn")
 
   @part_of("isPartOf", "hasSuperordinate")
   @subordinateSearchFor(String.format("http://lobid.org/resources/%s#!", (doc \ "hbzId").asOpt[String].getOrElse("")))

--- a/conf/rpb-titel-to-lobid.fix
+++ b/conf/rpb-titel-to-lobid.fix
@@ -328,9 +328,9 @@ do list_as(citation: "bibliographicCitation[]")
   if all_match("citation.value", "^http.*")
     copy_field("citation.value", "containedIn[].$append.id")
     copy_field("citation.label", "containedIn[].$last.label")
-    paste("fullLabel", "citation.label", "~. ", 
-      "citation.volume", "~ (", "citation.year", "~) ", 
-      "citation.issue", "~ ", "citation.alternativeNumbering", 
+    paste("fullLabel", "citation.label", "~ ",
+      "citation.volume", "~ (", "citation.year", "~) ",
+      "citation.issue", "~ ", "citation.alternativeNumbering",
       "~ Seite ", "citation.pages", join_char: "")
     replace_all("fullLabel", "\\(\\)", "") # empty year
   end

--- a/conf/rpb-titel-to-lobid.fix
+++ b/conf/rpb-titel-to-lobid.fix
@@ -337,6 +337,7 @@ do list_as(citation: "bibliographicCitation[]")
   move_field("fullLabel", "bibliographicCitation.$append")
 end
 
+uniq("containedIn[]")
 join_field("bibliographicCitation", "; ")
 
 # fulltextOnline and link to external description/ToC

--- a/conf/rpb-titel-to-lobid.fix
+++ b/conf/rpb-titel-to-lobid.fix
@@ -320,7 +320,23 @@ set_array("contribution[]")
 call_macro("contributions", from: "person")
 call_macro("contributions", from: "corporateBody")
 
-move_field("bibliographicCitation[].*.value", "bibliographicCitation")
+set_array("containedIn[]")
+set_array("bibliographicCitation")
+
+do list_as(citation: "bibliographicCitation[]")
+  copy_field("citation.value", "fullLabel")
+  if all_match("citation.value", "^http.*")
+    copy_field("citation.value", "containedIn[].$append.id")
+    copy_field("citation.label", "containedIn[].$last.label")
+    paste("fullLabel", "citation.label", "~. ", 
+      "citation.volume", "~ (", "citation.year", "~) ", 
+      "citation.issue", "~ ", "citation.alternativeNumbering", 
+      "~ Seite ", "citation.pages", join_char: "")
+    replace_all("fullLabel", "\\(\\)", "") # empty year
+  end
+  move_field("fullLabel", "bibliographicCitation.$append")
+end
+
 join_field("bibliographicCitation", "; ")
 
 # fulltextOnline and link to external description/ToC
@@ -345,6 +361,6 @@ end
 
 move_field("edition", "edition[]")
 
-retain( "type[]", "contribution[]", "edition[]", "extent", "hasItem[]", "responsibilityStatement[]", "language[]", "medium[]", "subject[]", "title", "hbzId", "oclcNumber[]", "otherTitleInformation[]", "natureOfContent[]", "publication[]", "sameAs[]", "describedBy", "@context", "id", "zdbId", "spatial[]", "inCollection[]", "rpbId", "schoeneNummer", "bibliographicCitation", "isPartOf[]", "note[]", "fulltextOnline[]", "description[]", "isbn[]")
+retain( "type[]", "contribution[]", "edition[]", "extent", "hasItem[]", "responsibilityStatement[]", "language[]", "medium[]", "subject[]", "title", "hbzId", "oclcNumber[]", "otherTitleInformation[]", "natureOfContent[]", "publication[]", "sameAs[]", "describedBy", "@context", "id", "zdbId", "spatial[]", "inCollection[]", "rpbId", "schoeneNummer", "bibliographicCitation", "isPartOf[]", "note[]", "fulltextOnline[]", "description[]", "isbn[]", "containedIn[]")
 
 vacuum()


### PR DESCRIPTION
Both transformed from Strapi `bibliographicCitation`, which contains free text for Allegro data or URIs for new Strapi data, as well as a required `pages` and other optional subfields.

This PR also switches from `word` to `q` search to make the `bibliographicCitation` details searchable.

See https://jira.hbz-nrw.de/browse/RPB-224