### PR TITLE
Fix memory leak (metafacture-core#666)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,17 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Install metafacture-fix 0.7.0
+    - name: Install metafacture-core 5.7.1
       run: |
-        git clone https://github.com/metafacture/metafacture-fix.git -b 0.7.0
+        cd ..
+        git clone https://github.com/metafacture/metafacture-core.git
+        cd metafacture-core
+        git checkout metafacture-core-5.7.1
+        ./gradlew publishToMavenLocal
+        cd -
+    - name: Install metafacture-fix 0.7.1
+      run: |
+        git clone https://github.com/metafacture/metafacture-fix.git -b 0.7.1
         cd metafacture-fix
         ./gradlew publishToMavenLocal
         cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,10 @@ jobs:
         java-version: 1.8
     - name: Install metafacture-core 5.7.1
       run: |
-        cd ..
-        git clone https://github.com/metafacture/metafacture-core.git
+        git clone https://github.com/metafacture/metafacture-core.git -b metafacture-core-5.7.1
         cd metafacture-core
-        git checkout metafacture-core-5.7.1
         ./gradlew publishToMavenLocal
-        cd -
+        cd ..
     - name: Install metafacture-fix 0.7.1
       run: |
         git clone https://github.com/metafacture/metafacture-fix.git -b 0.7.1

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "rpb"
 
-version := "0.1.0-SNAPSHOT"
+version := "0.1.1-SNAPSHOT"
 
 scalaVersion := "2.11.11"
 
@@ -10,17 +10,17 @@ libraryDependencies ++= Seq(
   cache,
   javaWs,
   "com.typesafe.play" % "play-test_2.11" % "2.4.11",
-  "org.metafacture" % "metafacture-elasticsearch" % "5.7.0",
-  "org.metafacture" % "metafacture-io" % "5.7.0",
-  "org.metafacture" % "metafacture-strings" % "5.7.0",
-  "org.metafacture" % "metafacture-json" % "5.7.0",
-  "org.metafacture" % "metafacture-flux" % "5.7.0",
-  "org.metafacture" % "metafacture-triples" % "5.7.0",
-  "org.metafacture" % "metafacture-formatting" % "5.7.0",
-  "org.metafacture" % "metafacture-monitoring" % "5.7.0",
-  "org.metafacture" % "metafacture-csv" % "5.7.0",
-  "org.metafacture" % "metafacture-linkeddata" % "5.7.0",
-  "org.metafacture" % "metafix" % "0.7.0",
+  "org.metafacture" % "metafacture-elasticsearch" % "5.7.1",
+  "org.metafacture" % "metafacture-io" % "5.7.1",
+  "org.metafacture" % "metafacture-strings" % "5.7.1",
+  "org.metafacture" % "metafacture-json" % "5.7.1",
+  "org.metafacture" % "metafacture-flux" % "5.7.1",
+  "org.metafacture" % "metafacture-triples" % "5.7.1",
+  "org.metafacture" % "metafacture-formatting" % "5.7.1",
+  "org.metafacture" % "metafacture-monitoring" % "5.7.1",
+  "org.metafacture" % "metafacture-csv" % "5.7.1",
+  "org.metafacture" % "metafix" % "0.7.1",
+  "org.metafacture" % "metafacture-linkeddata" % "5.7.1",
   "org.elasticsearch" % "elasticsearch" % "1.7.5" withSources(),
   "com.github.jsonld-java" % "jsonld-java" % "0.5.0",
   "org.apache.commons" % "commons-rdf-jena" % "0.5.0",


### PR DESCRIPTION
Bump metafacture dependencies to fix a memory leak. Follow `.github/workflows/build.yml` to locally build the proper metafacture-core dependencies.

Fixes https://github.com/metafacture/metafacture-core/issues/666#issuecomment-2706080485.