### PR TITLE
Move hbzId for Articles to containedIn RPB-232

### DIFF
--- a/conf/rpb-titel-to-lobid.fix
+++ b/conf/rpb-titel-to-lobid.fix
@@ -375,6 +375,17 @@ do list_as(citation: "bibliographicCitation[]")
   move_field("fullLabel", "bibliographicCitation.$append")
 end
 
+# containedIn - For articles we should move hbzId of parent records to containedIn since they are not the article records hbzId except for edoweb and dilibri resources
+
+if any_equal("type[]", "Article")
+  if exists("hbzId")
+    unless any_match("hbzId","CT.*") # exclude delibris and edoweb. See: https://jira.hbz-nrw.de/browse/RPB-232?focusedId=330532&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-330532
+      paste("containedIn[].$append.id","~https://lobid.org/resources/","hbzId","~#!", join_char:"")
+      remove_field("hbzId")
+    end
+  end
+end
+
 uniq("containedIn[]")
 join_field("bibliographicCitation", "; ")
 


### PR DESCRIPTION
Instead of fixing the data in strapi, the old Articles could be changed in the transformation to lobid.

An Articles `hbzId` would be moved to `containedIn` but it would  skip edoweb and dilibri resources. See: https://jira.hbz-nrw.de/browse/RPB-232?focusedId=330532&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-330532

This is missing test files because the existing Articles are dilibri or edoweb resources, see: #109

Also replaces #109

@fsteeg you could use this to fix RPB-232