### PR TITLE
Remove control characters (except \r, \n, \t) in views (RPB-274)

### DIFF
--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -557,7 +557,7 @@ public class Application extends Controller {
 			if (response.getStatus() == Http.Status.OK) {
 				JsonNode json = response.asJson();
 				hits = Lobid.getTotalResults(json);
-				s = json.toString().replaceAll("[\\p{Cc}&&[^\r\n\t]]", "");
+				s = removeNonFormattingControlCharacters(json.toString());
 				if (!q.contains("hbzId:")) {
 					List<JsonNode> ids = json.findValues("hbzId");
 					uncache(
@@ -588,6 +588,10 @@ public class Application extends Controller {
 							.writeValueAsString(Json.parse(s)))
 									.as("application/json; charset=utf-8");
 		});
+	}
+
+	public static String removeNonFormattingControlCharacters(String string) {
+		return string.replaceAll("[\\p{Cc}&&[^\r\n\t]]", "");
 	}
 
 	private static void uncache(List<String> ids) {

--- a/app/controllers/nwbib/Application.java
+++ b/app/controllers/nwbib/Application.java
@@ -557,7 +557,7 @@ public class Application extends Controller {
 			if (response.getStatus() == Http.Status.OK) {
 				JsonNode json = response.asJson();
 				hits = Lobid.getTotalResults(json);
-				s = json.toString();
+				s = json.toString().replaceAll("[\\p{Cc}&&[^\r\n\t]]", "");
 				if (!q.contains("hbzId:")) {
 					List<JsonNode> ids = json.findValues("hbzId");
 					uncache(

--- a/test/tests/ApplicationTest.java
+++ b/test/tests/ApplicationTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import controllers.nwbib.Application;
 import controllers.nwbib.Classification;
 import controllers.nwbib.Classification.Type;
 import controllers.nwbib.Lobid;
@@ -144,6 +145,21 @@ public class ApplicationTest {
 				Json.newObject().put("label", "Stadtbezirk X") };
 		Arrays.sort(in, Classification.comparator(Classification::labelText));
 		Assert.assertArrayEquals(correct, in);
+	}
+
+	@Test
+	public void removeNonFormattingControlCharacters() {
+		assertThat(Application
+				.removeNonFormattingControlCharacters("\u0098Der\u009c Gau-Algesheimer Weihnachtsmarkt"))
+				.as("Non-formatting control characters should be removed")
+				.doesNotContain("\u0098")
+				.doesNotContain("\u009c");
+		assertThat(Application
+				.removeNonFormattingControlCharacters("Line1\r\nLine2\n\tIndented"))
+				.as("Tabs and newlines should be retained")
+				.contains("\r")
+				.contains("\n")
+				.contains("\t");
 	}
 
 }


### PR DESCRIPTION
See https://jira.hbz-nrw.de/browse/RPB-274

Data in hebis uses `\u0098` (start of string) and `\u009c` (string terminator) to mark nonfiling / non-sorting words.

Remove these and others for display in details and search result views.