### PR TITLE
Re-enable global cache, un-cache on PUT route to see changes

### DIFF
--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -259,7 +259,8 @@ public class Application extends Controller {
 			response().setHeader("Pragma", "no-cache");
 			response().setHeader("Expires", "0");
 		}
-		String cacheId = String.format("%s-%s", uuid, request().uri());
+		String cacheId = request().queryString().isEmpty() ? request().uri()
+				: String.format("%s-%s", uuid, request().uri());
 		@SuppressWarnings("unchecked")
 		Promise<Result> cachedResult = (Promise<Result>) Cache.get(cacheId);
 		if (cachedResult != null)
@@ -957,6 +958,7 @@ public class Application extends Controller {
 		String result = Files.readAllLines(Paths.get(output.getAbsolutePath())).stream().collect(Collectors.joining("\n"));
 		boolean authorized = !secret.trim().isEmpty() && secret.equals(CONFIG.getString("secret"));
 		if (authorized) {
+			Cache.remove(String.format("/%s", id));
 			String url = "http://weywot3:9200/resources-rpb-test/resource/"
 					+ URLEncoder.encode("https://lobid.org/resources/" + id, "UTF-8");
 			WSRequest request = WS.url(url).setHeader("Content-Type", "application/json");

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -106,7 +106,7 @@
             <div class="panel panel-default nwbib-footer">
               <div class="panel-body">
                 @defining(controllers.nwbib.Lobid.getTotalHits("").get(Lobid.API_TIMEOUT)){ hits =>
-                <img class="media-object pull-left nrw-wappen" src="@controllers.routes.Assets.at("images/wappen.png")" alt="NRW-Wappen"> 
+                <img class="media-object pull-left nrw-wappen" src="@controllers.routes.Assets.at("images/wappen.png")" alt="RLP-Wappen"> 
                 <img class="media-object pull-right hbz-logo" src="@controllers.routes.Assets.at("images/hbz.png")" alt="hbz-Logo">
                 Die RPB enthält aktuell @hits Literaturnachweise | Ein Entwicklungsprojekt von <a href="https://lbz.rlp.de/">lbz</a> &amp; <a href="http://www.hbz-nrw.de/">hbz</a>
                 }

--- a/build.sbt
+++ b/build.sbt
@@ -45,8 +45,6 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
-javaOptions += "-Dnet.sf.ehcache.disabled=true"
-
 import com.typesafe.sbteclipse.core.EclipsePlugin.EclipseKeys
 
 EclipseKeys.projectFlavor := EclipseProjectFlavor.Java // Java project. Don't expect Scala IDE


### PR DESCRIPTION
Was disabled in https://github.com/hbz/rpb/pull/100.

Is deployed to https://rpb.lobid.org and http://test.rpb.lobid.org.

TODO: for deployment to BiblioVino, Strapi needs to PUT to BiblioVino (too).