### PR TITLE
RPB-267-localLookup

### DIFF
--- a/etl/maps/test/rpb-spatial.ttl
+++ b/etl/maps/test/rpb-spatial.ttl
@@ -1,0 +1,22162 @@
+@prefix :      <https://rpb.lobid.org/spatial#> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann:  <http://purl.org/vocab/vann/> .
+@prefix wd:    <http://www.wikidata.org/entity/> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+
+:n235031480104  a       skos:Concept ;
+        skos:broader    :n23503148 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scharzhofberg"@de .
+
+:n33705073  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siebeldingen"@de .
+
+:n138010030200  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Limbach"@de .
+
+:n131042110102  a       skos:Concept ;
+        skos:broader    :n13104211 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wabern"@de .
+
+:n07    a               skos:Concept ;
+        skos:broader    :n1 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfalz"@de .
+
+:n14302215  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreifelden"@de .
+
+:n33702018  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dierbach"@de .
+
+:n14004030  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dillendorf"@de .
+
+:n23506078  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Longuich"@de .
+
+:n14107137  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welterod"@de .
+
+:n33100003  a           skos:Concept ;
+        skos:broader    :n331 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alzey, Stadt"@de .
+
+:n235070690105  a       skos:Concept ;
+        skos:broader    :n23507069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kimmlingerhof"@de .
+
+:n312000000300  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Einsiedlerhof (Ortsbezirk)"@de .
+
+:n131015010200  a       skos:Concept ;
+        skos:broader    :n13101501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lückenbach (Ortsbezirk)"@de .
+
+:n34001029  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ludwigswinkel"@de .
+
+:n23301079  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallenborn"@de .
+
+:n33207012  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ebertsheim"@de .
+
+:n33901  a              skos:Concept ;
+        skos:broader    :n339 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Nahe, Verbandsgemeinde"@de .
+
+:n339010030203  a       skos:Concept ;
+        skos:broader    :n33901003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nauheim"@de .
+
+:n14103077  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laurenburg"@de .
+
+:n131010370202  a       skos:Concept ;
+        skos:broader    :n13101037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochacht"@de .
+
+:n133000060659  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trombacherhof"@de .
+
+:n14309224  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gemünden"@de .
+
+:n13210100  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schürdt"@de .
+
+:n14111126  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönborn"@de .
+
+:n13210094  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rettersen"@de .
+
+:n33702076  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinfeld"@de .
+
+:n13707224  a           skos:Concept ;
+        skos:broader    :n13707 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Urbar"@de .
+
+:n13101085  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winnerath"@de .
+
+:n13210015  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bürdenbach"@de .
+
+:n231010810109  a       skos:Concept ;
+        skos:broader    :n23101081 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siebenborn"@de .
+
+:n14107116  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rettershain"@de .
+
+:n33501201  a           skos:Concept ;
+        skos:broader    :n33501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lambsborn"@de .
+
+:n235075010400  a       skos:Concept ;
+        skos:broader    :n23507501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Möhn (Ortsbezirk)"@de .
+
+:n33201039  a           skos:Concept ;
+        skos:broader    :n33201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederkirchen bei Deidesheim"@de .
+
+:n13703079  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nachtsheim"@de .
+
+:n335100290400  a       skos:Concept ;
+        skos:broader    :n33510029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wörsbach (Ortsbezirk)"@de .
+
+:n13702080  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Naunheim"@de .
+
+:n137092120313  a       skos:Concept ;
+        skos:broader    :n13709212 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sürzerhof"@de .
+
+:n335100350114  a       skos:Concept ;
+        skos:broader    :n33510035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münchschwanderhof"@de .
+
+:n137072260108  a       skos:Concept ;
+        skos:broader    :n13707226 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mallendarerberg, Hof"@de .
+
+:n14302252  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kundert"@de .
+
+:n33702055  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhorbach"@de .
+
+:n33705031  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Göcklingen"@de .
+
+:n132100640101  a       skos:Concept ;
+        skos:broader    :n13210064 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heuberg"@de .
+
+:n13501056  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lütz"@de .
+
+:n33908202  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolfsheim"@de .
+
+:n4058411n2  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Südeifel"@de .
+
+:n333020380102  a       skos:Concept ;
+        skos:broader    :n33302038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Göllheimer Häuschen (T.a.Ortsbezirk Rosenthal)"@de .
+
+:n235071110200  a       skos:Concept ;
+        skos:broader    :n23507111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Godendorf (Ortsbezirk)"@de .
+
+:n13809010  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Datzeroth"@de .
+
+:n138000450400  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gladbach (Ortsbezirk)"@de .
+
+:n141091080101  a       skos:Concept ;
+        skos:broader    :n14109108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büchelborn"@de .
+
+:n4031415n7  a          skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Regierungsbezirk Koblenz (1946-1999)"@de .
+
+:n233015010800  a       skos:Concept ;
+        skos:broader    :n23301501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiersbach (Ortsbezirk)"@de .
+
+:n33806009  a           skos:Concept ;
+        skos:broader    :n33806 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großniedesheim"@de .
+
+:n23207107  a           skos:Concept ;
+        skos:broader    :n23207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Preist"@de .
+
+:n235071510107  a       skos:Concept ;
+        skos:broader    :n23507151 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodt (Ortsbezirk)"@de .
+
+:n132060130101  a       skos:Concept ;
+        skos:broader    :n13206013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mühlental"@de .
+
+:n332000020400  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ungstein (Ortsbezirk)"@de .
+
+:n23109020  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Diefenbach"@de .
+
+:n14306285  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rehe"@de .
+
+:n135030830103  a       skos:Concept ;
+        skos:broader    :n13503083 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Furth"@de .
+
+:n23306239  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schüller"@de .
+
+:n333070790103  a       skos:Concept ;
+        skos:broader    :n33307079 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolfsmühle"@de .
+
+:n312000002001  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bahnheim"@de .
+
+:n33907033  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Köngernheim"@de .
+
+:n23    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberrheinisches Tiefland / Nord"@de .
+
+:n33610098  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Theisbergstegen"@de .
+
+:n132081170101  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenbrendebach"@de .
+
+:n33608104  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiesweiler"@de .
+
+:n13104502  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kempenich"@de .
+
+:n13804  a              skos:Concept ;
+        skos:broader    :n138 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Linz a.Rh., Verbandsgemeinde"@de .
+
+:n13210052  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hilgenroth"@de .
+
+:n4666501n8  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brohltal"@de .
+
+:n133092010101  a       skos:Concept ;
+        skos:broader    :n13309201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rudolfshaus"@de .
+
+:n235010300101  a       skos:Concept ;
+        skos:broader    :n23501030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Abtei"@de .
+
+:n132070450102  a       skos:Concept ;
+        skos:broader    :n13207045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinhausen"@de .
+
+:n332070420101  a       skos:Concept ;
+        skos:broader    :n33207042 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Boßweiler"@de .
+
+:n138010440216  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kodden (ehem.Gem.Elsaffthal)"@de .
+
+:n33608019  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Einöllen"@de .
+
+:n34001045  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönau (Pfalz)"@de .
+
+:n23208313  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinborn"@de .
+
+:n23506015  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Detzem"@de .
+
+:n33402021  a           skos:Concept ;
+        skos:broader    :n33402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuburg am Rhein"@de .
+
+:n143080110200  a       skos:Concept ;
+        skos:broader    :n14308011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pütschbach"@de .
+
+:n33206  a              skos:Concept ;
+        skos:broader    :n332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wachenheim an der Weinstraße, Verbandsgemeinde"@de .
+
+:n232012850100  a       skos:Concept ;
+        skos:broader    :n23201285 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merkeshausen"@de .
+
+:n23301016  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Demerath"@de .
+
+:n141091220104  a       skos:Concept ;
+        skos:broader    :n14109122 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sauerburg"@de .
+
+:n13505068  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neef"@de .
+
+:n23208228  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gransdorf"@de .
+
+:n33306075  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinbach am Donnersberg"@de .
+
+:n4126432n0  a          skos:Concept ;
+        skos:broader    :n22 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelrheintal"@de .
+
+:n33907012  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dienheim"@de .
+
+:n33610077  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfeffelbach"@de .
+
+:n14103014  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birlenbach"@de .
+
+:n13306021  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dalberg"@de .
+
+:n13210031  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fiersbach"@de .
+
+:n231010700600  a       skos:Concept ;
+        skos:broader    :n23101070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberkleinich (Ortsbezirk)"@de .
+
+:n33702013  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Böllenborn"@de .
+
+:n13101022  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fuchshofen"@de .
+
+:n335010030100  a       skos:Concept ;
+        skos:broader    :n33501003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruchmühlbach"@de .
+
+:n138090710200  a       skos:Concept ;
+        skos:broader    :n13809071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jahrsfeld"@de .
+
+:n23301074  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Udler"@de .
+
+:n14107047  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gemmerich"@de .
+
+:n133000060654  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Ebernburg"@de .
+
+:n33702071  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweigen-Rechtenbach"@de .
+
+:n13501072  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pommern"@de .
+
+:n143040480400  a       skos:Concept ;
+        skos:broader    :n14304048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ettersdorf (Ortsbezirk)"@de .
+
+:n14111036  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eisighofen"@de .
+
+:n33307202  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reichsthal"@de .
+
+:n13101001  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Adenau, Stadt"@de .
+
+:n231010810104  a       skos:Concept ;
+        skos:broader    :n23101081 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laymühle"@de .
+
+:n23207123  a           skos:Concept ;
+        skos:broader    :n23207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Speicher, Stadt"@de .
+
+:n337060700102  a       skos:Concept ;
+        skos:broader    :n33706070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kropsburg, Gastst."@de .
+
+:n333040460102  a       skos:Concept ;
+        skos:broader    :n33304046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfaffenloch"@de .
+
+:n132080110122  a       skos:Concept ;
+        skos:broader    :n13208011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steckenstein"@de .
+
+:n143082630102  a       skos:Concept ;
+        skos:broader    :n14308263 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langwiesen"@de .
+
+:n4490539n7  a          skos:Concept ;
+        skos:broader    :n11 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Aartal"@de .
+
+:n13703074  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Monreal"@de .
+
+:n132070760105  a       skos:Concept ;
+        skos:broader    :n13207076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahnhof"@de .
+
+:n14100075  a           skos:Concept ;
+        skos:broader    :n141 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lahnstein, große kreisangehörige Stadt"@de .
+
+:n137072260103  a       skos:Concept ;
+        skos:broader    :n13707226 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berg Schönstatt"@de .
+
+:n332050140108  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Iggelbach"@de .
+
+:n140091120200  a       skos:Concept ;
+        skos:broader    :n14009112 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langscheid (Ortsbezirk)"@de .
+
+:n33306033  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Imsbach"@de .
+
+:n14009036  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Emmelshausen, Stadt"@de .
+
+:n332070010105  a       skos:Concept ;
+        skos:broader    :n33207001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höningen"@de .
+
+:n131000070601  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Green"@de .
+
+:n33608035  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hausweiler"@de .
+
+:n33705  a              skos:Concept ;
+        skos:broader    :n337 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Landau-Land, Verbandsgemeinde"@de .
+
+:n23503055  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kanzem"@de .
+
+:n133110950103  a       skos:Concept ;
+        skos:broader    :n13311095 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Füllenbacherhof"@de .
+
+:n231005020900  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hundheim (Ortsbezirk)"@de .
+
+:n14107084  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienfels"@de .
+
+:n133090410100  a       skos:Concept ;
+        skos:broader    :n13309041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heimberg"@de .
+
+:n13401051  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leitzweiler"@de .
+
+:n132080110101  a       skos:Concept ;
+        skos:broader    :n13208011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Blickhausen"@de .
+
+:n232062310200  a       skos:Concept ;
+        skos:broader    :n23206231 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hollnich"@de .
+
+:n14103030  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörnberg"@de .
+
+:n137030600102  a       skos:Concept ;
+        skos:broader    :n13703060 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Jost"@de .
+
+:n137020890112  a       skos:Concept ;
+        skos:broader    :n13702089 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nettesürsch"@de .
+
+:n319000000900  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leiselheim (Ortsbezirk)"@de .
+
+:n14111073  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klingelbach"@de .
+
+:n33703028  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gleisweiler"@de .
+
+:n132100820300  a       skos:Concept ;
+        skos:broader    :n13210082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rimbach"@de .
+
+:n13311110  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Warmsroth"@de .
+
+:n337070410200  a       skos:Concept ;
+        skos:broader    :n33707041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhochstadt"@de .
+
+:n13300006  a           skos:Concept ;
+        skos:broader    :n133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Kreuznach, große kreisangehörige Stadt"@de .
+
+:n33608014  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Deimberg"@de .
+
+:n13311025  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörrebach"@de .
+
+:n132081170409  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holschbach"@de .
+
+:n14107063  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hunzel"@de .
+
+:n33201  a              skos:Concept ;
+        skos:broader    :n332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Deidesheim, Verbandsgemeinde"@de .
+
+:n23301011  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brockscheid"@de .
+
+:n137000030301  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Tönisstein, Kuranlage und Hotel"@de .
+
+:n141000750200  a       skos:Concept ;
+        skos:broader    :n14100075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberlahnstein"@de .
+
+:n13402029  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gimbweiler"@de .
+
+:n311000000200  a       skos:Concept ;
+        skos:broader    :n31100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eppstein (Ortsbezirk)"@de .
+
+:n131000700300  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwinter (T.a. Ortsbezirk 3)"@de .
+
+:n132091110101  a       skos:Concept ;
+        skos:broader    :n13209111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dasberg"@de .
+
+:n131042020303  a       skos:Concept ;
+        skos:broader    :n13104202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buchholz"@de .
+
+:n33608072  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberweiler im Tal"@de .
+
+:n13209025  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elkenroth"@de .
+
+:n132070370158  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steeg"@de .
+
+:n235010930103  a       skos:Concept ;
+        skos:broader    :n23501093 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmelz"@de .
+
+:n34001502  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bundenthal"@de .
+
+:n137095040102  a       skos:Concept ;
+        skos:broader    :n13709504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lehmerhöfe"@de .
+
+:n332020190103  a       skos:Concept ;
+        skos:broader    :n33202019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lindemannsruhe"@de .
+
+:n332000020204  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weilach, Forsthaus"@de .
+
+:n111000000600  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Güls  (Ortsbezirk 4)"@de .
+
+:n13801080  a           skos:Concept ;
+        skos:broader    :n13801 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buchholz (Westerwald)"@de .
+
+:n331030480100  a       skos:Concept ;
+        skos:broader    :n33103048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kriegsheim"@de .
+
+:n339000050300  a       skos:Concept ;
+        skos:broader    :n33900005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büdesheim"@de .
+
+:n33202049  a           skos:Concept ;
+        skos:broader    :n33202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weisenheim am Berg"@de .
+
+:n13210  a              skos:Concept ;
+        skos:broader    :n132 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenkirchen-Flammersfeld, Verbandsgemeinde"@de .
+
+:n138010770205  a       skos:Concept ;
+        skos:broader    :n13801077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stockhausen"@de .
+
+:n336100980100  a       skos:Concept ;
+        skos:broader    :n33610098 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Godelhausen"@de .
+
+:n13703011  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bermel"@de .
+
+:n138030310102  a       skos:Concept ;
+        skos:broader    :n13803031 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Isenburg, Sdlg."@de .
+
+:n33610051  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Körborn"@de .
+
+:n235030680502  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Löllberg"@de .
+
+:n333075020100  a       skos:Concept ;
+        skos:broader    :n33307502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörnbach (Ortsbezirk)"@de .
+
+:n140091330203  a       skos:Concept ;
+        skos:broader    :n14009133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinfels, Burgschenke"@de .
+
+:n33101050  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nack"@de .
+
+:n13206028  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Etzbach"@de .
+
+:n233015010100  a       skos:Concept ;
+        skos:broader    :n23301501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Boverath (Ortsbezirk)"@de .
+
+:n131000770300  a       skos:Concept ;
+        skos:broader    :n13100077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Koisdorf (Ortsbezirk)"@de .
+
+:n320000000300  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ernstweiler"@de .
+
+:n33202028  a           skos:Concept ;
+        skos:broader    :n33202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kallstadt"@de .
+
+:n140090840103  a       skos:Concept ;
+        skos:broader    :n14009084 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sauerbrunnen"@de .
+
+:n134050410101  a       skos:Concept ;
+        skos:broader    :n13405041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siedlung Wassergall"@de .
+
+:n132070760100  a       skos:Concept ;
+        skos:broader    :n13207076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hüttseifen"@de .
+
+:n13301106  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Volxheim"@de .
+
+:n332050140103  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erlenbach (ehem.Gem.Wilgartswiesen)"@de .
+
+:n4607820n4  a          skos:Concept ;
+        skos:broader    :n19 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bingerwald"@de .
+
+:n13502045  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaisersesch, Stadt"@de .
+
+:n14009031  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörth"@de .
+
+:n23108117  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sehlem"@de .
+
+:n13104  a              skos:Concept ;
+        skos:broader    :n131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brohltal, Verbandsgemeinde"@de .
+
+:n33608030  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Glanbrücken"@de .
+
+:n333060200104  a       skos:Concept ;
+        skos:broader    :n33306020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wambacherhof"@de .
+
+:n132060100101  a       skos:Concept ;
+        skos:broader    :n13206010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dünebusch"@de .
+
+:n137000680400  a       skos:Concept ;
+        skos:broader    :n13700068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mayen"@de .
+
+:n14111010  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berghausen"@de .
+
+:n138010800200  a       skos:Concept ;
+        skos:broader    :n13801080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Griesenbach"@de .
+
+:n13206007  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birkenbeul"@de .
+
+:n332060460104  a       skos:Concept ;
+        skos:broader    :n33206046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mundhardterhof"@de .
+
+:n13805013  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Döttesfeld"@de .
+
+:n232000180500  a       skos:Concept ;
+        skos:broader    :n23200018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Matzen (Ortsbezirk)"@de .
+
+:n33908022  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grolsheim"@de .
+
+:n211000001506  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sievenicherhof"@de .
+
+:n337050400200  a       skos:Concept ;
+        skos:broader    :n33705040 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klingen"@de .
+
+:n232051020105  a       skos:Concept ;
+        skos:broader    :n23205102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rußdorf"@de .
+
+:n111000001700  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwerth"@de .
+
+:n33508030  a           skos:Concept ;
+        skos:broader    :n33508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedermohr"@de .
+
+:n33105062  a           skos:Concept ;
+        skos:broader    :n33105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stein-Bockenheim"@de .
+
+:n335020040100  a       skos:Concept ;
+        skos:broader    :n33502004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alsenborn"@de .
+
+:n14310  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wirges, Verbandsgemeinde"@de .
+
+:n33609008  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Börsborn"@de .
+
+:n140032020100  a       skos:Concept ;
+        skos:broader    :n14003202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dommershausen (Ortsbezirk)"@de .
+
+:n13402024  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellweiler"@de .
+
+:n317000000600  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Windsberg (Ortsbezirk)"@de .
+
+:n337010010102  a       skos:Concept ;
+        skos:broader    :n33701001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "St. Johann"@de .
+
+:n13310009  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bärweiler"@de .
+
+:n137092070105  a       skos:Concept ;
+        skos:broader    :n13709207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kondertal"@de .
+
+:n33703002  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altdorf"@de .
+
+:n13206044  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hamm (Sieg)"@de .
+
+:n13209020  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dickendorf"@de .
+
+:n13102011  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berg"@de .
+
+:n132070370153  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmalenbachsmühle"@de .
+
+:n33509  a              skos:Concept ;
+        skos:broader    :n335 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weilerbach, Verbandsgemeinde"@de .
+
+:n23208133  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wettlingen"@de .
+
+:n23108069  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klausen"@de .
+
+:n14308316  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zehnhausen bei Wallmerod"@de .
+
+:n211000000401  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Duisburgerhof"@de .
+
+:n13805050  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederwambach"@de .
+
+:n23306038  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kerpen (Eifel)"@de .
+
+:n23206305  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwirzheim"@de .
+
+:n13310067  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Monzingen"@de .
+
+:n23208048  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heilenbach"@de .
+
+:n33307043  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mannweiler-Cölln"@de .
+
+:n132070630609  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winnersbach"@de .
+
+:n14003095  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Michelbach"@de .
+
+:n13709207  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dieblich"@de .
+
+:n14310073  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Staudt"@de .
+
+:n13301037  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hackenheim"@de .
+
+:n33106019  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ensheim"@de .
+
+:n132070370132  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krottorf"@de .
+
+:n339010440103  a       skos:Concept ;
+        skos:broader    :n33901044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winzberg"@de .
+
+:n13402061  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nohen"@de .
+
+:n231005020200  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elzerath (Ortsbezirk)"@de .
+
+:n23100502  a           skos:Concept ;
+        skos:broader    :n231 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morbach"@de .
+
+:n143092300104  a       skos:Concept ;
+        skos:broader    :n14309230 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Witzelbach"@de .
+
+:n337015010300  a       skos:Concept ;
+        skos:broader    :n33701501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gräfenhausen (Ortsbezirk)"@de .
+
+:n13803201  a           skos:Concept ;
+        skos:broader    :n13803 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienhausen"@de .
+
+:n23208027  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dudeldorf"@de .
+
+:n134020850105  a       skos:Concept ;
+        skos:broader    :n13402085 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winnenberg"@de .
+
+:n4115441n1  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ösling"@de .
+
+:n235081420102  a       skos:Concept ;
+        skos:broader    :n23508142 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mühlscheid"@de .
+
+:n33707014  a           skos:Concept ;
+        skos:broader    :n33707 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bornheim"@de .
+
+:n33704038  a           skos:Concept ;
+        skos:broader    :n33704 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herxheim bei Landau (Pfalz)"@de .
+
+:n13502040  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hauroth"@de .
+
+:n33304046  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörsfeld"@de .
+
+:n23508104  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Palzem"@de .
+
+:n23501153  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Züsch"@de .
+
+:n23508098  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ockfen"@de .
+
+:n319000000200  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Abenheim (Ortsbezirk)"@de .
+
+:n33502015  a           skos:Concept ;
+        skos:broader    :n33502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochspeyer"@de .
+
+:n13405049  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krummenau"@de .
+
+:n34006025  a           skos:Concept ;
+        skos:broader    :n34006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horbach"@de .
+
+:n333030180101  a       skos:Concept ;
+        skos:broader    :n33303018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiesenmühle"@de .
+
+:n138010030307  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heckenhahn"@de .
+
+:n23504044  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herl"@de .
+
+:n338000170106  a       skos:Concept ;
+        skos:broader    :n33800017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rehhütte"@de .
+
+:n23101076  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lösnich"@de .
+
+:n134000450600  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchenbollenbach"@de .
+
+:n135050920101  a       skos:Concept ;
+        skos:broader    :n13505092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Barl"@de .
+
+:n137030360101  a       skos:Concept ;
+        skos:broader    :n13703036 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kreuznick"@de .
+
+:n33610  a              skos:Concept ;
+        skos:broader    :n336 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kusel-Altenglan, Verbandsgemeinde"@de .
+
+:n13502502  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leienkaul"@de .
+
+:n33509024  a           skos:Concept ;
+        skos:broader    :n33509 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mackenbach"@de .
+
+:n33609082  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rehweiler"@de .
+
+:n33106056  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Partenheim"@de .
+
+:n13503018  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büchel"@de .
+
+:n211000000900  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Irsch (Ortsbezirk 15)"@de .
+
+:n132060380104  a       skos:Concept ;
+        skos:broader    :n13206038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Opsen"@de .
+
+:n14109136  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weisel"@de .
+
+:n137092230200  a       skos:Concept ;
+        skos:broader    :n13709223 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberspay"@de .
+
+:n23108085  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Minderlittgen"@de .
+
+:n336   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kusel, Landkreis"@de .
+
+:n13405028  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gerach"@de .
+
+:n336080730101  a       skos:Concept ;
+        skos:broader    :n33608073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberweiler"@de .
+
+:n34003028  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lemberg"@de .
+
+:n33102002  a           skos:Concept ;
+        skos:broader    :n33102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alsheim"@de .
+
+:n23306054  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberehe-Stroheich"@de .
+
+:n23206321  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wawern"@de .
+
+:n33404004  a           skos:Concept ;
+        skos:broader    :n33404 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erlenbach bei Kandel"@de .
+
+:n13310083  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rehborn"@de .
+
+:n23501047  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinzert-Pölert"@de .
+
+:n339070430200  a       skos:Concept ;
+        skos:broader    :n33907043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwabsburg (Ortsbezirk)"@de .
+
+:n23205088  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuerburg, Stadt"@de .
+
+:n135010860103  a       skos:Concept ;
+        skos:broader    :n13501086 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Valwigerberg"@de .
+
+:n23304226  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mosbruch"@de .
+
+:n338000050200  a       skos:Concept ;
+        skos:broader    :n33800005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Iggelheim"@de .
+
+:n13709223  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spay"@de .
+
+:n23206236  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heckhuscheid"@de .
+
+:n131000070400  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heimersheim (Ortsbezirk)"@de .
+
+:n13405086  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sonnschied"@de .
+
+:n231005021300  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morscheid-Riedenburg (Ortsbezirk)"@de .
+
+:n131020390200  a       skos:Concept ;
+        skos:broader    :n13102039 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Staffel"@de .
+
+:n335080300300  a       skos:Concept ;
+        skos:broader    :n33508030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schrollbach"@de .
+
+:n131020400103  a       skos:Concept ;
+        skos:broader    :n13102040 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hürnig"@de .
+
+:n14310010  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dernbach (Westerwald)"@de .
+
+:n14109115  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reitzenhain"@de .
+
+:n131000900400  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gelsdorf (Ortsbezirk)"@de .
+
+:n34008209  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großbundenbach"@de .
+
+:n14307078  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vielbach"@de .
+
+:n23306033  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hohenfels-Essingen"@de .
+
+:n23206300  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rommersheim"@de .
+
+:n319000001300  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheindürkheim (Ortsbezirk)"@de .
+
+:n13310062  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Martinstein"@de .
+
+:n235010450104  a       skos:Concept ;
+        skos:broader    :n23501045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höfchen"@de .
+
+:n232082280101  a       skos:Concept ;
+        skos:broader    :n23208228 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biermühle"@de .
+
+:n23208043  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gindorf"@de .
+
+:n23205067  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Körperich"@de .
+
+:n23304205  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bodenbach"@de .
+
+:n231085030300  a       skos:Concept ;
+        skos:broader    :n23108503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederkail (Ortsbezirk)"@de .
+
+:n14110128  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seelbach"@de .
+
+:n33701078  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Völkersweiler"@de .
+
+:n33304062  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rittersheim"@de .
+
+:n111000000903  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kondertal"@de .
+
+:n13301032  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fürfeld"@de .
+
+:n13405065  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberkirn"@de .
+
+:n140040670102  a       skos:Concept ;
+        skos:broader    :n14004067 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Denzen"@de .
+
+:n13104211  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weibern"@de .
+
+:n23101092  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neumagen-Dhron"@de .
+
+:n23205131  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallendorf"@de .
+
+:n23201229  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großkampenberg"@de .
+
+:n233010340102  a       skos:Concept ;
+        skos:broader    :n23301034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Immerathermühle"@de .
+
+:n23506207  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trittenheim"@de .
+
+:n137092210103  a       skos:Concept ;
+        skos:broader    :n13709221 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hünenfeld"@de .
+
+:n23501005  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bescheid"@de .
+
+:n33509040  a           skos:Concept ;
+        skos:broader    :n33509 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodenbach"@de .
+
+:n138090530103  a       skos:Concept ;
+        skos:broader    :n13809053 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhonnefeld"@de .
+
+:n4377902n5  a          skos:Concept ;
+        skos:broader    :n22 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelrheintal / Nord"@de .
+
+:n13503034  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gevenich"@de .
+
+:n111000001000  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kesselheim (Ortsbezirk 5)"@de .
+
+:n13405044  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hottenbach"@de .
+
+:n33502010  a           skos:Concept ;
+        skos:broader    :n33502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frankenstein"@de .
+
+:n132070630100  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freusburg (Ortsbezirk)"@de .
+
+:n23201287  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Olmscheid"@de .
+
+:n143022670102  a       skos:Concept ;
+        skos:broader    :n14302267 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hanwerth"@de .
+
+:n138010030302  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenhofen"@de .
+
+:n340020570104  a       skos:Concept ;
+        skos:broader    :n34002057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hofstätten (Ortsbezirk)"@de .
+
+:n33404020  a           skos:Concept ;
+        skos:broader    :n33404 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Minfeld"@de .
+
+:n23108022  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dierscheid"@de .
+
+:n23101071  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kommen"@de .
+
+:n23205110  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodershausen"@de .
+
+:n14008  a              skos:Concept ;
+        skos:broader    :n140 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Simmern-Rheinböllen, Verbandsgemeinde"@de .
+
+:n14308263  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meudt"@de .
+
+:n23304242  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Uersfeld"@de .
+
+:n13310020  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Callbach"@de .
+
+:n23205025  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dauwelshausen"@de .
+
+:n340090370101  a       skos:Concept ;
+        skos:broader    :n34009037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Staffelhof"@de .
+
+:n235030680301  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Konzerbrück"@de .
+
+:n333070770101  a       skos:Concept ;
+        skos:broader    :n33307077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mausmühle"@de .
+
+:n141095010200  a       skos:Concept ;
+        skos:broader    :n14109501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinterwald (Ortsbezirk)"@de .
+
+:n316000000500  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gimmeldingen (Ortsbezirk)"@de .
+
+:n23508072  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lampaden"@de .
+
+:n132100650101  a       skos:Concept ;
+        skos:broader    :n13210065 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Epgert"@de .
+
+:n23108080  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Manderscheid, Stadt"@de .
+
+:n331   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alzey-Worms, Landkreis"@de .
+
+:n33207029  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kindenheim"@de .
+
+:n235070010101  a       skos:Concept ;
+        skos:broader    :n23507001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hohensonne"@de .
+
+:n138090060113  a       skos:Concept ;
+        skos:broader    :n13809006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nassen"@de .
+
+:n33401023  a           skos:Concept ;
+        skos:broader    :n33401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ottersheim bei Landau"@de .
+
+:n13306107  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldböckelheim"@de .
+
+:n23108001  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altrich"@de .
+
+:n13309077  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Otzweiler"@de .
+
+:n14307015  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellenhausen"@de .
+
+:n23304221  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kötterichen"@de .
+
+:n14303040  a           skos:Concept ;
+        skos:broader    :n14303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kammerforst"@de .
+
+:n14304039  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kadenbach"@de .
+
+:n132060140101  a       skos:Concept ;
+        skos:broader    :n13206014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haderschen"@de .
+
+:n14004111  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ober Kostenz"@de .
+
+:n13208117  a           skos:Concept ;
+        skos:broader    :n13208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wissen, Stadt"@de .
+
+:n23206231  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Habscheid"@de .
+
+:n23205004  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ammeldingen an der Our"@de .
+
+:n13405081  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sensweiler"@de .
+
+:n33103054  a           skos:Concept ;
+        skos:broader    :n33103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Offstein"@de .
+
+:n4283491n0  a          skos:Concept ;
+        skos:broader    :n18 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberes Nahebergland"@de .
+
+:n23201245  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Irrhausen"@de .
+
+:n23200018  a           skos:Concept ;
+        skos:broader    :n232 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bitburg, Stadt"@de .
+
+:n14008144  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Simmern / Hunsrück, Stadt"@de .
+
+:n111000002100  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stolzenfels (Ortsbezirk 8)"@de .
+
+:n335080160101  a       skos:Concept ;
+        skos:broader    :n33508016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elschbacherhof"@de .
+
+:n14301270  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neunkhausen"@de .
+
+:n14302269  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Müschenbach"@de .
+
+:n140030090500  a       skos:Concept ;
+        skos:broader    :n14003009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Völkenroth (Ortsbezirk)"@de .
+
+:n13405060  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederwörresbach"@de .
+
+:n13207012  a           skos:Concept ;
+        skos:broader    :n13207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brachbach"@de .
+
+:n132060070103  a       skos:Concept ;
+        skos:broader    :n13206007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weißenbrüchen"@de .
+
+:n14109083  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lykershausen"@de .
+
+:n132100480103  a       skos:Concept ;
+        skos:broader    :n13210048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Helmerotherhöhe"@de .
+
+:n14008123  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reich"@de .
+
+:n132080540105  a       skos:Concept ;
+        skos:broader    :n13208054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhövels"@de .
+
+:n235030680800  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberemmel (Ortsbezirk 5)"@de .
+
+:n14109004  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auel"@de .
+
+:n23205041  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gemünd"@de .
+
+:n232085010102  a       skos:Concept ;
+        skos:broader    :n23208501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Koosbüsch (Ortsbezirk)"@de .
+
+:n13210069  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mehren"@de .
+
+:n13809006  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitscheid"@de .
+
+:n337020720102  a       skos:Concept ;
+        skos:broader    :n33702072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhof"@de .
+
+:n133000060300  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ippesheim (Ortsbezirk)"@de .
+
+:n137072240101  a       skos:Concept ;
+        skos:broader    :n13707224 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Besselich"@de .
+
+:n34004038  a           skos:Concept ;
+        skos:broader    :n34004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodalben, Stadt"@de .
+
+:n140005011001  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fleckertshöhe"@de .
+
+:n140030100200  a       skos:Concept ;
+        skos:broader    :n14003010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frankweiler (Ortsbezirk)"@de .
+
+:n211000000200  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biewer (T.a. Ortsbezirk 6)"@de .
+
+:n33511047  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trippstadt"@de .
+
+:n141101030102  a       skos:Concept ;
+        skos:broader    :n14110103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenau"@de .
+
+:n140005010400  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herschwiesen (Ortsbezirk)"@de .
+
+:n14003  a              skos:Concept ;
+        skos:broader    :n140 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kastellaun, Verbandsgemeinde"@de .
+
+:n13800045  a           skos:Concept ;
+        skos:broader    :n138 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuwied, große kreisangehörige Stadt"@de .
+
+:n14304055  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nomborn"@de .
+
+:n338010060200  a       skos:Concept ;
+        skos:broader    :n33801006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schauernheim"@de .
+
+:n14008096  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörschbach"@de .
+
+:n13402  a              skos:Concept ;
+        skos:broader    :n134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birkenfeld, Verbandsgemeinde"@de .
+
+:n19    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hunsrück"@de .
+
+:n4049765n3  a          skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Regierungsbezirk Rheinhessen-Pfalz (1946-1999)"@de .
+
+:n13210048  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Helmeroth"@de .
+
+:n340010040102  a       skos:Concept ;
+        skos:broader    :n34001004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fischwoogmühle"@de .
+
+:n33302038  a           skos:Concept ;
+        skos:broader    :n33302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kerzenheim"@de .
+
+:n34009219  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obernheim-Kirchenarnbach"@de .
+
+:n333070040101  a       skos:Concept ;
+        skos:broader    :n33307004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bremricherhof"@de .
+
+:n233042180300  a       skos:Concept ;
+        skos:broader    :n23304218 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Köttelbach (Ortsbezirk)"@de .
+
+:n235071370201  a       skos:Concept ;
+        skos:broader    :n23507137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhaus"@de .
+
+:n231091240100  a       skos:Concept ;
+        skos:broader    :n23109124 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kautenbach (Ortsbezirk)"@de .
+
+:n23106019  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dhronecken"@de .
+
+:n132090060101  a       skos:Concept ;
+        skos:broader    :n13209006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruche"@de .
+
+:n14304034  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horbach"@de .
+
+:n231060790102  a       skos:Concept ;
+        skos:broader    :n23106079 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Echternach"@de .
+
+:n13104073  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schalkenbach"@de .
+
+:n134050460104  a       skos:Concept ;
+        skos:broader    :n13405046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wildenburg"@de .
+
+:n337020790102  a       skos:Concept ;
+        skos:broader    :n33702079 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lindelbrunn"@de .
+
+:n13809043  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Melsbach"@de .
+
+:n33400007  a           skos:Concept ;
+        skos:broader    :n334 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Germersheim, Stadt"@de .
+
+:n314000000200  a       skos:Concept ;
+        skos:broader    :n31400000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Friesenheim (Ortsbezirk)"@de .
+
+:n138090470108  a       skos:Concept ;
+        skos:broader    :n13809047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolfenacker"@de .
+
+:n340090550300  a       skos:Concept ;
+        skos:broader    :n34009055 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zeselberg"@de .
+
+:n137040690100  a       skos:Concept ;
+        skos:broader    :n13704069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedermendig"@de .
+
+:n138090070116  a       skos:Concept ;
+        skos:broader    :n13809007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallbachsmühle (ehem.Gem.Dattenberg)"@de .
+
+:n13210027  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ersfeld"@de .
+
+:n313000000800  a       skos:Concept ;
+        skos:broader    :n31300000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wollmesheim (Ortsbezirk)"@de .
+
+:n13101018  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dorsel"@de .
+
+:n333065030103  a       skos:Concept ;
+        skos:broader    :n33306503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sattelhof"@de .
+
+:n134000451000  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Regulshausen"@de .
+
+:n143022360101  a       skos:Concept ;
+        skos:broader    :n14302236 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrlich"@de .
+
+:n140005010209  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jakobsberg"@de .
+
+:n23201240  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herzfeld"@de .
+
+:n140091120302  a       skos:Concept ;
+        skos:broader    :n14009112 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Engehöll (Ortsbezirk)"@de .
+
+:n33207003  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Battenberg (Pfalz)"@de .
+
+:n33907066  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wintersheim"@de .
+
+:n138070730106  a       skos:Concept ;
+        skos:broader    :n13807073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stuxhöhe"@de .
+
+:n13306075  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberstreit"@de .
+
+:n14304013  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eitelborn"@de .
+
+:n13210085  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obersteinebach"@de .
+
+:n211000001300  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberkirch (T.a. Ortsbezirk 10)"@de .
+
+:n14111117  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rettert"@de .
+
+:n33705043  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Impflingen"@de .
+
+:n138010800307  a       skos:Concept ;
+        skos:broader    :n13801080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seifen"@de .
+
+:n33807  a              skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Römerberg-Dudenhofen, Verbandsgemeinde"@de .
+
+:n13101076  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sierscheid"@de .
+
+:n4101050n4  a          skos:Concept ;
+        skos:broader    :n22 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelrheinisches Becken"@de .
+
+:n135   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Cochem-Zell, Landkreis"@de .
+
+:n00Sn02k2161a  a       skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breisiger Ländchen"@de .
+
+:n14110033  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dornholzhausen"@de .
+
+:n14107107  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oelsberg"@de .
+
+:n14306303  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldmühlen"@de .
+
+:n143022020103  a       skos:Concept ;
+        skos:broader    :n14302202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirtscheid"@de .
+
+:n14304071  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Simmern"@de .
+
+:n23301049  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nerdlen"@de .
+
+:n13401068  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reichenbach"@de .
+
+:n14009117  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfalzfeld"@de .
+
+:n135030050101  a       skos:Concept ;
+        skos:broader    :n13503005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldfrieden"@de .
+
+:n35    a               skos:Concept ;
+        skos:broader    :n3 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katholische Kirche / Diözese Limburg"@de .
+
+:n335095010400  a       skos:Concept ;
+        skos:broader    :n33509501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reichenbachsteegen"@de .
+
+:n132081170113  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhombach"@de .
+
+:n143013000100  a       skos:Concept ;
+        skos:broader    :n14301300 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Korb"@de .
+
+:n14306218  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elsoff (Westerwald)"@de .
+
+:n13210064  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kraam"@de .
+
+:n14110091  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nassau, Stadt"@de .
+
+:n33702046  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kapsweyer"@de .
+
+:n33705022  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eschbach"@de .
+
+:n333030260104  a       skos:Concept ;
+        skos:broader    :n33303026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gundheimerhof"@de .
+
+:n333072010200  a       skos:Concept ;
+        skos:broader    :n33307201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rudolphskirchen"@de .
+
+:n33303  a              skos:Concept ;
+        skos:broader    :n333 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Göllheim, Verbandsgemeinde"@de .
+
+:n138010440228  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unterelsaff (ehem.Gem.Elsaffthal)"@de .
+
+:n33207040  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obersülzen"@de .
+
+:n317000000707  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rehmühle"@de .
+
+:n93    a               skos:Concept ;
+        skos:broader    :n5 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Neckar-Raum"@de .
+
+:n315000000400  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ebersheim (Ortsbezirk)"@de .
+
+:n141101280103  a       skos:Concept ;
+        skos:broader    :n14110128 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hollerich"@de .
+
+:n23106035  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gielert"@de .
+
+:n337050070400  a       skos:Concept ;
+        skos:broader    :n33705007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mühlhofen"@de .
+
+:n232080130101  a       skos:Concept ;
+        skos:broader    :n23208013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alt-Bettingen"@de .
+
+:n33201009  a           skos:Concept ;
+        skos:broader    :n33201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Deidesheim, Stadt"@de .
+
+:n4054887n9  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siegerland"@de .
+
+:n33907024  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Guntersblum"@de .
+
+:n135030570100  a       skos:Concept ;
+        skos:broader    :n13503057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Driesch"@de .
+
+:n13703049  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchwald"@de .
+
+:n14    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vorderpfalz"@de .
+
+:n132070630403  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freusburgermühle"@de .
+
+:n33610089  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rutsweiler am Glan"@de .
+
+:n13306033  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gebroth"@de .
+
+:n332070410300  a       skos:Concept ;
+        skos:broader    :n33207041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mühlheim"@de .
+
+:n133100110200  a       skos:Concept ;
+        skos:broader    :n13310011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gangloff"@de .
+
+:n13210043  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Güllesheim"@de .
+
+:n13101034  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Insul"@de .
+
+:n340040310101  a       skos:Concept ;
+        skos:broader    :n34004031 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birkwieserhof"@de .
+
+:n14008012  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bergenhausen"@de .
+
+:n331000030300  a       skos:Concept ;
+        skos:broader    :n33100003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heimersheim (Ortsbezirk)"@de .
+
+:n23106093  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neunkirchen"@de .
+
+:n137082160202  a       skos:Concept ;
+        skos:broader    :n13708216 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Depot-Siedlung"@de .
+
+:n131042060102  a       skos:Concept ;
+        skos:broader    :n13104206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lederbach"@de .
+
+:n33511021  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krickenbach"@de .
+
+:n340082110105  a       skos:Concept ;
+        skos:broader    :n34008211 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stuppacherhof"@de .
+
+:n131010440101  a       skos:Concept ;
+        skos:broader    :n13101044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Adorferhof"@de .
+
+:n13703113  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welschenbach"@de .
+
+:n23306209  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Densborn"@de .
+
+:n339000300100  a       skos:Concept ;
+        skos:broader    :n33900030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großwinternheim (Ortsbezirk)"@de .
+
+:n13401026  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fohren-Linden"@de .
+
+:n320000001003  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heidelbingerhof"@de .
+
+:n14008070  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klosterkumbd"@de .
+
+:n33610068  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederstaufenbach"@de .
+
+:n14103005  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Aull"@de .
+
+:n233015010202  a       skos:Concept ;
+        skos:broader    :n23301501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gemünden (Ortsbezirk)"@de .
+
+:n33101067  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wahlheim"@de .
+
+:n13210022  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eichelhardt"@de .
+
+:n138010030101  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bennau (ehemals Gemeinde Elsaff)"@de .
+
+:n140005010204  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eisenbolz"@de .
+
+:n23301065  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schutz"@de .
+
+:n143022960101  a       skos:Concept ;
+        skos:broader    :n14302296 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alhausen"@de .
+
+:n131020030107  a       skos:Concept ;
+        skos:broader    :n13102003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reimerzhoven"@de .
+
+:n14009133  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Goar, Stadt"@de .
+
+:n235081310201  a       skos:Concept ;
+        skos:broader    :n23508131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forstgut Hundscheid"@de .
+
+:n137092050103  a       skos:Concept ;
+        skos:broader    :n13709205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrenburgertal"@de .
+
+:n13203036  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Friedewald"@de .
+
+:n51    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinprovinz"@de .
+
+:n13206  a              skos:Concept ;
+        skos:broader    :n132 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hamm(Sieg), Verbandsgemeinde"@de .
+
+:n135010820200  a       skos:Concept ;
+        skos:broader    :n13501082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Treis"@de .
+
+:n13306070  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhausen"@de .
+
+:n231001340500  a       skos:Concept ;
+        skos:broader    :n23100134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wengerohr (Ortsbezirk)"@de .
+
+:n14305007  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Caan"@de .
+
+:n33702062  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pleisweiler-Oberhofen"@de .
+
+:n13401005  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Baumholder, Stadt"@de .
+
+:n235030680100  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Filzen (Ortsbezirk 1)"@de .
+
+:n138050700200  a       skos:Concept ;
+        skos:broader    :n13805070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weroth"@de .
+
+:n13208080  a           skos:Concept ;
+        skos:broader    :n13208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katzwinkel (Sieg)"@de .
+
+:n13708209  a           skos:Concept ;
+        skos:broader    :n13708 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaltenengers"@de .
+
+:n315000001500  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberstadt (Ortsbezirk)"@de .
+
+:n143062950101  a       skos:Concept ;
+        skos:broader    :n14306295 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neukirch"@de .
+
+:n13703007  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Baar"@de .
+
+:n311000000500  a       skos:Concept ;
+        skos:broader    :n31100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Studernheim (Ortsbezirk)"@de .
+
+:n235080820101  a       skos:Concept ;
+        skos:broader    :n23508082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kümmern"@de .
+
+:n141100910100  a       skos:Concept ;
+        skos:broader    :n14110091 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bergnassau"@de .
+
+:n13210001  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Almersbach"@de .
+
+:n33806016  a           skos:Concept ;
+        skos:broader    :n33806 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lambsheim"@de .
+
+:n4110084n0  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eifel / Ost"@de .
+
+:n143022990103  a       skos:Concept ;
+        skos:broader    :n14302299 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kloster Marienstatt"@de .
+
+:n333020190104  a       skos:Concept ;
+        skos:broader    :n33302019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lauberhof"@de .
+
+:n14306292  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seck"@de .
+
+:n134020580104  a       skos:Concept ;
+        skos:broader    :n13402058 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heupweiler"@de .
+
+:n233062400100  a       skos:Concept ;
+        skos:broader    :n23306240 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönfeld (Ortsbezirk)"@de .
+
+:n137025010102  a       skos:Concept ;
+        skos:broader    :n13702501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pilligerheck"@de .
+
+:n14009112  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwesel, Stadt"@de .
+
+:n30    a               skos:Concept ;
+        skos:broader    :n3 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Evangelische Kirche im Rheinland"@de .
+
+:n232081260101  a       skos:Concept ;
+        skos:broader    :n23208126 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Teitelbach"@de .
+
+:n135050710200  a       skos:Concept ;
+        skos:broader    :n13505071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Peterswald"@de .
+
+:n340082080105  a       skos:Concept ;
+        skos:broader    :n34008208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Monbijou"@de .
+
+:n13102049  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mayschoß"@de .
+
+:n13101050  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meuspath"@de .
+
+:n13807019  a           skos:Concept ;
+        skos:broader    :n13807 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erpel"@de .
+
+:n33101025  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flonheim"@de .
+
+:n235081050101  a       skos:Concept ;
+        skos:broader    :n23508105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Benratherhof"@de .
+
+:n23506022  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fell"@de .
+
+:n138030120300  a       skos:Concept ;
+        skos:broader    :n13803012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elgert (Ortsbezirk)"@de .
+
+:n14306271  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neunkirchen"@de .
+
+:n33400501  a           skos:Concept ;
+        skos:broader    :n334 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wörth am Rhein, Stadt"@de .
+
+:n143093080200  a       skos:Concept ;
+        skos:broader    :n14309308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sainscheid"@de .
+
+:n13700068  a           skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mayen, große kreisangehörige Stadt"@de .
+
+:n33610084  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reichweiler"@de .
+
+:n14103021  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Charlottenberg"@de .
+
+:n211000000503  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloß Monaise"@de .
+
+:n138040750106  a       skos:Concept ;
+        skos:broader    :n13804075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwillscheid"@de .
+
+:n13501021  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dohr"@de .
+
+:n13311095  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seibersbach"@de .
+
+:n14306  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rennerod, Verbandsgemeinde"@de .
+
+:n138010440202  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bertenau"@de .
+
+:n33608005  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Aschbach"@de .
+
+:n313000000100  a       skos:Concept ;
+        skos:broader    :n31300000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arzheim (Ortsbezirk)"@de .
+
+:n33205037  a           skos:Concept ;
+        skos:broader    :n33205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neidenfels"@de .
+
+:n23301081  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weidenbach"@de .
+
+:n312000000700  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hohenecken (Ortsbezirk)"@de .
+
+:n134050430104  a       skos:Concept ;
+        skos:broader    :n13405043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neumühle"@de .
+
+:n235061250215  a       skos:Concept ;
+        skos:broader    :n23506125 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Molitorsmühle"@de .
+
+:n336080360100  a       skos:Concept ;
+        skos:broader    :n33608036 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berzweiler"@de .
+
+:n140091330300  a       skos:Concept ;
+        skos:broader    :n14009133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Werlau (Ortsbezirk)"@de .
+
+:n23306204  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birresborn"@de .
+
+:n33703077  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Venningen"@de .
+
+:n333040100104  a       skos:Concept ;
+        skos:broader    :n33304010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weierhof"@de .
+
+:n13401021  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eckersweiler"@de .
+
+:n13505054  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Liesenich"@de .
+
+:n13708225  a           skos:Concept ;
+        skos:broader    :n13708 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Urmitz"@de .
+
+:n13209095  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rosenheim (Lkr. Altenkirchen)"@de .
+
+:n33107  a              skos:Concept ;
+        skos:broader    :n331 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wonnegau, Verbandsgemeinde"@de .
+
+:n14111043  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flacht"@de .
+
+:n33303006  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biedesheim"@de .
+
+:n23208129  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Usch"@de .
+
+:n34001010  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erlenbach bei Dahn"@de .
+
+:n13402078  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmißberg"@de .
+
+:n33205016  a           skos:Concept ;
+        skos:broader    :n33205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Esthal"@de .
+
+:n131030060204  a       skos:Concept ;
+        skos:broader    :n13103006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auf Wallers"@de .
+
+:n333070430100  a       skos:Concept ;
+        skos:broader    :n33307043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Cölln"@de .
+
+:n14009043  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gondershausen"@de .
+
+:n33303064  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rüssingen"@de .
+
+:n137092140200  a       skos:Concept ;
+        skos:broader    :n13709214 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kattenes"@de .
+
+:n133100580102  a       skos:Concept ;
+        skos:broader    :n13310058 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neudorferhof"@de .
+
+:n33608042  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinzweiler"@de .
+
+:n34009018  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hettenhausen"@de .
+
+:n4393883n8  a          skos:Concept ;
+        skos:broader    :n15 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stumpfwald"@de .
+
+:n137000680412  a       skos:Concept ;
+        skos:broader    :n13700068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katzenberg, Schiefergrube"@de .
+
+:n233010750200  a       skos:Concept ;
+        skos:broader    :n23301075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trittscheid (Ortsbezirk)"@de .
+
+:n235071110600  a       skos:Concept ;
+        skos:broader    :n23507111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wintersdorf (Ortsbezirk)"@de .
+
+:n138000450800  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederbieber (Ortsbezirk)"@de .
+
+:n23306241  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steffeln"@de .
+
+:n13805025  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hanroth"@de .
+
+:n13402057  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederbrombach"@de .
+
+:n33202019  a           skos:Concept ;
+        skos:broader    :n33202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freinsheim, Stadt"@de .
+
+:n333035010100  a       skos:Concept ;
+        skos:broader    :n33303501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Harxheim (Ortsbezirk)"@de .
+
+:n14107012  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bettendorf"@de .
+
+:n13703060  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenfeld"@de .
+
+:n232051310101  a       skos:Concept ;
+        skos:broader    :n23205131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gaymühle"@de .
+
+:n336080190102  a       skos:Concept ;
+        skos:broader    :n33608019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hobstätterhof"@de .
+
+:n33703035  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großfischlingen"@de .
+
+:n13206077  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederirsen"@de .
+
+:n23108108  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Plein"@de .
+
+:n33610021  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elzweiler"@de .
+
+:n232062260200  a       skos:Concept ;
+        skos:broader    :n23206226 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hermespand"@de .
+
+:n33101020  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eppelsheim"@de .
+
+:n235081040401  a       skos:Concept ;
+        skos:broader    :n23508104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloß Thorn"@de .
+
+:n14111001  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Allendorf"@de .
+
+:n132070120101  a       skos:Concept ;
+        skos:broader    :n13207012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büdenholz"@de .
+
+:n235080720108  a       skos:Concept ;
+        skos:broader    :n23508072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obersehr"@de .
+
+:n33403022  a           skos:Concept ;
+        skos:broader    :n33403 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neupotz"@de .
+
+:n14107070  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kehlbach"@de .
+
+:n23301501  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daun, Stadt"@de .
+
+:n143022650100  a       skos:Concept ;
+        skos:broader    :n14302265 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedermörsbach"@de .
+
+:n13505070  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Panzweiler"@de .
+
+:n14009080  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laudert"@de .
+
+:n131000900502  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Esch"@de .
+
+:n33901062  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldalgesheim"@de .
+
+:n335020480102  a       skos:Concept ;
+        skos:broader    :n33502048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stüterhof"@de .
+
+:n138040750101  a       skos:Concept ;
+        skos:broader    :n13804075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalenborn"@de .
+
+:n339060570200  a       skos:Concept ;
+        skos:broader    :n33906057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stadecken"@de .
+
+:n134020720102  a       skos:Concept ;
+        skos:broader    :n13402072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rötsweiler"@de .
+
+:n34009055  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weselberg"@de .
+
+:n138020040101  a       skos:Concept ;
+        skos:broader    :n13802004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arenfels, Schloß und Hsgr."@de .
+
+:n14301  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Marienberg (Ww), Verbandsgemeinde"@de .
+
+:n23101136  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zeltingen-Rachtig"@de .
+
+:n13402094  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wilzenberg-Hußweiler"@de .
+
+:n33205032  a           skos:Concept ;
+        skos:broader    :n33205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lambrecht (Pfalz), Stadt"@de .
+
+:n335010030500  a       skos:Concept ;
+        skos:broader    :n33501003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vogelbachermühle"@de .
+
+:n338000040103  a       skos:Concept ;
+        skos:broader    :n33800004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nonnenhof"@de .
+
+:n232063320200  a       skos:Concept ;
+        skos:broader    :n23206332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhersdorf"@de .
+
+:n132105010200  a       skos:Concept ;
+        skos:broader    :n13210501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dieperzen"@de .
+
+:n13402015  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brücken"@de .
+
+:n33307055  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberndorf"@de .
+
+:n338070230300  a       skos:Concept ;
+        skos:broader    :n33807023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mechtersheim"@de .
+
+:n13709219  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nörtershausen"@de .
+
+:n235075010105  a       skos:Concept ;
+        skos:broader    :n23507501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kostermühle"@de .
+
+:n33502048  a           skos:Concept ;
+        skos:broader    :n33502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldleiningen"@de .
+
+:n33102  a              skos:Concept ;
+        skos:broader    :n331 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eich, Verbandsgemeinde"@de .
+
+:n331070150100  a       skos:Concept ;
+        skos:broader    :n33107015 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dittelsheim"@de .
+
+:n141000750101  a       skos:Concept ;
+        skos:broader    :n14100075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Allerheiligenberg"@de .
+
+:n137030970101  a       skos:Concept ;
+        skos:broader    :n13703097 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bürresheim, Schloß und Hof"@de .
+
+:n311000000101  a       skos:Concept ;
+        skos:broader    :n31100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ormsheimerhof"@de .
+
+:n33303001  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Albisheim (Pfrimm)"@de .
+
+:n13102002  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ahrbrück"@de .
+
+:n143040480800  a       skos:Concept ;
+        skos:broader    :n14304048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wirzenborn (Ortsbezirk)"@de .
+
+:n23208124  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stockem"@de .
+
+:n332070120200  a       skos:Concept ;
+        skos:broader    :n33207012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodenbach (Ortsbezirk)"@de .
+
+:n23306029  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hillesheim, Stadt"@de .
+
+:n335110470108  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Johanniskreuz"@de .
+
+:n13310058  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lettweiler"@de .
+
+:n33908050  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Johann"@de .
+
+:n23208039  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fließem"@de .
+
+:n332050140110  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Röderthal"@de .
+
+:n13502052  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laubach"@de .
+
+:n33200025  a           skos:Concept ;
+        skos:broader    :n332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haßloch"@de .
+
+:n33307034  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Imsweiler"@de .
+
+:n23504141  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldrach"@de .
+
+:n137002030105  a       skos:Concept ;
+        skos:broader    :n13700203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sayn"@de .
+
+:n336090920400  a       skos:Concept ;
+        skos:broader    :n33609092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönenberg"@de .
+
+:n13206014  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruchertseifen"@de .
+
+:n23504056  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kasel"@de .
+
+:n141091210102  a       skos:Concept ;
+        skos:broader    :n14109121 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Katz"@de .
+
+:n23205127  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Übereisenbach"@de .
+
+:n23208097  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberstedem"@de .
+
+:n231061230100  a       skos:Concept ;
+        skos:broader    :n23106123 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bäsch (Ortsbezirk)"@de .
+
+:n232062960200  a       skos:Concept ;
+        skos:broader    :n23206296 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederprüm"@de .
+
+:n337020450101  a       skos:Concept ;
+        skos:broader    :n33702045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Deutschhof"@de .
+
+:n33106068  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallertheim"@de .
+
+:n131010860102  a       skos:Concept ;
+        skos:broader    :n13101086 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirmutscheid"@de .
+
+:n13502031  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forst (Eifel)"@de .
+
+:n232063290200  a       skos:Concept ;
+        skos:broader    :n23206329 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Urb"@de .
+
+:n23108103  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Osann-Monzel"@de .
+
+:n34006016  a           skos:Concept ;
+        skos:broader    :n34006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hermersberg"@de .
+
+:n33804008  a           skos:Concept ;
+        skos:broader    :n33804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fußgönheim"@de .
+
+:n336090370100  a       skos:Concept ;
+        skos:broader    :n33609037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haschbach"@de .
+
+:n23205106  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Plascheid"@de .
+
+:n23208076  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Malbergweich"@de .
+
+:n13402031  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gollenberg"@de .
+
+:n14004128  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rödelhausen"@de .
+
+:n137030070108  a       skos:Concept ;
+        skos:broader    :n13703007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wanderath"@de .
+
+:n13701057  a           skos:Concept ;
+        skos:broader    :n13701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kruft"@de .
+
+:n131000700700  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rolandswerth (Ortsbezirk 5)"@de .
+
+:n235081540100  a       skos:Concept ;
+        skos:broader    :n23508154 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dittlingen (Ortsbezirk)"@de .
+
+:n13405019  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dickesbach"@de .
+
+:n34002020  a           skos:Concept ;
+        skos:broader    :n34002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinterweidenthal"@de .
+
+:n34003019  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hilst"@de .
+
+:n138090060109  a       skos:Concept ;
+        skos:broader    :n13809006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gersthahnsmühle"@de .
+
+:n3     a               skos:Concept ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchliche Gebiete in Rheinland-Pfalz"@de .
+
+:n339000050700  a       skos:Concept ;
+        skos:broader    :n33900005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kempten"@de .
+
+:n23304217  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaperich"@de .
+
+:n13402010  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birkenfeld, Stadt"@de .
+
+:n14004107  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedersohren"@de .
+
+:n33307050  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhausen an der Appel"@de .
+
+:n13709214  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Löf"@de .
+
+:n23206227  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gondenbrett"@de .
+
+:n312000001604  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eselsfürth"@de .
+
+:n231080010102  a       skos:Concept ;
+        skos:broader    :n23108001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haardt"@de .
+
+:n335100290100  a       skos:Concept ;
+        skos:broader    :n33510029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heimkirchen (Ortsbezirk)"@de .
+
+:n13405077  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmidthachenbach"@de .
+
+:n14307069  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sessenhausen"@de .
+
+:n138000450100  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altwied (Ortsbezirk)"@de .
+
+:n14004165  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Würrich"@de .
+
+:n233015010500  a       skos:Concept ;
+        skos:broader    :n23301501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rengen (Ortsbezirk)"@de .
+
+:n13310053  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirschroth"@de .
+
+:n143092490102  a       skos:Concept ;
+        skos:broader    :n14309249 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönberg"@de .
+
+:n320000000700  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörsbach (Ortsbezirk)"@de .
+
+:n232050120101  a       skos:Concept ;
+        skos:broader    :n23205012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gaymühle"@de .
+
+:n23208034  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eßlingen"@de .
+
+:n333070650106  a       skos:Concept ;
+        skos:broader    :n33307065 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unter-Tierwasen"@de .
+
+:n332000020100  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Dürkheim"@de .
+
+:n337010240103  a       skos:Concept ;
+        skos:broader    :n33701024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sanatorium Eußerthal"@de .
+
+:n23206206  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bleialf"@de .
+
+:n13309201  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruschied"@de .
+
+:n135050700101  a       skos:Concept ;
+        skos:broader    :n13505070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gassenhof"@de .
+
+:n13405056  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörschied"@de .
+
+:n137002030100  a       skos:Concept ;
+        skos:broader    :n13700203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bendorf"@de .
+
+:n33609031  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Glan-Münchweiler"@de .
+
+:n13104202  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burgbrohl"@de .
+
+:n140030180200  a       skos:Concept ;
+        skos:broader    :n14003018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dudenroth (Ortsbezirk)"@de .
+
+:n138050140102  a       skos:Concept ;
+        skos:broader    :n13805014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Muscheid"@de .
+
+:n14109079  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lierschied"@de .
+
+:n23205122  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sinspelt"@de .
+
+:n23208092  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederweiler"@de .
+
+:n14008119  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ravengiersburg"@de .
+
+:n33906047  a           skos:Concept ;
+        skos:broader    :n33906 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ober-Olm"@de .
+
+:n23208013  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bettingen"@de .
+
+:n23205037  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ferschweiler"@de .
+
+:n33106063  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sulzheim"@de .
+
+:n140081000200  a       skos:Concept ;
+        skos:broader    :n14008100 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nickweiler"@de .
+
+:n137025010400  a       skos:Concept ;
+        skos:broader    :n13702501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Metternich (Ortsbezirk)"@de .
+
+:n13405035  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hausen"@de .
+
+:n333075020309  a       skos:Concept ;
+        skos:broader    :n33307502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schacherhof"@de .
+
+:n33609010  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitenbach"@de .
+
+:n232012530300  a       skos:Concept ;
+        skos:broader    :n23201253 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ringhuscheid"@de .
+
+:n138050520103  a       skos:Concept ;
+        skos:broader    :n13805052 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lautzert"@de .
+
+:n33804003  a           skos:Concept ;
+        skos:broader    :n33804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birkenheide"@de .
+
+:n231010700300  a       skos:Concept ;
+        skos:broader    :n23101070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Götzeroth (Ortsbezirk)"@de .
+
+:n13310090  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmittweiler"@de .
+
+:n23208071  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kyllburgweiler"@de .
+
+:n23108013  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruch"@de .
+
+:n23205095  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nusbaum"@de .
+
+:n331030230100  a       skos:Concept ;
+        skos:broader    :n33103023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dalsheim"@de .
+
+:n23304233  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reimerath"@de .
+
+:n13503083  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ulmen, Stadt"@de .
+
+:n13709230  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winningen"@de .
+
+:n137030070103  a       skos:Concept ;
+        skos:broader    :n13703007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freilingen"@de .
+
+:n336091020104  a       skos:Concept ;
+        skos:broader    :n33609102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eichelscheiderhof"@de .
+
+:n13310011  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Becherbach"@de .
+
+:n333070230102  a       skos:Concept ;
+        skos:broader    :n33307023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leiningerhof"@de .
+
+:n23205016  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biesdorf"@de .
+
+:n13405093  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wickenrodt"@de .
+
+:n33103066  a           skos:Concept ;
+        skos:broader    :n33103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wachenheim"@de .
+
+:n134000450501  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Algenrodt"@de .
+
+:n133090460200  a       skos:Concept ;
+        skos:broader    :n13309046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochstetten"@de .
+
+:n33511  a              skos:Concept ;
+        skos:broader    :n335 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Landstuhl, Verbandsgemeinde"@de .
+
+:n13207045  a           skos:Concept ;
+        skos:broader    :n13207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Harbach"@de .
+
+:n14109122  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sauerthal"@de .
+
+:n13405014  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruchweiler"@de .
+
+:n14307085  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wölferlingen"@de .
+
+:n141095010106  a       skos:Concept ;
+        skos:broader    :n14109501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marksburg"@de .
+
+:n143040480100  a       skos:Concept ;
+        skos:broader    :n14304048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bladernheim (Ortsbezirk)"@de .
+
+:n33401014  a           skos:Concept ;
+        skos:broader    :n33401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Knittelsheim"@de .
+
+:n23101041  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Graach an der Mosel"@de .
+
+:n14303031  a           skos:Concept ;
+        skos:broader    :n14303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hillscheid"@de .
+
+:n14110135  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weinähr"@de .
+
+:n23304212  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gelenberg"@de .
+
+:n4095533n3  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hoher Westerwald"@de .
+
+:n233060290100  a       skos:Concept ;
+        skos:broader    :n23306029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bolsdorf (Ortsbezirk)"@de .
+
+:n132081170300  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönstein"@de .
+
+:n23206222  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Feuerscheid"@de .
+
+:n340090350101  a       skos:Concept ;
+        skos:broader    :n34009035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bärenhütte"@de .
+
+:n340060540104  a       skos:Concept ;
+        skos:broader    :n34006054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maria Rosenberg"@de .
+
+:n131020110105  a       skos:Concept ;
+        skos:broader    :n13102011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unter-Krälingen"@de .
+
+:n233060260800  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Müllenborn (Ortsbezirk)"@de .
+
+:n23108050  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heckenmünster"@de .
+
+:n340040320101  a       skos:Concept ;
+        skos:broader    :n34004032 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beckenhof"@de .
+
+:n34006  a              skos:Concept ;
+        skos:broader    :n340 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldfischbach-Burgalben, Verbandsgemeinde"@de .
+
+:n14307064  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rückeroth"@de .
+
+:n340030280108  a       skos:Concept ;
+        skos:broader    :n34003028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Salzwoog (Ortsbezirk)"@de .
+
+:n33405  a              skos:Concept ;
+        skos:broader    :n334 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lingenfeld, Verbandsgemeinde"@de .
+
+:n14109016  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bornich"@de .
+
+:n23205053  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holsthum"@de .
+
+:n13309047  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horbach"@de .
+
+:n231005020600  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heinzerath (Ortsbezirk)"@de .
+
+:n333070650101  a       skos:Concept ;
+        skos:broader    :n33307065 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ober-Gerbacherhof"@de .
+
+:n33701064  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ramberg"@de .
+
+:n335020280104  a       skos:Concept ;
+        skos:broader    :n33502028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Randeckerhof"@de .
+
+:n141110200103  a       skos:Concept ;
+        skos:broader    :n14111020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zollhaus"@de .
+
+:n333060710101  a       skos:Concept ;
+        skos:broader    :n33306071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfrimmerhof"@de .
+
+:n33903008  a           skos:Concept ;
+        skos:broader    :n33903 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bubenheim"@de .
+
+:n23201294  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Preischeid"@de .
+
+:n141091080109  a       skos:Concept ;
+        skos:broader    :n14109108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloß Liebeneck"@de .
+
+:n319000000600  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horchheim (Ortsbezirk)"@de .
+
+:n231060420101  a       skos:Concept ;
+        skos:broader    :n23106042 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krakesmühle"@de .
+
+:n331010320100  a       skos:Concept ;
+        skos:broader    :n33101032 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gau-Köngernheim"@de .
+
+:n337010330200  a       skos:Concept ;
+        skos:broader    :n33701033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stein"@de .
+
+:n33906042  a           skos:Concept ;
+        skos:broader    :n33906 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nieder-Olm, Stadt"@de .
+
+:n13809076  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldbreitbach"@de .
+
+:n331020020102  a       skos:Concept ;
+        skos:broader    :n33102002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hangen-Wahlheim"@de .
+
+:n138010440309  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Strauscheid"@de .
+
+:n23507  a              skos:Concept ;
+        skos:broader    :n235 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trier-Land, Verbandsgemeinde"@de .
+
+:n14110087  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Misselberg"@de .
+
+:n23506108  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pölich"@de .
+
+:n13405030  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gösenroth"@de .
+
+:n231011050201  a       skos:Concept ;
+        skos:broader    :n23101105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ferres"@de .
+
+:n4026464n6  a          skos:Concept ;
+        skos:broader    :n19 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Idarwald"@de .
+
+:n33207036  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mertesheim"@de .
+
+:n14110008  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Becheln"@de .
+
+:n140081190101  a       skos:Concept ;
+        skos:broader    :n14008119 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhof"@de .
+
+:n23205090  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederraden"@de .
+
+:n13803012  a           skos:Concept ;
+        skos:broader    :n13803 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dierdorf, Stadt"@de .
+
+:n14307022  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Goddert"@de .
+
+:n111000000300  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Asterstein"@de .
+
+:n333065030200  a       skos:Concept ;
+        skos:broader    :n33306503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochstein"@de .
+
+:n233062410100  a       skos:Concept ;
+        skos:broader    :n23306241 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auel (Ortsbezirk)"@de .
+
+:n23205011  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berkoth"@de .
+
+:n33107036  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gundersheim"@de .
+
+:n336080300100  a       skos:Concept ;
+        skos:broader    :n33608030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hachenbach"@de .
+
+:n132101140102  a       skos:Concept ;
+        skos:broader    :n13210114 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leingen"@de .
+
+:n14008008  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Belgweiler"@de .
+
+:n132070720103  a       skos:Concept ;
+        skos:broader    :n13207072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederschelden, Bhf."@de .
+
+:n14309312  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Willmenrod"@de .
+
+:n231005021700  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiperath (Ortsbezirk)"@de .
+
+:n138070190102  a       skos:Concept ;
+        skos:broader    :n13807019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reifstein"@de .
+
+:n34008211  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hornbach,Stadt"@de .
+
+:n131000900800  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leimersdorf (Ortsbezirk)"@de .
+
+:n340092220200  a       skos:Concept ;
+        skos:broader    :n34009222 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rieschweiler"@de .
+
+:n33402008  a           skos:Concept ;
+        skos:broader    :n33402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hagenbach, Stadt"@de .
+
+:n4329692n0  a          skos:Concept ;
+        skos:broader    :n11 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Einrich"@de .
+
+:n14302276  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nister"@de .
+
+:n13309063  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meckenbach"@de .
+
+:n232   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eifelkreis Bitburg-Prüm"@de .
+
+:n13210103  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seelbach (Westerwald)"@de .
+
+:n13210097  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rott"@de .
+
+:n33702079  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vorderweidenthal"@de .
+
+:n33701080  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldhambach"@de .
+
+:n4110085n2  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eifel / West"@de .
+
+:n333060090104  a       skos:Concept ;
+        skos:broader    :n33306009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herfingerhof"@de .
+
+:n143022350300  a       skos:Concept ;
+        skos:broader    :n14302235 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhattert"@de .
+
+:n33107015  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dittelsheim-Heßloch"@de .
+
+:n33701001  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Albersweiler"@de .
+
+:n13101009  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bauler"@de .
+
+:n132100880102  a       skos:Concept ;
+        skos:broader    :n13210088 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahn"@de .
+
+:n14306315  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zehnhausen bei Rennerod"@de .
+
+:n34001  a              skos:Concept ;
+        skos:broader    :n340 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dahner Felsenland, Verbandsgemeinde"@de .
+
+:n14308058  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obererbach"@de .
+
+:n23304037  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katzwinkel"@de .
+
+:n137000680100  a       skos:Concept ;
+        skos:broader    :n13700068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alzheim (Ortsbezirk)"@de .
+
+:n340030280103  a       skos:Concept ;
+        skos:broader    :n34003028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Glashütte (Ortsbezirk)"@de .
+
+:n47    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfalz-Zweibrücken"@de .
+
+:n14103059  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holzappel"@de .
+
+:n13309042  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heinzenberg"@de .
+
+:n137000030500  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Namedy (Ortsbezirk)"@de .
+
+:n33702058  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhausen"@de .
+
+:n23503148  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiltingen"@de .
+
+:n232000180200  a       skos:Concept ;
+        skos:broader    :n23200018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erdorf (Ortsbezirk)"@de .
+
+:n333020380105  a       skos:Concept ;
+        skos:broader    :n33302038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kerzweilerhof (T.a.Ortsbezirk Rosenthal)"@de .
+
+:n111000001400  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Moselweiß"@de .
+
+:n132070630500  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Offhausen (Ortsbezirk)"@de .
+
+:n4264313n2  a          skos:Concept ;
+        skos:broader    :n24 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Untermosel-Gebiet"@de .
+
+:n135030830106  a       skos:Concept ;
+        skos:broader    :n13503083 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vorpochten"@de .
+
+:n4205902n1  a          skos:Concept ;
+        skos:broader    :n15 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gräfensteiner Land"@de .
+
+:n14308037  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hundsangen"@de .
+
+:n14009108  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedert"@de .
+
+:n26    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nahetal"@de .
+
+:n14103038  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eppenrod"@de .
+
+:n13809071  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Straßenhaus"@de .
+
+:n138010440304  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhoppen, Hof"@de .
+
+:n13807  a              skos:Concept ;
+        skos:broader    :n138 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unkel, Verbandsgemeinde"@de .
+
+:n13210055  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horhausen (Westerwald)"@de .
+
+:n137030740108  a       skos:Concept ;
+        skos:broader    :n13703074 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schnürenhof"@de .
+
+:n14110082  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lollschied"@de .
+
+:n33702037  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hergersweiler"@de .
+
+:n317000000300  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gersbach (Ortsbezirk)"@de .
+
+:n138010440219  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelelsaff (ehem.Gem.Elsaffthal)"@de .
+
+:n4051098n0  a          skos:Concept ;
+        skos:broader    :n19 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saargau"@de .
+
+:n316000000900  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lachen-Speyerdorf (Ortsbezirk)"@de .
+
+:n14110003  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Attenhausen"@de .
+
+:n33207031  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinkarlbach"@de .
+
+:n320000001100  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wattweiler (Ortsbezirk)"@de .
+
+:n131020470300  a       skos:Concept ;
+        skos:broader    :n13102047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Plittersdorf"@de .
+
+:n133100940101  a       skos:Concept ;
+        skos:broader    :n13310094 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldfriede"@de .
+
+:n211000000101  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Petrisberg"@de .
+
+:n33907015  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eimsheim"@de .
+
+:n233060360100  a       skos:Concept ;
+        skos:broader    :n23306036 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalenborn"@de .
+
+:n05    a               skos:Concept ;
+        skos:broader    :n1 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinhessen"@de .
+
+:n13702041  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalt"@de .
+
+:n4114920n8  a          skos:Concept ;
+        skos:broader    :n22 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maifeld"@de .
+
+:n140090450102  a       skos:Concept ;
+        skos:broader    :n14009045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehr"@de .
+
+:n13501017  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruttig-Fankel"@de .
+
+:n14008003  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Argenthal"@de .
+
+:n23503106  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pellingen"@de .
+
+:n138010030113  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rindhausen (ehemals Gemeinde Elsaff)"@de .
+
+:n335010030103  a       skos:Concept ;
+        skos:broader    :n33501003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tausendmühle"@de .
+
+:n137092200101  a       skos:Concept ;
+        skos:broader    :n13709220 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bleidenbergerhof"@de .
+
+:n14308074  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinefrenz"@de .
+
+:n34004003  a           skos:Concept ;
+        skos:broader    :n34004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Clausen"@de .
+
+:n33207010  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dirmstein"@de .
+
+:n23301077  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Utzerath"@de .
+
+:n33511012  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hauptstuhl"@de .
+
+:n233060260100  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bewingen (Ortsbezirk)"@de .
+
+:n143092420400  a       skos:Concept ;
+        skos:broader    :n14309242 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönberg"@de .
+
+:n4101955n6  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ober-Westerwald"@de .
+
+:n14306246  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Irmtraut"@de .
+
+:n14304020  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gackenbach"@de .
+
+:n13210092  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Racksen"@de .
+
+:n33705050  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Knöringen"@de .
+
+:n134020110103  a       skos:Concept ;
+        skos:broader    :n13402011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thranenweier (ehem.Gem.Allenbach)"@de .
+
+:n13101083  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiesemscheid"@de .
+
+:n13703019  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ditscheid"@de .
+
+:n138090070102  a       skos:Concept ;
+        skos:broader    :n13809007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bremscheid"@de .
+
+:n14111039  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ergeshausen"@de .
+
+:n333035010202  a       skos:Concept ;
+        skos:broader    :n33303501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reitzenmühle"@de .
+
+:n138045010200  a       skos:Concept ;
+        skos:broader    :n13804501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ohlenberg"@de .
+
+:n13101004  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Antweiler"@de .
+
+:n23304032  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hörschhausen"@de .
+
+:n13401075  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruschberg"@de .
+
+:n232063290307  a       skos:Concept ;
+        skos:broader    :n23206329 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallmerath"@de .
+
+:n132100150102  a       skos:Concept ;
+        skos:broader    :n13210015 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bürdenbach-Bruch"@de .
+
+:n13703077  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münk"@de .
+
+:n13306061  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mandel"@de .
+
+:n14302250  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kroppach"@de .
+
+:n232063000100  a       skos:Concept ;
+        skos:broader    :n23206300 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellwerath"@de .
+
+:n134000450300  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Göttschied"@de .
+
+:n23503143  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wasserliesch"@de .
+
+:n13101062  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ohlenhard"@de .
+
+:n232062220101  a       skos:Concept ;
+        skos:broader    :n23206222 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Denterhof"@de .
+
+:n33608038  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heinzenhausen"@de .
+
+:n211000001201  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brubacherhof"@de .
+
+:n137000680408  a       skos:Concept ;
+        skos:broader    :n13700068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geisheckerhof"@de .
+
+:n14111018  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bremberg"@de .
+
+:n23109501  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Irmenach"@de .
+
+:n33406015  a           skos:Concept ;
+        skos:broader    :n33406 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kuhardt"@de .
+
+:n211000000600  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Feyen (T.a. Ortsbezirk 17)"@de .
+
+:n140030100600  a       skos:Concept ;
+        skos:broader    :n14003010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sevenich (Ortsbezirk)"@de .
+
+:n23106042  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gräfendhron"@de .
+
+:n14306283  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberroßbach"@de .
+
+:n23306237  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scheid"@de .
+
+:n143022940101  a       skos:Concept ;
+        skos:broader    :n14302294 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenbaum"@de .
+
+:n13401054  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mettweiler"@de .
+
+:n140005010800  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinbay (Ortsbezirk)"@de .
+
+:n143100420101  a       skos:Concept ;
+        skos:broader    :n14310042 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hosten"@de .
+
+:n21    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ingelheimer Rheinebene"@de .
+
+:n33508038  a           skos:Concept ;
+        skos:broader    :n33508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ramstein-Miesenbach, Stadt"@de .
+
+:n13306040  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hargesheim"@de .
+
+:n232082100106  a       skos:Concept ;
+        skos:broader    :n23208210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neustraßburg"@de .
+
+:n13802  a              skos:Concept ;
+        skos:broader    :n138 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Hönningen, Verbandsgemeinde"@de .
+
+:n336090310100  a       skos:Concept ;
+        skos:broader    :n33609031 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bettenhausen"@de .
+
+:n137030740103  a       skos:Concept ;
+        skos:broader    :n13703074 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lauxhof"@de .
+
+:n235030950300  a       skos:Concept ;
+        skos:broader    :n23503095 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rehlingen (Ortsbezirk)"@de .
+
+:n138010440214  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hombachsmühle"@de .
+
+:n34001043  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schindhard"@de .
+
+:n131000070100  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ahrweiler (Ortsbezirk)"@de .
+
+:n14009161  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiebelsheim"@de .
+
+:n13311028  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eckenroth"@de .
+
+:n231005021000  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hunolstein (Ortsbezirk)"@de .
+
+:n132100570101  a       skos:Concept ;
+        skos:broader    :n13210057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bahnhof Ingelbach"@de .
+
+:n131000900100  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bengen (Ortsbezirk)"@de .
+
+:n14308011  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreikirchen"@de .
+
+:n13401033  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahnweiler"@de .
+
+:n23301014  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Darscheid"@de .
+
+:n4267498n0  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schneifel"@de .
+
+:n31500000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mainz, Kreisfreie Stadt"@de .
+
+:n235070940300  a       skos:Concept ;
+        skos:broader    :n23507094 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lorich (Ortsbezirk)"@de .
+
+:n33907010  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dalheim"@de .
+
+:n33901058  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trechtingshausen"@de .
+
+:n13703035  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herresbach"@de .
+
+:n319000001000  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhausen (Ortsbezirk)"@de .
+
+:n33608075  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Offenbach-Hundheim"@de .
+
+:n340082060105  a       skos:Concept ;
+        skos:broader    :n34008206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Offweilerhof"@de .
+
+:n23503101  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Onsdorf"@de .
+
+:n13501012  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bremm"@de .
+
+:n33303018  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Einselthum"@de .
+
+:n314000000600  a       skos:Concept ;
+        skos:broader    :n31400000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oppau (Ortsbezirk)"@de .
+
+:n132100470101  a       skos:Concept ;
+        skos:broader    :n13210047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberölfen"@de .
+
+:n23503095  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nittel"@de .
+
+:n13805058  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ratzert"@de .
+
+:n4316101n7  a          skos:Concept ;
+        skos:broader    :n24 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelmosel-Gebiet"@de .
+
+:n31400000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ludwigshafen am Rhein, Kreisfreie Stadt"@de .
+
+:n14009140  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwall"@de .
+
+:n235010080200  a       skos:Concept ;
+        skos:broader    :n23501008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Prosterath"@de .
+
+:n232081000103  a       skos:Concept ;
+        skos:broader    :n23208100 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hoorhof"@de .
+
+:n137092050110  a       skos:Concept ;
+        skos:broader    :n13709205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stabenhof"@de .
+
+:n135050920300  a       skos:Concept ;
+        skos:broader    :n13505092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zell"@de .
+
+:n337020710100  a       skos:Concept ;
+        skos:broader    :n33702071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rechtenbach"@de .
+
+:n23306  a              skos:Concept ;
+        skos:broader    :n233 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gerolstein, Verbandsgemeinde"@de .
+
+:n13708216  a           skos:Concept ;
+        skos:broader    :n13708 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mülheim-Kärlich, Stadt"@de .
+
+:n211000001700  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruwer (T.a. Ortsbezirk 7)"@de .
+
+:n13703014  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Boos"@de .
+
+:n143070750101  a       skos:Concept ;
+        skos:broader    :n14307075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kautenmühle"@de .
+
+:n33101053  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Offenheim"@de .
+
+:n14111034  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ebertshausen"@de .
+
+:n4055608n6  a          skos:Concept ;
+        skos:broader    :n19 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Soonwald"@de .
+
+:n335100460200  a       skos:Concept ;
+        skos:broader    :n33510046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Untersulzbach"@de .
+
+:n34001001  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bobenthal"@de .
+
+:n143082630100  a       skos:Concept ;
+        skos:broader    :n14308263 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dahlen"@de .
+
+:n232063290302  a       skos:Concept ;
+        skos:broader    :n23206329 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eigelscheid"@de .
+
+:n135010200102  a       skos:Concept ;
+        skos:broader    :n13501020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Cochem-Brauheck"@de .
+
+:n141035030200  a       skos:Concept ;
+        skos:broader    :n14103503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schaumburg"@de .
+
+:n132070760103  a       skos:Concept ;
+        skos:broader    :n13207076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fischbacherhütte"@de .
+
+:n332050140106  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Helmbach"@de .
+
+:n143050620200  a       skos:Concept ;
+        skos:broader    :n14305062 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ransbach"@de .
+
+:n138010440230  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wied (ehem.Gem.Elsaffthal)"@de .
+
+:n33608033  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grumbach"@de .
+
+:n33101032  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gau-Odernheim"@de .
+
+:n141075020200  a       skos:Concept ;
+        skos:broader    :n14107502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münchenroth"@de .
+
+:n132061020101  a       skos:Concept ;
+        skos:broader    :n13206102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienthal"@de .
+
+:n14111013  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biebrich"@de .
+
+:n138010800203  a       skos:Concept ;
+        skos:broader    :n13801080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mendt"@de .
+
+:n33806002  a           skos:Concept ;
+        skos:broader    :n33806 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beindersheim"@de .
+
+:n33703  a              skos:Concept ;
+        skos:broader    :n337 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Edenkoben, Verbandsgemeinde"@de .
+
+:n316000000200  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Diedesfeld (Ortsbezirk)"@de .
+
+:n4010909n4  a          skos:Concept ;
+        skos:broader    :n15 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dahner Felsenland"@de .
+
+:n23306232  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ormont"@de .
+
+:n13402048  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kronweiler"@de .
+
+:n23301030  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinterweiler"@de .
+
+:n315000000800  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laubenheim (Ortsbezirk)"@de .
+
+:n33610091  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schellweiler"@de .
+
+:n141091090102  a       skos:Concept ;
+        skos:broader    :n14109109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hasenbachtal"@de .
+
+:n13505003  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altlay"@de .
+
+:n23504116  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Riveris"@de .
+
+:n338000040200  a       skos:Concept ;
+        skos:broader    :n33800004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roxheim"@de .
+
+:n137092120200  a       skos:Concept ;
+        skos:broader    :n13709212 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gondorf"@de .
+
+:n33501003  a           skos:Concept ;
+        skos:broader    :n33501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruchmühlbach-Miesau"@de .
+
+:n13805074  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Urbach"@de .
+
+:n33608012  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buborn"@de .
+
+:n13311023  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daxweiler"@de .
+
+:n233062140104  a       skos:Concept ;
+        skos:broader    :n23306214 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinebrück"@de .
+
+:n23206329  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winterspelt"@de .
+
+:n23306211  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Duppach"@de .
+
+:n33703084  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weyher in der Pfalz"@de .
+
+:n13505061  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelstrimmig"@de .
+
+:n33307067  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schiersfeld"@de .
+
+:n23508149  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wincheringen"@de .
+
+:n33908004  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Badenheim"@de .
+
+:n33610070  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberalben"@de .
+
+:n132090660200  a       skos:Concept ;
+        skos:broader    :n13209066 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steineberg"@de .
+
+:n14111050  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gutenacker"@de .
+
+:n137092070108  a       skos:Concept ;
+        skos:broader    :n13709207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mariaroth"@de .
+
+:n320000000802  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gersbergerhof"@de .
+
+:n140030090200  a       skos:Concept ;
+        skos:broader    :n14003009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hundheim (Ortsbezirk)"@de .
+
+:n13402085  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sonnenberg-Winnenberg"@de .
+
+:n23206308  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sellerich"@de .
+
+:n135010790101  a       skos:Concept ;
+        skos:broader    :n13501079 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Senhals"@de .
+
+:n14107040  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eschbach"@de .
+
+:n143040650200  a       skos:Concept ;
+        skos:broader    :n14304065 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruppach"@de .
+
+:n138010440103  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Etscheid"@de .
+
+:n23301  a              skos:Concept ;
+        skos:broader    :n233 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daun, Verbandsgemeinde"@de .
+
+:n13708211  a           skos:Concept ;
+        skos:broader    :n13708 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kettig"@de .
+
+:n13704008  a           skos:Concept ;
+        skos:broader    :n13704 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bell"@de .
+
+:n235030680500  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Konz"@de .
+
+:n235081520105  a       skos:Concept ;
+        skos:broader    :n23508152 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frommersbach"@de .
+
+:n13209002  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alsdorf"@de .
+
+:n23208115  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scharfbillig"@de .
+
+:n33202026  a           skos:Concept ;
+        skos:broader    :n33202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herxheim am Berg"@de .
+
+:n14107502  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Diethardt"@de .
+
+:n13310049  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hundsbach"@de .
+
+:n13301104  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tiefenthal"@de .
+
+:n140005010100  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Salzig (Ortsbezirk)"@de .
+
+:n13502043  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaifenheim"@de .
+
+:n333070140102  a       skos:Concept ;
+        skos:broader    :n33307014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hanauerhof"@de .
+
+:n33307025  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gerbach"@de .
+
+:n13102  a              skos:Concept ;
+        skos:broader    :n131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenahr, Verbandsgemeinde"@de .
+
+:n140091170101  a       skos:Concept ;
+        skos:broader    :n14009117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nenzhäuserhof, Hsgr."@de .
+
+:n33609027  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frohnhofen"@de .
+
+:n333060200102  a       skos:Concept ;
+        skos:broader    :n33306020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fuchshof"@de .
+
+:n134020150103  a       skos:Concept ;
+        skos:broader    :n13402015 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Traunen"@de .
+
+:n337030200101  a       skos:Concept ;
+        skos:broader    :n33703020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heldenstein, Forsthaus"@de .
+
+:n13805011  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dernbach"@de .
+
+:n33202005  a           skos:Concept ;
+        skos:broader    :n33202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bobenheim am Berg"@de .
+
+:n335080160300  a       skos:Concept ;
+        skos:broader    :n33508016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spesbach"@de .
+
+:n33307083  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winterborn"@de .
+
+:n335100170105  a       skos:Concept ;
+        skos:broader    :n33510017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schafmühle"@de .
+
+:n23207010  a           skos:Concept ;
+        skos:broader    :n23207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beilingen"@de .
+
+:n23208009  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Baustert"@de .
+
+:n4094352n5  a          skos:Concept ;
+        skos:broader    :n15 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haardt"@de .
+
+:n33105060  a           skos:Concept ;
+        skos:broader    :n33105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siefersheim"@de .
+
+:n131042080102  a       skos:Concept ;
+        skos:broader    :n13104208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heulingshof"@de .
+
+:n33106059  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schornsheim"@de .
+
+:n33703021  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Edesheim"@de .
+
+:n13502022  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dünfus"@de .
+
+:n333070660101  a       skos:Concept ;
+        skos:broader    :n33307066 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hengstbacherhof"@de .
+
+:n33307004  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bayerfeld-Steckweiler"@de .
+
+:n339   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mainz-Bingen, Landkreis"@de .
+
+:n132081170402  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brückhöfe"@de .
+
+:n231085040201  a       skos:Concept ;
+        skos:broader    :n23108504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wenzelhausen"@de .
+
+:n313000000500  a       skos:Concept ;
+        skos:broader    :n31300000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörzheim (Ortsbezirk)"@de .
+
+:n23108009  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bettenfeld"@de .
+
+:n13402022  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elchweiler"@de .
+
+:n135020310102  a       skos:Concept ;
+        skos:broader    :n13502031 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Molzig"@de .
+
+:n13405089  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Veitsrodt"@de .
+
+:n233042170102  a       skos:Concept ;
+        skos:broader    :n23304217 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kölnische Höfe"@de .
+
+:n131000070403  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heppingen (Ortsbezirk)"@de .
+
+:n33509006  a           skos:Concept ;
+        skos:broader    :n33509 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eulenbis"@de .
+
+:n33609064  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nanzdietschweiler"@de .
+
+:n34009041  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saalstadt"@de .
+
+:n235040850101  a       skos:Concept ;
+        skos:broader    :n23504085 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eisenbahnhaltepunkt Grünhaus-Mertesdorf"@de .
+
+:n211000001000  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kernscheid (Ortsbezirk 16)"@de .
+
+:n33304007  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bischheim"@de .
+
+:n23501114  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reinsfeld"@de .
+
+:n137021140101  a       skos:Concept ;
+        skos:broader    :n13702114 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Eltz"@de .
+
+:n13402080  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwollen"@de .
+
+:n23306036  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalenborn-Scheuern"@de .
+
+:n319000001303  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fahrt"@de .
+
+:n335110470115  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhof"@de .
+
+:n131040410101  a       skos:Concept ;
+        skos:broader    :n13104041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Landgut Leyerhof"@de .
+
+:n13310065  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meisenheim, Stadt"@de .
+
+:n235010450107  a       skos:Concept ;
+        skos:broader    :n23501045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lascheiderhof"@de .
+
+:n23208046  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hamm"@de .
+
+:n332000020112  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jägertal"@de .
+
+:n13402001  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Abentheuer"@de .
+
+:n336090640300  a       skos:Concept ;
+        skos:broader    :n33609064 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nanzweiler"@de .
+
+:n23508123  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schömerich"@de .
+
+:n13709205  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brodenbach"@de .
+
+:n33902026  a           skos:Concept ;
+        skos:broader    :n33902 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Harxheim"@de .
+
+:n332070070200  a       skos:Concept ;
+        skos:broader    :n33207007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hertlingshausen"@de .
+
+:n339060470101  a       skos:Concept ;
+        skos:broader    :n33906047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Am Wald"@de .
+
+:n335095010100  a       skos:Concept ;
+        skos:broader    :n33509501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Albersbach"@de .
+
+:n34006044  a           skos:Concept ;
+        skos:broader    :n34006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmalenberg"@de .
+
+:n143092540100  a       skos:Concept ;
+        skos:broader    :n14309254 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinterkirchen"@de .
+
+:n231010920100  a       skos:Concept ;
+        skos:broader    :n23101092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dhron"@de .
+
+:n23108046  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großlittgen"@de .
+
+:n235071370400  a       skos:Concept ;
+        skos:broader    :n23507137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Udelfangen (Ortsbezirk)"@de .
+
+:n23501008  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beuren (Hochwald)"@de .
+
+:n23206276  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederlauch"@de .
+
+:n23101016  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burgen"@de .
+
+:n33509043  a           skos:Concept ;
+        skos:broader    :n33509 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwedelbach"@de .
+
+:n14308208  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berod bei Wallmerod"@de .
+
+:n335100130102  a       skos:Concept ;
+        skos:broader    :n33510013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horterhof"@de .
+
+:n340030260101  a       skos:Concept ;
+        skos:broader    :n34003026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Einöderwiesenhof"@de .
+
+:n337050070100  a       skos:Concept ;
+        skos:broader    :n33705007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Appenhofen"@de .
+
+:n13405047  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirschweiler"@de .
+
+:n23507501  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welschbillig"@de .
+
+:n232050670500  a       skos:Concept ;
+        skos:broader    :n23205067 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seimerich"@de .
+
+:n131030060100  a       skos:Concept ;
+        skos:broader    :n13103006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederbreisig"@de .
+
+:n334050180100  a       skos:Concept ;
+        skos:broader    :n33405018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederlustadt"@de .
+
+:n23108025  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eckfeld"@de .
+
+:n23208083  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mülbach"@de .
+
+:n14308266  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Molsberg"@de .
+
+:n33511204  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schopp"@de .
+
+:n14004135  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schlierschied"@de .
+
+:n23205028  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Echternacherbrück"@de .
+
+:n334   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Germersheim, Landkreis"@de .
+
+:n34003026  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kröppen"@de .
+
+:n235070010104  a       skos:Concept ;
+        skos:broader    :n23507001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhaus"@de .
+
+:n33510035  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Otterberg, Stadt"@de .
+
+:n23504021  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Farschweiler"@de .
+
+:n13310081  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Raumbach"@de .
+
+:n23501045  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hermeskeil, Stadt"@de .
+
+:n23208062  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ingendorf"@de .
+
+:n14301300  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unnau"@de .
+
+:n23304224  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lirstal"@de .
+
+:n14307018  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freilingen"@de .
+
+:n235081490100  a       skos:Concept ;
+        skos:broader    :n23508149 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bilzingen (Ortsbezirk)"@de .
+
+:n133105010301  a       skos:Concept ;
+        skos:broader    :n13310501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörndich"@de .
+
+:n13709221  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhens, Stadt"@de .
+
+:n33906017  a           skos:Concept ;
+        skos:broader    :n33906 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Essenheim"@de .
+
+:n23201333  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Üttfeld"@de .
+
+:n33106033  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gau-Weinheim"@de .
+
+:n231001340200  a       skos:Concept ;
+        skos:broader    :n23100134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dorf (Ortsbezirk)"@de .
+
+:n14004029  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dill"@de .
+
+:n33502  a              skos:Concept ;
+        skos:broader    :n335 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Enkenbach-Alsenborn, Verbandsgemeinde"@de .
+
+:n14309308  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westerburg, Stadt"@de .
+
+:n23108062  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hupperath"@de .
+
+:n34008207  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dellfeld"@de .
+
+:n23201248  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kickeshausen"@de .
+
+:n315000001200  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weisenau (Ortsbezirk)"@de .
+
+:n140090430100  a       skos:Concept ;
+        skos:broader    :n14009043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedergondershausen"@de .
+
+:n33510014  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirschhorn (Pfalz)"@de .
+
+:n334005010300  a       skos:Concept ;
+        skos:broader    :n33400501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schaidt (Ortsbezirk)"@de .
+
+:n335110470110  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langensohl"@de .
+
+:n13310060  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Löllbach"@de .
+
+:n132080080122  a       skos:Concept ;
+        skos:broader    :n13208008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steckelbach"@de .
+
+:n23205065  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaschenbach"@de .
+
+:n13309059  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Limbach"@de .
+
+:n23304203  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berenbach"@de .
+
+:n233060760300  a       skos:Concept ;
+        skos:broader    :n23306076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederehe (Ortsbezirk)"@de .
+
+:n132070630602  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Düsternseifen"@de .
+
+:n231010080400  a       skos:Concept ;
+        skos:broader    :n23101008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wehlen (Ortsbezirk)"@de .
+
+:n13301030  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Feilbingert"@de .
+
+:n143012060200  a       skos:Concept ;
+        skos:broader    :n14301206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eichenstruth"@de .
+
+:n340092250101  a       skos:Concept ;
+        skos:broader    :n34009225 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seitershof"@de .
+
+:n138020380105  a       skos:Concept ;
+        skos:broader    :n13802038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienburg"@de .
+
+:n134020420201  a       skos:Concept ;
+        skos:broader    :n13402042 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bleiderdingen"@de .
+
+:n23508033  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Greimerath"@de .
+
+:n23101090  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mülheim an der Mosel"@de .
+
+:n132030500100  a       skos:Concept ;
+        skos:broader    :n13203050 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dermbach (Ortsbezirk)"@de .
+
+:n14304079  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welschneudorf"@de .
+
+:n14008126  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Riegenroth"@de .
+
+:n14004151  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Todenroth"@de .
+
+:n23206271  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mützenich"@de .
+
+:n33906054  a           skos:Concept ;
+        skos:broader    :n33906 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sörgenloch"@de .
+
+:n132080080101  a       skos:Concept ;
+        skos:broader    :n13208008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bilgenroth"@de .
+
+:n23208020  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brecht"@de .
+
+:n13309038  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahnenbach"@de .
+
+:n14308203  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arnshöfen"@de .
+
+:n138040680300  a       skos:Concept ;
+        skos:broader    :n13804068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Notscheid"@de .
+
+:n340082210101  a       skos:Concept ;
+        skos:broader    :n34008221 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Riedelbergermühle"@de .
+
+:n23201285  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberpierscheid"@de .
+
+:n131000770601  a       skos:Concept ;
+        skos:broader    :n13100077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beuler Hof"@de .
+
+:n131040590104  a       skos:Concept ;
+        skos:broader    :n13104059 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schelborn"@de .
+
+:n23108503  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Landscheid"@de .
+
+:n138010030300  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schöneberg"@de .
+
+:n231011260103  a       skos:Concept ;
+        skos:broader    :n23101126 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thalveldenz"@de .
+
+:n33405017  a           skos:Concept ;
+        skos:broader    :n33405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lingenfeld"@de .
+
+:n13309096  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Simmertal"@de .
+
+:n14006  a              skos:Concept ;
+        skos:broader    :n140 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Simmern-Rheinböllen, Verbandsgemeinde"@de .
+
+:n13310501  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Sobernheim, Stadt"@de .
+
+:n14004130  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rohrbach"@de .
+
+:n14008099  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mutterschied"@de .
+
+:n13405  a              skos:Concept ;
+        skos:broader    :n134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herrstein-Rhaunen, Verbandsgemeinde"@de .
+
+:n333070280102  a       skos:Concept ;
+        skos:broader    :n33307028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Messersbacherhof"@de .
+
+:n23206250  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinlangenfeld"@de .
+
+:n14301231  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahn bei Marienberg"@de .
+
+:n133061150102  a       skos:Concept ;
+        skos:broader    :n13306115 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kreershäuschen"@de .
+
+:n131015010300  a       skos:Concept ;
+        skos:broader    :n13101501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederadenau (Ortsbezirk)"@de .
+
+:n312000000400  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erfenbach (Ortsbezirk)"@de .
+
+:n132100510101  a       skos:Concept ;
+        skos:broader    :n13210051 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beul"@de .
+
+:n33705009  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birkweiler"@de .
+
+:n233060260202  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedereich"@de .
+
+:n34008223  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rosenkopf"@de .
+
+:n23201264  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Manderscheid"@de .
+
+:n235081540500  a       skos:Concept ;
+        skos:broader    :n23508154 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Portz (Ortsbezirk)"@de .
+
+:n33207027  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hettenleidelheim"@de .
+
+:n140081000101  a       skos:Concept ;
+        skos:broader    :n14008100 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auf dem Schmiedel"@de .
+
+:n13306105  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Traisen"@de .
+
+:n13306099  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spabrücken"@de .
+
+:n133060270103  a       skos:Concept ;
+        skos:broader    :n13306027 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Montforterhof"@de .
+
+:n13210115  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weyerbusch"@de .
+
+:n23205002  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alsdorf"@de .
+
+:n14004024  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büchenbeuren"@de .
+
+:n34008202  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Battweiler"@de .
+
+:n339070240103  a       skos:Concept ;
+        skos:broader    :n33907024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wasserwerk"@de .
+
+:n138000451101  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Monrepos"@de .
+
+:n33207006  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bockenheim an der Weinstraße"@de .
+
+:n232080090101  a       skos:Concept ;
+        skos:broader    :n23208009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Baustertgraben"@de .
+
+:n14109023  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dachsenhausen"@de .
+
+:n235071110300  a       skos:Concept ;
+        skos:broader    :n23507111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kersch (Ortsbezirk)"@de .
+
+:n337070230101  a       skos:Concept ;
+        skos:broader    :n33707023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreihof"@de .
+
+:n13702095  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rüber"@de .
+
+:n135010820208  a       skos:Concept ;
+        skos:broader    :n13501082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maria Engelport, Kloster"@de .
+
+:n138000450500  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heimbach-Weis (Ortsbezirk)"@de .
+
+:n14302267  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mudenbach"@de .
+
+:n13210088  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Orfgen"@de .
+
+:n340040380109  a       skos:Concept ;
+        skos:broader    :n34004038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Imsbachermühle"@de .
+
+:n13707218  a           skos:Concept ;
+        skos:broader    :n13707 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederwerth"@de .
+
+:n13104055  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederzissen"@de .
+
+:n14004082  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lautzenhausen"@de .
+
+:n13101079  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trierscheid"@de .
+
+:n23109120  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Starkenburg"@de .
+
+:n138020240102  a       skos:Concept ;
+        skos:broader    :n13802024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhammerstein"@de .
+
+:n138   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuwied, Landkreis"@de .
+
+:n33107006  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bechtheim"@de .
+
+:n312000002101  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erzhütten"@de .
+
+:n14009205  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morshausen"@de .
+
+:n13210009  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birnbach"@de .
+
+:n33808001  a           skos:Concept ;
+        skos:broader    :n33808 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altrip"@de .
+
+:n132060070101  a       skos:Concept ;
+        skos:broader    :n13206007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kratzhahn"@de .
+
+:n33405033  a           skos:Concept ;
+        skos:broader    :n33405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westheim (Pfalz)"@de .
+
+:n232063040200  a       skos:Concept ;
+        skos:broader    :n23206304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wetteldorf"@de .
+
+:n231011330108  a       skos:Concept ;
+        skos:broader    :n23101133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rondel"@de .
+
+:n231080800105  a       skos:Concept ;
+        skos:broader    :n23108080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kapellenhof"@de .
+
+:n132100480101  a       skos:Concept ;
+        skos:broader    :n13210048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eng"@de .
+
+:n38    a               skos:Concept ;
+        skos:broader    :n3 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katholische Kirche / Diözese Trier"@de .
+
+:n232085010100  a       skos:Concept ;
+        skos:broader    :n23208501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hermesdorf (Ortsbezirk)"@de .
+
+:n13210067  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mammelzen"@de .
+
+:n33702049  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klingenmünster"@de .
+
+:n23506115  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Riol"@de .
+
+:n13101058  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nürburg"@de .
+
+:n335080300102  a       skos:Concept ;
+        skos:broader    :n33508030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchmohr"@de .
+
+:n23106123  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thalfang"@de .
+
+:n33306  a              skos:Concept ;
+        skos:broader    :n333 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winnweiler, Verbandsgemeinde"@de .
+
+:n335080440100  a       skos:Concept ;
+        skos:broader    :n33508044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obermohr"@de .
+
+:n33511045  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stelzenberg"@de .
+
+:n138040680210  a       skos:Concept ;
+        skos:broader    :n13804068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinshardt"@de .
+
+:n23109014  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg (Mosel)"@de .
+
+:n14302310  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wied"@de .
+
+:n23201201  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arzfeld"@de .
+
+:n14304053  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederelbert"@de .
+
+:n231010700700  a       skos:Concept ;
+        skos:broader    :n23101070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pilmeroth (Ortsbezirk)"@de .
+
+:n231085030102  a       skos:Concept ;
+        skos:broader    :n23108503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heeg"@de .
+
+:n14008100  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nannhausen"@de .
+
+:n335010030200  a       skos:Concept ;
+        skos:broader    :n33501003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buchholz"@de .
+
+:n17    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nordpfälzer Bergland"@de .
+
+:n13702053  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kollig"@de .
+
+:n14103029  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Diez,Stadt"@de .
+
+:n138090710300  a       skos:Concept ;
+        skos:broader    :n13809071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhonnefeld"@de .
+
+:n13306036  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gutenberg"@de .
+
+:n14302225  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Giesenhausen"@de .
+
+:n132100620104  a       skos:Concept ;
+        skos:broader    :n13210062 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuenhof"@de .
+
+:n13210046  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hasselbach"@de .
+
+:n13501029  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Faid"@de .
+
+:n14004040  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gehlweiler"@de .
+
+:n14008015  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biebern"@de .
+
+:n13101037  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaltenborn"@de .
+
+:n23109072  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kröv"@de .
+
+:n137082160205  a       skos:Concept ;
+        skos:broader    :n13708216 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Urmitz-Bahnhof"@de .
+
+:n34009217  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maßweiler"@de .
+
+:n34001039  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rumbach"@de .
+
+:n231090570107  a       skos:Concept ;
+        skos:broader    :n23109057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krinkhof (Ortsbezirk)"@de .
+
+:n23106017  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burtscheid"@de .
+
+:n13306100  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spall"@de .
+
+:n143040480500  a       skos:Concept ;
+        skos:broader    :n14304048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horressen (Ortsbezirk)"@de .
+
+:n13210110  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Volkerzen"@de .
+
+:n141111250101  a       skos:Concept ;
+        skos:broader    :n14111125 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zollhaus"@de .
+
+:n143030320107  a       skos:Concept ;
+        skos:broader    :n14303032 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höhr"@de .
+
+:n33306069  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweisweiler"@de .
+
+:n138040680104  a       skos:Concept ;
+        skos:broader    :n13804068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Noll"@de .
+
+:n13306015  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Braunweiler"@de .
+
+:n131020270108  a       skos:Concept ;
+        skos:broader    :n13102027 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberheckenbach"@de .
+
+:n14302204  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Astert"@de .
+
+:n138090070114  a       skos:Concept ;
+        skos:broader    :n13809007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Solscheid"@de .
+
+:n333065030101  a       skos:Concept ;
+        skos:broader    :n33306503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bahnhof Langmeil"@de .
+
+:n23506067  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Köwerich"@de .
+
+:n138040090107  a       skos:Concept ;
+        skos:broader    :n13804009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallen"@de .
+
+:n235081040600  a       skos:Concept ;
+        skos:broader    :n23508104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wehr (Ortsbezirk)"@de .
+
+:n13804055  a           skos:Concept ;
+        skos:broader    :n13804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ockenfels"@de .
+
+:n336090920100  a       skos:Concept ;
+        skos:broader    :n33609092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kübelberg"@de .
+
+:n33207001  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altleiningen"@de .
+
+:n23301068  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steiningen"@de .
+
+:n14109501  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Braubach, Stadt"@de .
+
+:n137092050106  a       skos:Concept ;
+        skos:broader    :n13709205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jahrsbergerhöfe"@de .
+
+:n13209  a              skos:Concept ;
+        skos:broader    :n132 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Betzdorf-Gebhardshain, Verbandsgemeinde"@de .
+
+:n33907064  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weinolsheim"@de .
+
+:n334050330101  a       skos:Concept ;
+        skos:broader    :n33405033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holzmühle"@de .
+
+:n54    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Staat Nassau"@de .
+
+:n138070730104  a       skos:Concept ;
+        skos:broader    :n13807073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hohenunkel, Hof u.Erhh."@de .
+
+:n135010820203  a       skos:Concept ;
+        skos:broader    :n13501082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gotteshäuserhof"@de .
+
+:n14309213  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brandscheid"@de .
+
+:n14306237  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hellenhahn-Schellenberg"@de .
+
+:n14302262  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merkelbach"@de .
+
+:n232062020401  a       skos:Concept ;
+        skos:broader    :n23206202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Verschneid"@de .
+
+:n13210083  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberlahr"@de .
+
+:n138010800305  a       skos:Concept ;
+        skos:broader    :n13801080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kölsch-Büllesbach"@de .
+
+:n13401008  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berschweiler bei Baumholder"@de .
+
+:n13501066  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Müden (Mosel)"@de .
+
+:n33306048  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münchweiler an der Alsenz"@de .
+
+:n339010030107  a       skos:Concept ;
+        skos:broader    :n33901003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Medenscheid (Ortsbezirk)"@de .
+
+:n13101074  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schuld"@de .
+
+:n133090410200  a       skos:Concept ;
+        skos:broader    :n13309041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krebsweiler"@de .
+
+:n133   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Kreuznach, Landkreis"@de .
+
+:n13210004  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bachenberg"@de .
+
+:n14107105  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwallmenach"@de .
+
+:n14103130  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinsberg"@de .
+
+:n14306295  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stein-Neukirch"@de .
+
+:n23106054  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hilscheid"@de .
+
+:n131020290200  a       skos:Concept ;
+        skos:broader    :n13102029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Liers"@de .
+
+:n231080800100  a       skos:Concept ;
+        skos:broader    :n23108080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Manderscheid"@de .
+
+:n137030060101  a       skos:Concept ;
+        skos:broader    :n13703006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Netterhöfe"@de .
+
+:n143022020101  a       skos:Concept ;
+        skos:broader    :n14302202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dehlingen"@de .
+
+:n14305068  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sessenbach"@de .
+
+:n133105010100  a       skos:Concept ;
+        skos:broader    :n13310501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eckweiler"@de .
+
+:n33907043  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nierstein, Stadt"@de .
+
+:n14103045  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geilnau"@de .
+
+:n13203018  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daaden, Stadt"@de .
+
+:n14302241  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höchstenbach"@de .
+
+:n14111088  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelfischbach"@de .
+
+:n13210062  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kircheib"@de .
+
+:n231081130100  a       skos:Concept ;
+        skos:broader    :n23108113 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörbach"@de .
+
+:n33306027  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gonbach"@de .
+
+:n336080430101  a       skos:Concept ;
+        skos:broader    :n33608043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sulzhof"@de .
+
+:n137000030401  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nettehammer"@de .
+
+:n33608029  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ginsweiler"@de .
+
+:n34004031  a           skos:Concept ;
+        skos:broader    :n34004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merzalben"@de .
+
+:n132060910104  a       skos:Concept ;
+        skos:broader    :n13206091 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhausen"@de .
+
+:n311000000300  a       skos:Concept ;
+        skos:broader    :n31100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flomersheim (Ortsbezirk)"@de .
+
+:n131000700400  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oedingen (Ortsbezirk 4)"@de .
+
+:n132100970105  a       skos:Concept ;
+        skos:broader    :n13210097 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaffroth"@de .
+
+:n91    a               skos:Concept ;
+        skos:broader    :n5 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saar-Lor-Lux"@de .
+
+:n14107078  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lautert"@de .
+
+:n141101280101  a       skos:Concept ;
+        skos:broader    :n14110128 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arnstein, Kloster"@de .
+
+:n14306274  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederroßbach"@de .
+
+:n231081030100  a       skos:Concept ;
+        skos:broader    :n23108103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Monzel"@de .
+
+:n138050580101  a       skos:Concept ;
+        skos:broader    :n13805058 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brubbach"@de .
+
+:n12    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinhessisches Hügelland"@de .
+
+:n111000000700  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horchheim"@de .
+
+:n33608087  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rothselberg"@de .
+
+:n339000050400  a       skos:Concept ;
+        skos:broader    :n33900005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dietersheim"@de .
+
+:n13210041  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Giershausen"@de .
+
+:n13501024  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ediger-Eller"@de .
+
+:n14309  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westerburg, Verbandsgemeinde"@de .
+
+:n23506083  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mehring"@de .
+
+:n13101032  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Honerath"@de .
+
+:n336080950100  a       skos:Concept ;
+        skos:broader    :n33608095 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eschenau"@de .
+
+:n13310  a              skos:Concept ;
+        skos:broader    :n133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nahe-Glan, Verbandsgemeinde"@de .
+
+:n340010290101  a       skos:Concept ;
+        skos:broader    :n34001029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reißlerhof"@de .
+
+:n137082160200  a       skos:Concept ;
+        skos:broader    :n13708216 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mülheim"@de .
+
+:n138010440205  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dinkelbach (ehemals Gemeinde Elsaff)"@de .
+
+:n34001034  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nothweiler"@de .
+
+:n33101007  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bechtolsheim"@de .
+
+:n23301084  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winkel (Eifel)"@de .
+
+:n13708  a              skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weißenthurm, Verbandsgemeinde"@de .
+
+:n23506004  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bekond"@de .
+
+:n70    a               skos:Concept ;
+        skos:broader    :n5 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saarland"@de .
+
+:n33403009  a           skos:Concept ;
+        skos:broader    :n33403 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hatzenbühl"@de .
+
+:n333075020200  a       skos:Concept ;
+        skos:broader    :n33307502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienthal (Ortsbezirk)"@de .
+
+:n13501082  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Treis-Karden"@de .
+
+:n13708228  a           skos:Concept ;
+        skos:broader    :n13708 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weißenthurm, Stadt"@de .
+
+:n13209098  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scheuerfeld"@de .
+
+:n33610066  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neunkirchen am Potzberg"@de .
+
+:n320000000400  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hengstbach"@de .
+
+:n131000770400  a       skos:Concept ;
+        skos:broader    :n13100077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Löhndorf (Ortsbezirk)"@de .
+
+:n33502205  a           skos:Concept ;
+        skos:broader    :n33502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sembach"@de .
+
+:n4653560n3  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ahreifel"@de .
+
+:n140005010202  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buchenau"@de .
+
+:n333070670101  a       skos:Concept ;
+        skos:broader    :n33307067 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sulzhof"@de .
+
+:n14305084  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wittgert"@de .
+
+:n23301063  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schalkenmehren"@de .
+
+:n135010200114  a       skos:Concept ;
+        skos:broader    :n13501020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sehl"@de .
+
+:n143023010103  a       skos:Concept ;
+        skos:broader    :n14302301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marzauer Mühle"@de .
+
+:n14103061  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holzheim"@de .
+
+:n137000680500  a       skos:Concept ;
+        skos:broader    :n13700068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nitztal (Ortsbezirk)"@de .
+
+:n33702060  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberschlettenbach"@de .
+
+:n138010800300  a       skos:Concept ;
+        skos:broader    :n13801080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krautscheid"@de .
+
+:n13102068  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rech"@de .
+
+:n33608045  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hoppstädten"@de .
+
+:n33101044  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mauchenheim"@de .
+
+:n232000180600  a       skos:Concept ;
+        skos:broader    :n23200018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mötsch (Ortsbezirk)"@de .
+
+:n13311056  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laubenheim"@de .
+
+:n14107100  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberbachheim"@de .
+
+:n14107094  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederbachheim"@de .
+
+:n111000001800  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfaffendorf"@de .
+
+:n231010410101  a       skos:Concept ;
+        skos:broader    :n23101041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Graacher Schäferei"@de .
+
+:n134020580102  a       skos:Concept ;
+        skos:broader    :n13402058 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burbach"@de .
+
+:n233060350103  a       skos:Concept ;
+        skos:broader    :n23306035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Glaadt"@de .
+
+:n137025010100  a       skos:Concept ;
+        skos:broader    :n13702501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Keldung (Ortsbezirk)"@de .
+
+:n23301042  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mehren"@de .
+
+:n337030280101  a       skos:Concept ;
+        skos:broader    :n33703028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hainbachtal, Papiermühle"@de .
+
+:n14009110  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Norath"@de .
+
+:n335020040200  a       skos:Concept ;
+        skos:broader    :n33502004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Enkenbach"@de .
+
+:n13703063  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lind"@de .
+
+:n14107015  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bogel"@de .
+
+:n340082080103  a       skos:Concept ;
+        skos:broader    :n34008208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirschbachermühle"@de .
+
+:n13102047  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lind"@de .
+
+:n14009025  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Damscheid"@de .
+
+:n140032020200  a       skos:Concept ;
+        skos:broader    :n14003202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dorweiler (Ortsbezirk)"@de .
+
+:n33901007  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitscheid"@de .
+
+:n33610024  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Etschberg"@de .
+
+:n34002049  a           skos:Concept ;
+        skos:broader    :n34002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spirkelbach"@de .
+
+:n317000000700  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winzeln (Ortsbezirk)"@de .
+
+:n13311035  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Guldental"@de .
+
+:n132081170419  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Widderbach"@de .
+
+:n14308501  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elbingen"@de .
+
+:n23306223  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kopp"@de .
+
+:n141000750210  a       skos:Concept ;
+        skos:broader    :n14100075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Friedland"@de .
+
+:n23301021  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellscheid"@de .
+
+:n13505073  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pünderich"@de .
+
+:n33307079  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldgrehweiler"@de .
+
+:n33306080  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wartenberg-Rohrbach"@de .
+
+:n33609  a              skos:Concept ;
+        skos:broader    :n336 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberes Glantal, Verbandsgemeinde"@de .
+
+:n133000060601  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Münster am Stein"@de .
+
+:n23207006  a           skos:Concept ;
+        skos:broader    :n23207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auw an der Kyll"@de .
+
+:n211000000501  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herresthal"@de .
+
+:n335100340200  a       skos:Concept ;
+        skos:broader    :n33510034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sambach (Ortsbezirk)"@de .
+
+:n13311093  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweppenhausen"@de .
+
+:n23504107  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pluwig"@de .
+
+:n132070370168  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wildenburg"@de .
+
+:n14304  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Montabaur, Verbandsgemeinde"@de .
+
+:n33610003  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenglan"@de .
+
+:n13703  a              skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vordereifel, Verbandsgemeinde"@de .
+
+:n235040900104  a       skos:Concept ;
+        skos:broader    :n23504090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloß Marienlay"@de .
+
+:n13203050  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herdorf, Stadt"@de .
+
+:n232013330404  a       skos:Concept ;
+        skos:broader    :n23201333 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spielmannsholz"@de .
+
+:n233060260500  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinterhausen (Ortsbezirk)"@de .
+
+:n13402018  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dambach"@de .
+
+:n33901044  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberdiebach"@de .
+
+:n33105  a              skos:Concept ;
+        skos:broader    :n331 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wöllstein, Verbandsgemeinde"@de .
+
+:n33608061  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Medard"@de .
+
+:n34009037  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Petersberg"@de .
+
+:n33105035  a           skos:Concept ;
+        skos:broader    :n33105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gumbsheim"@de .
+
+:n231005020300  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gonzerath (Ortsbezirk)"@de .
+
+:n337015010400  a       skos:Concept ;
+        skos:broader    :n33701501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Queichhambach (Ortsbezirk)"@de .
+
+:n13206038  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fürthen"@de .
+
+:n132070370147  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberweidenbruch"@de .
+
+:n233010630106  a       skos:Concept ;
+        skos:broader    :n23301063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Observatorium Hoher List"@de .
+
+:n33205014  a           skos:Concept ;
+        skos:broader    :n33205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elmstein"@de .
+
+:n135010250102  a       skos:Concept ;
+        skos:broader    :n13501025 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Poltersdorf"@de .
+
+:n319000000300  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heppenheim (Ortsbezirk)"@de .
+
+:n13206102  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seelbach bei Hamm (Sieg)"@de .
+
+:n33307037  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katzenbach"@de .
+
+:n23508119  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schillingen"@de .
+
+:n13708202  a           skos:Concept ;
+        skos:broader    :n13708 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bassenheim"@de .
+
+:n13206096  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roth"@de .
+
+:n23108127  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallscheid"@de .
+
+:n134000450700  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelbollenbach"@de .
+
+:n33608040  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herren-Sulzbach"@de .
+
+:n33102038  a           skos:Concept ;
+        skos:broader    :n33102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hamm am Rhein"@de .
+
+:n14111020  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burgschwalbach"@de .
+
+:n23207  a              skos:Concept ;
+        skos:broader    :n232 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Speicher, Verbandsgemeinde"@de .
+
+:n340060120101  a       skos:Concept ;
+        skos:broader    :n34006012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhof"@de .
+
+:n14003153  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Uhler"@de .
+
+:n134020200101  a       skos:Concept ;
+        skos:broader    :n13402020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eborn"@de .
+
+:n232081370102  a       skos:Concept ;
+        skos:broader    :n23208137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolsfelderberg"@de .
+
+:n33105072  a           skos:Concept ;
+        skos:broader    :n33105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wöllstein"@de .
+
+<https://rpb.lobid.org/spatial>
+        a                              skos:ConceptScheme ;
+        dct:description                "This controlled vocabulary for areas in Rineland-Palatinate was created for use in the Bibliography of Rhineland (RPB)." ;
+        dct:issued                     "2022-08-26" ;
+        dct:license                    <http://creativecommons.org/publicdomain/zero/1.0/> ;
+        dct:modified                   "2022-10-21" ;
+        dct:publisher                  <http://lobid.org/organisations/DE-605> ;
+        dct:title                      "Spatial classification scheme for the Bibiography of Rhineland-Palatinate"@en , "Raumsystematik der Rheinland-Pfälzischen Bibliographie"@de ;
+        vann:preferredNamespacePrefix  "rpb-spatial" ;
+        vann:preferredNamespaceUri     "https://rpb.lobid.org/spatial#" ;
+        skos:hasTopConcept             :n4 , :n5 , :n2 , :n3 , :n1 , :n6 .
+
+:n13505010  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Blankenrath"@de .
+
+:n336090960100  a       skos:Concept ;
+        skos:broader    :n33609096 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frutzweiler"@de .
+
+:n33307016  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörrmoschel"@de .
+
+:n33303041  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lautersheim"@de .
+
+:n13700003  a           skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Andernach, große kreisangehörige Stadt"@de .
+
+:n232081130104  a       skos:Concept ;
+        skos:broader    :n23208113 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "St.Johann"@de .
+
+:n132081170414  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pirzenthal"@de .
+
+:n23504038  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gutweiler"@de .
+
+:n131000070500  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchdaun (Ortsbezirk)"@de .
+
+:n134020100101  a       skos:Concept ;
+        skos:broader    :n13402010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burgbirkenfeld"@de .
+
+:n23208079  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Messerich"@de .
+
+:n231005021400  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Odert (Ortsbezirk)"@de .
+
+:n335090490105  a       skos:Concept ;
+        skos:broader    :n33509049 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schellenbergerhof"@de .
+
+:n13402034  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hattgenstein"@de .
+
+:n132090240102  a       skos:Concept ;
+        skos:broader    :n13209024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiselstein"@de .
+
+:n131000900500  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holzweiler (Ortsbezirk)"@de .
+
+:n33609076  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ohmbach"@de .
+
+:n231090050105  a       skos:Concept ;
+        skos:broader    :n23109005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Springiersbach"@de .
+
+:n319000001400  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weinsheim (Ortsbezirk)"@de .
+
+:n13209030  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fensdorf"@de .
+
+:n333040450103  a       skos:Concept ;
+        skos:broader    :n33304045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Froschauerhof"@de .
+
+:n6     a               skos:Concept ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Einzelne Landkreise, Verbandsgemeinden, Orte und Ortsteile"@de .
+
+:n338000040101  a       skos:Concept ;
+        skos:broader    :n33800004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Am Binnendamm"@de .
+
+:n23208058  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hüttingen an der Kyll"@de .
+
+:n143022290201  a       skos:Concept ;
+        skos:broader    :n14302229 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hof Kleeberg"@de .
+
+:n33307053  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhausen an der Appel"@de .
+
+:n13709217  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederfell"@de .
+
+:n337050090103  a       skos:Concept ;
+        skos:broader    :n33705009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herrenbergerhof"@de .
+
+:n340092190103  a       skos:Concept ;
+        skos:broader    :n34009219 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obernheim"@de .
+
+:n33105030  a           skos:Concept ;
+        skos:broader    :n33105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gau-Bickelheim"@de .
+
+:n33106029  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gabsheim"@de .
+
+:n336080230103  a       skos:Concept ;
+        skos:broader    :n33608023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schneeweiderhof"@de .
+
+:n137000030200  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eich (Ortsbezirk)"@de .
+
+:n23507051  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Igel"@de .
+
+:n14109109  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Patersberg"@de .
+
+:n13802063  a           skos:Concept ;
+        skos:broader    :n13802 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinbrohl"@de .
+
+:n233010630101  a       skos:Concept ;
+        skos:broader    :n23301063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altburg"@de .
+
+:n13402071  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rinzenberg"@de .
+
+:n336080850102  a       skos:Concept ;
+        skos:broader    :n33608085 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ingweilerhof"@de .
+
+:n111000001100  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lay (Ortsbezirk 6)"@de .
+
+:n23109206  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lötzbeuren"@de .
+
+:n23206288  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Olzheim"@de .
+
+:n132070630200  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herkersdorf (Ortsbezirk)"@de .
+
+:n14307221  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ewighausen"@de .
+
+:n333070540101  a       skos:Concept ;
+        skos:broader    :n33307054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kahlforsterhof"@de .
+
+:n33304056  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwiesen"@de .
+
+:n13206091  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pracht"@de .
+
+:n23206209  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büdesheim"@de .
+
+:n13309204  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schneppenbach"@de .
+
+:n13405059  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhosenbach"@de .
+
+:n143063110101  a       skos:Concept ;
+        skos:broader    :n14306311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fuchskauten"@de .
+
+:n138010770104  a       skos:Concept ;
+        skos:broader    :n13801077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hallerbach"@de .
+
+:n132081050101  a       skos:Concept ;
+        skos:broader    :n13208105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brunken"@de .
+
+:n13104205  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Glees"@de .
+
+:n232050880101  a       skos:Concept ;
+        skos:broader    :n23205088 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daudistel"@de .
+
+:n23208101  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Orsfeld"@de .
+
+:n23108037  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gladbach"@de .
+
+:n23101086  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Minheim"@de .
+
+:n312000000502  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gersweilerhof"@de .
+
+:n13402050  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leisel"@de .
+
+:n316000000600  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haardt (Ortsbezirk)"@de .
+
+:n132100320101  a       skos:Concept ;
+        skos:broader    :n13210032 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ahlbach"@de .
+
+:n339070250103  a       skos:Concept ;
+        skos:broader    :n33907025 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wahlheimerhof"@de .
+
+:n14301248  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirburg"@de .
+
+:n143012770200  a       skos:Concept ;
+        skos:broader    :n14301277 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfuhl"@de .
+
+:n33609092  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönenberg-Kübelberg"@de .
+
+:n141030640300  a       skos:Concept ;
+        skos:broader    :n14103064 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruppenrod"@de .
+
+:n33200002  a           skos:Concept ;
+        skos:broader    :n332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Dürkheim, Stadt"@de .
+
+:n33304035  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jakobsweiler"@de .
+
+:n131010330203  a       skos:Concept ;
+        skos:broader    :n13101033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hümmeler Mühle"@de .
+
+:n23108101  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberscheidweiler"@de .
+
+:n23108095  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederöfflingen"@de .
+
+:n33502004  a           skos:Concept ;
+        skos:broader    :n33502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Enkenbach-Alsenborn"@de .
+
+:n13405038  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herborn"@de .
+
+:n320000000114  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tschifflick"@de .
+
+:n23208074  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ließem"@de .
+
+:n23304236  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sassen"@de .
+
+:n132100700102  a       skos:Concept ;
+        skos:broader    :n13210070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Widderstein"@de .
+
+:n33707061  a           skos:Concept ;
+        skos:broader    :n33707 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Offenbach an der Queich"@de .
+
+:n141110510102  a       skos:Concept ;
+        skos:broader    :n14111051 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zollhaus"@de .
+
+:n23205019  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bollendorf"@de .
+
+:n14301227  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großseifen"@de .
+
+:n138090650104  a       skos:Concept ;
+        skos:broader    :n13809065 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reifert"@de .
+
+:n111000002200  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallersheim"@de .
+
+:n14003042  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gödenroth"@de .
+
+:n23108074  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laufeld"@de .
+
+:n13405017  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bundenbach"@de .
+
+:n132100600102  a       skos:Concept ;
+        skos:broader    :n13210060 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Püscheid"@de .
+
+:n1     a               skos:Concept ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinland-Pfalz insgesamt. Landesteile"@de .
+
+:n335110470122  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wilensteinermühle"@de .
+
+:n140030090600  a       skos:Concept ;
+        skos:broader    :n14003009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wohnroth (Ortsbezirk)"@de .
+
+:n13310072  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nußbaum"@de .
+
+:n23501036  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gusenburg"@de .
+
+:n23304215  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höchstberg"@de .
+
+:n143082030101  a       skos:Concept ;
+        skos:broader    :n14308203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Etzelbach"@de .
+
+:n14004105  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nieder Kostenz"@de .
+
+:n13709212  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kobern-Gondorf"@de .
+
+:n131020490104  a       skos:Concept ;
+        skos:broader    :n13102049 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lochmühle"@de .
+
+:n14301206  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Marienberg (Westerwald), Stadt"@de .
+
+:n4076027n3  a          skos:Concept ;
+        skos:broader    :n16 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfälzer Gebrüch"@de .
+
+:n340090350104  a       skos:Concept ;
+        skos:broader    :n34009035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Huberhof"@de .
+
+:n333030170107  a       skos:Concept ;
+        skos:broader    :n33303017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münsterhof"@de .
+
+:n340010110200  a       skos:Concept ;
+        skos:broader    :n34001011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Petersbächel (Ortsbezirk)"@de .
+
+:n333060330103  a       skos:Concept ;
+        skos:broader    :n33306033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Röderhof"@de .
+
+:n14003504  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zilshausen"@de .
+
+:n135020160102  a       skos:Concept ;
+        skos:broader    :n13502016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Einigsmühle"@de .
+
+:n33103048  a           skos:Concept ;
+        skos:broader    :n33103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Monsheim"@de .
+
+:n14003021  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buch"@de .
+
+:n23504070  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Korlingen"@de .
+
+:n23108053  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hetzerath"@de .
+
+:n34009  a              skos:Concept ;
+        skos:broader    :n340 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thaleischweiler-Wallhalben, Verbandsgemeinde"@de .
+
+:n14307067  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Selters (Westerwald), Stadt"@de .
+
+:n134050920101  a       skos:Concept ;
+        skos:broader    :n13405092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weitersbacher Hütte"@de .
+
+:n23306022  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Esch"@de .
+
+:n14004163  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Womrath"@de .
+
+:n14008138  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schnorbach"@de .
+
+:n335110470101  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Antonihof"@de .
+
+:n133000060400  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Planig (Ortsbezirk)"@de .
+
+:n13310051  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jeckenbach"@de .
+
+:n23206283  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberlascheid"@de .
+
+:n23208032  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Enzen"@de .
+
+:n340030520102  a       skos:Concept ;
+        skos:broader    :n34003052 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochstellerhof (Ortsbezirk)"@de .
+
+:n23205056  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hütten"@de .
+
+:n14301264  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörlen"@de .
+
+:n140030100300  a       skos:Concept ;
+        skos:broader    :n14003010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heyweiler (Ortsbezirk)"@de .
+
+:n211000000300  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrang (Ortsbezirk 4)"@de .
+
+:n33701067  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rinnthal"@de .
+
+:n132100530104  a       skos:Concept ;
+        skos:broader    :n13210053 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maulsbach"@de .
+
+:n140005010500  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirzenach (Ortsbezirk)"@de .
+
+:n14103  a              skos:Concept ;
+        skos:broader    :n141 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Diez, Verbandsgemeinde"@de .
+
+:n23201297  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reiff"@de .
+
+:n141111260101  a       skos:Concept ;
+        skos:broader    :n14111126 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Apfelhof Bärbach"@de .
+
+:n231085030204  a       skos:Concept ;
+        skos:broader    :n23108503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Raskop"@de .
+
+:n23306080  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Walsdorf"@de .
+
+:n235081230102  a       skos:Concept ;
+        skos:broader    :n23508123 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kimmlerhof"@de .
+
+:n13502  a              skos:Concept ;
+        skos:broader    :n135 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaisersesch, Verbandsgemeinde"@de .
+
+:n33404030  a           skos:Concept ;
+        skos:broader    :n33404 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinweiler"@de .
+
+:n23101081  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maring-Noviand"@de .
+
+:n232081200104  a       skos:Concept ;
+        skos:broader    :n23208120 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waxbrunnen"@de .
+
+:n14308273  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederahr"@de .
+
+:n14307046  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maxsain"@de .
+
+:n235070510103  a       skos:Concept ;
+        skos:broader    :n23507051 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Löwener Mühle"@de .
+
+:n133110870101  a       skos:Concept ;
+        skos:broader    :n13311087 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Layen"@de .
+
+:n23106204  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heidenburg"@de .
+
+:n14301243  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hof"@de .
+
+:n233042180400  a       skos:Concept ;
+        skos:broader    :n23304218 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rothenbach-Meisenthal (Ortsbezirk)"@de .
+
+:n33106061  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spiesheim"@de .
+
+:n231091240200  a       skos:Concept ;
+        skos:broader    :n23109124 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Traben-Trarbach"@de .
+
+:n23508082  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mannebach"@de .
+
+:n33510042  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schneckenhausen"@de .
+
+:n14302306  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welkenbach"@de .
+
+:n131040540102  a       skos:Concept ;
+        skos:broader    :n13104054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lochmühle"@de .
+
+:n23508003  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Baldringen"@de .
+
+:n314000000300  a       skos:Concept ;
+        skos:broader    :n31400000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maudach (Ortsbezirk)"@de .
+
+:n13306117  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rüdesheim"@de .
+
+:n235010470100  a       skos:Concept ;
+        skos:broader    :n23501047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinzert"@de .
+
+:n23205093  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederweis"@de .
+
+:n137040690200  a       skos:Concept ;
+        skos:broader    :n13704069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obermendig"@de .
+
+:n14307025  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hartenfels"@de .
+
+:n138010030206  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sessenhausen"@de .
+
+:n336100090200  a       skos:Concept ;
+        skos:broader    :n33610009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Friedelhausen (Ortsbezirk)"@de .
+
+:n332000240300  a       skos:Concept ;
+        skos:broader    :n33200024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sausenheim (Ortsbezirk)"@de .
+
+:n334040300101  a       skos:Concept ;
+        skos:broader    :n33404030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Archenweyermühle"@de .
+
+:n137030070101  a       skos:Concept ;
+        skos:broader    :n13703007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büchel"@de .
+
+:n134000451100  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weierbach"@de .
+
+:n33903048  a           skos:Concept ;
+        skos:broader    :n33903 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ockenheim"@de .
+
+:n336100240101  a       skos:Concept ;
+        skos:broader    :n33610024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gehöft Hub, Leidsthalerhube"@de .
+
+:n13405091  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiden"@de .
+
+:n13309008  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bärenbach"@de .
+
+:n14301222  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fehl-Ritzhausen"@de .
+
+:n33107039  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hangen-Weisheim"@de .
+
+:n235041070104  a       skos:Concept ;
+        skos:broader    :n23504107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Willmerich"@de .
+
+:n13503002  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alflen"@de .
+
+:n143040200102  a       skos:Concept ;
+        skos:broader    :n14304020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchähr"@de .
+
+:n13405012  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bollenbach"@de .
+
+:n211000001400  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Olewig (Ortsbezirk 11)"@de .
+
+:n23201255  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lascheid"@de .
+
+:n23109068  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kinheim"@de .
+
+:n34008214  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinsteinhausen"@de .
+
+:n337020490104  a       skos:Concept ;
+        skos:broader    :n33702049 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Magdalenenhof"@de .
+
+:n336080440101  a       skos:Concept ;
+        skos:broader    :n33608044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönbornerhof"@de .
+
+:n33907  a              skos:Concept ;
+        skos:broader    :n339 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Selz, Verbandsgemeinde"@de .
+
+:n131000900803  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oeverich"@de .
+
+:n14301280  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Norken"@de .
+
+:n235   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trier-Saarburg, Landkreis"@de .
+
+:n23205072  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lahr"@de .
+
+:n140091020101  a       skos:Concept ;
+        skos:broader    :n14009102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dieler"@de .
+
+:n23304210  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Drees"@de .
+
+:n13210106  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sörth"@de .
+
+:n33701083  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wernersberg"@de .
+
+:n235060780101  a       skos:Concept ;
+        skos:broader    :n23506078 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirsch"@de .
+
+:n14004094  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Metzenhausen"@de .
+
+:n23109132  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Willwerscheid"@de .
+
+:n233062400205  a       skos:Concept ;
+        skos:broader    :n23306240 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederkyll"@de .
+
+:n133060700102  a       skos:Concept ;
+        skos:broader    :n13306070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehemalige Weinbaudomäne"@de .
+
+:n00Sn02m0557a  a       skos:Concept ;
+        skos:broader    :n19 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Viertäler"@de .
+
+:n133105010202  a       skos:Concept ;
+        skos:broader    :n13310501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Entenpfuhl mit Martinshof"@de .
+
+:n14309288  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rotenhain"@de .
+
+:n23508040  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heddert"@de .
+
+:n132081170213  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weidacker"@de .
+
+:n233060380200  a       skos:Concept ;
+        skos:broader    :n23306038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Loogh (Ortsbezirk)"@de .
+
+:n143013000200  a       skos:Concept ;
+        skos:broader    :n14301300 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stangenrod"@de .
+
+:n132080800109  a       skos:Concept ;
+        skos:broader    :n13208080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elkhausen"@de .
+
+:n332050160101  a       skos:Concept ;
+        skos:broader    :n33205016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitenstein"@de .
+
+:n23201234  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Harspelt"@de .
+
+:n34004  a              skos:Concept ;
+        skos:broader    :n340 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodalben, Verbandsgemeinde"@de .
+
+:n137030490100  a       skos:Concept ;
+        skos:broader    :n13703049 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchesch"@de .
+
+:n340030280106  a       skos:Concept ;
+        skos:broader    :n34003028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langmühle (Ortsbezirk)"@de .
+
+:n137020410102  a       skos:Concept ;
+        skos:broader    :n13702041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heidgermühle"@de .
+
+:n13702086  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ochtendung"@de .
+
+:n33403  a              skos:Concept ;
+        skos:broader    :n334 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jockgrim, Verbandsgemeinde"@de .
+
+:n14309209  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berzhahn"@de .
+
+:n14308210  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bilkheim"@de .
+
+:n14302258  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Linden"@de .
+
+:n335112040102  a       skos:Concept ;
+        skos:broader    :n33511204 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pulvermühle"@de .
+
+:n137030110104  a       skos:Concept ;
+        skos:broader    :n13703011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fensterseifen"@de .
+
+:n315000000500  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Finthen (Ortsbezirk)"@de .
+
+:n14110027  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dienethal"@de .
+
+:n233060760201  a       skos:Concept ;
+        skos:broader    :n23306076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flesten"@de .
+
+:n14109072  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kestert"@de .
+
+:n23201213  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daleiden"@de .
+
+:n13803031  a           skos:Concept ;
+        skos:broader    :n13803 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Isenburg"@de .
+
+:n14307041  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krümmel"@de .
+
+:n14304065  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruppach-Goldhausen"@de .
+
+:n133100110300  a       skos:Concept ;
+        skos:broader    :n13310011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roth"@de .
+
+:n331000030400  a       skos:Concept ;
+        skos:broader    :n33100003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schafhausen (Ortsbezirk)"@de .
+
+:n13702065  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lonnig"@de .
+
+:n13503501  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Bertrich"@de .
+
+:n13306048  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hüffelsheim"@de .
+
+:n33107055  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Osthofen, Stadt"@de .
+
+:n131010440201  a       skos:Concept ;
+        skos:broader    :n13101044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birnbachsmühle"@de .
+
+:n13210058  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Isert"@de .
+
+:n4678434n2  a          skos:Concept ;
+        skos:broader    :n19 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lützelsoon"@de .
+
+:n14008027  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dichtelbach"@de .
+
+:n33900009  a           skos:Concept ;
+        skos:broader    :n339 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Budenheim"@de .
+
+:n34004027  a           skos:Concept ;
+        skos:broader    :n34004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leimen"@de .
+
+:n14110006  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Ems, Stadt"@de .
+
+:n33402027  a           skos:Concept ;
+        skos:broader    :n33402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scheibenhardt"@de .
+
+:n233010430103  a       skos:Concept ;
+        skos:broader    :n23301043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siedlung Rackenbach"@de .
+
+:n13306112  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weinsheim"@de .
+
+:n23109005  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bengel"@de .
+
+:n14302301  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wahlrod"@de .
+
+:n232012600100  a       skos:Concept ;
+        skos:broader    :n23201260 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kopscheid"@de .
+
+:n13804009  a           skos:Concept ;
+        skos:broader    :n13804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dattenberg"@de .
+
+:n14008085  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Liebshausen"@de .
+
+:n333070340103  a       skos:Concept ;
+        skos:broader    :n33307034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spreiterhof"@de .
+
+:n33907018  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Friesenheim"@de .
+
+:n13809053  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhonnefeld-Gierend"@de .
+
+:n13306027  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Duchroth"@de .
+
+:n33702019  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörrenbach"@de .
+
+:n132070720101  a       skos:Concept ;
+        skos:broader    :n13207072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birken"@de .
+
+:n135020230102  a       skos:Concept ;
+        skos:broader    :n13502023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lehnholz"@de .
+
+:n13101028  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herschbroich"@de .
+
+:n13306  a              skos:Concept ;
+        skos:broader    :n133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rüdesheim, Verbandsgemeinde"@de .
+
+:n132080800125  a       skos:Concept ;
+        skos:broader    :n13208080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scheuern"@de .
+
+:n316000001000  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mußbach (Ortsbezirk)"@de .
+
+:n235030680200  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hamm (Ortsbezirk)"@de .
+
+:n33902  a              skos:Concept ;
+        skos:broader    :n339 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bodenheim, Verbandsgemeinde"@de .
+
+:n315000001600  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hartenberg/Münchfeld (Ortsbezirk)"@de .
+
+:n235070730300  a       skos:Concept ;
+        skos:broader    :n23507073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mesenich (Ortsbezirk)"@de .
+
+:n141100910200  a       skos:Concept ;
+        skos:broader    :n14110091 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nassau"@de .
+
+:n232000180702  a       skos:Concept ;
+        skos:broader    :n23200018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wingertsberg"@de .
+
+:n14304023  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Görgeshausen"@de .
+
+:n333060300103  a       skos:Concept ;
+        skos:broader    :n33306030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wingertsweilerhof"@de .
+
+:n13101086  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wirft"@de .
+
+:n13702023  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Einig"@de .
+
+:n138090070105  a       skos:Concept ;
+        skos:broader    :n13809007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langscheid"@de .
+
+:n13210016  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burglahr"@de .
+
+:n33501202  a           skos:Concept ;
+        skos:broader    :n33501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langwieden"@de .
+
+:n34001009  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erfweiler"@de .
+
+:n340030280101  a       skos:Concept ;
+        skos:broader    :n34003028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenwoogsmühle, Gastst."@de .
+
+:n45    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochstift Speyer"@de .
+
+:n14103057  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirschberg"@de .
+
+:n33107071  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westhofen"@de .
+
+:n33702056  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederotterbach"@de .
+
+:n23503146  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wellen"@de .
+
+:n13104041  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Königsfeld"@de .
+
+:n138030120400  a       skos:Concept ;
+        skos:broader    :n13803012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Giershofen (Ortsbezirk)"@de .
+
+:n13101065  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pomster"@de .
+
+:n232080770101  a       skos:Concept ;
+        skos:broader    :n23208077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meilbrück"@de .
+
+:n33903001  a           skos:Concept ;
+        skos:broader    :n33903 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Appenheim"@de .
+
+:n143093080300  a       skos:Concept ;
+        skos:broader    :n14309308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wengenroth"@de .
+
+:n235071510108  a       skos:Concept ;
+        skos:broader    :n23507151 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schleidweiler (Ortsbezirk)"@de .
+
+:n332000020401  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfeffingen"@de .
+
+:n14306286  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rennerod, Stadt"@de .
+
+:n135030830104  a       skos:Concept ;
+        skos:broader    :n13503083 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meiserich (Ortsbezirk)"@de .
+
+:n14305059  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhaid"@de .
+
+:n132080110107  a       skos:Concept ;
+        skos:broader    :n13208011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleehahn"@de .
+
+:n312000002002  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Blechhammer"@de .
+
+:n33800025  a           skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schifferstadt, Stadt"@de .
+
+:n24    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Moseltal"@de .
+
+:n33610099  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ulmet"@de .
+
+:n137092170104  a       skos:Concept ;
+        skos:broader    :n13709217 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kühr"@de .
+
+:n33608105  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolfstein, Stadt"@de .
+
+:n313000000200  a       skos:Concept ;
+        skos:broader    :n31300000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dammheim (Ortsbezirk)"@de .
+
+:n13805  a              skos:Concept ;
+        skos:broader    :n138 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Puderbach, Verbandsgemeinde"@de .
+
+:n13210053  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirz-Maulsbach"@de .
+
+:n13501036  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Greimersburg"@de .
+
+:n340092200101  a       skos:Concept ;
+        skos:broader    :n34009220 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stockbornerhof"@de .
+
+:n14310275  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedersayn"@de .
+
+:n13101044  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leimbach"@de .
+
+:n312000000800  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mölschbach (Ortsbezirk)"@de .
+
+:n334000070100  a       skos:Concept ;
+        skos:broader    :n33400007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Germersheim"@de .
+
+:n34009224  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmitshausen"@de .
+
+:n131000070103  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bachem (Ortsbezirk)"@de .
+
+:n33511031  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberarnbach"@de .
+
+:n33207  a              skos:Concept ;
+        skos:broader    :n332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leiningerland, Verbandsgemeinde"@de .
+
+:n23306219  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kerschenbach"@de .
+
+:n14305038  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hundsdorf"@de .
+
+:n13401036  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heimbach"@de .
+
+:n23301017  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Deudesfeld"@de .
+
+:n33800004  a           skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bobenheim-Roxheim"@de .
+
+:n03    a               skos:Concept ;
+        skos:broader    :n1 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinland"@de .
+
+:n33907013  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dolgesheim"@de .
+
+:n340082060108  a       skos:Concept ;
+        skos:broader    :n34008206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Truppacherhof"@de .
+
+:n13210032  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flammersfeld"@de .
+
+:n13501015  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Briedern"@de .
+
+:n23506074  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leiwen"@de .
+
+:n340010100101  a       skos:Concept ;
+        skos:broader    :n34001010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berwartstein, Burg und Gastst."@de .
+
+:n13301  a              skos:Concept ;
+        skos:broader    :n133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Kreuznach, Verbandsgemeinde"@de .
+
+:n235070690101  a       skos:Concept ;
+        skos:broader    :n23507069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Ramstein, Gastst."@de .
+
+:n23301075  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Üdersdorf"@de .
+
+:n333070430200  a       skos:Concept ;
+        skos:broader    :n33307043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mannweiler"@de .
+
+:n133090520300  a       skos:Concept ;
+        skos:broader    :n13309052 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirnsulzbach (Ortsbezirk)"@de .
+
+:n135025020101  a       skos:Concept ;
+        skos:broader    :n13502502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kloster Maria Martental"@de .
+
+:n14306244  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Homberg"@de .
+
+:n13210090  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pleckhausen"@de .
+
+:n33702072  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweighofen"@de .
+
+:n33706047  a           skos:Concept ;
+        skos:broader    :n33706 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirrweiler (Pfalz)"@de .
+
+:n13702501  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münstermaifeld, Stadt"@de .
+
+:n134020110101  a       skos:Concept ;
+        skos:broader    :n13402011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Einschiederhof"@de .
+
+:n23507137  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trierweiler"@de .
+
+:n138000450900  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberbieber (Ortsbezirk)"@de .
+
+:n235071370100  a       skos:Concept ;
+        skos:broader    :n23507137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fusenich (Ortsbezirk)"@de .
+
+:n33608057  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langweiler"@de .
+
+:n140   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Hunsrück-Kreis"@de .
+
+:n4051096n7  a          skos:Concept ;
+        skos:broader    :n50 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saardepartement"@de .
+
+:n333035010200  a       skos:Concept ;
+        skos:broader    :n33303501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niefernheim (Ortsbezirk)"@de .
+
+:n33307203  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seelen"@de .
+
+:n231010810105  a       skos:Concept ;
+        skos:broader    :n23101081 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maring"@de .
+
+:n13208011  a           skos:Concept ;
+        skos:broader    :n13208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelhof"@de .
+
+:n340092170101  a       skos:Concept ;
+        skos:broader    :n34009217 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Faustermühle"@de .
+
+:n13804041  a           skos:Concept ;
+        skos:broader    :n13804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Linz am Rhein, Stadt"@de .
+
+:n34001004  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dahn, Stadt"@de .
+
+:n13401073  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rohrbach"@de .
+
+:n33201035  a           skos:Concept ;
+        skos:broader    :n33201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meckenheim"@de .
+
+:n312000001900  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bännjerrück/Karl-Pfaff-Siedlung"@de .
+
+:n232050670200  a       skos:Concept ;
+        skos:broader    :n23205067 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedersgegen"@de .
+
+:n232063290305  a       skos:Concept ;
+        skos:broader    :n23206329 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hemmeres"@de .
+
+:n14103052  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hambach"@de .
+
+:n332050140109  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mückenwiese"@de .
+
+:n4526161n1  a          skos:Concept ;
+        skos:broader    :n50 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Département des Forêts"@de .
+
+:n14111101  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberfischbach"@de .
+
+:n140091120201  a       skos:Concept ;
+        skos:broader    :n14009112 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Engelsburg"@de .
+
+:n14111095  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederneisen"@de .
+
+:n33303058  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ottersheim"@de .
+
+:n143022650200  a       skos:Concept ;
+        skos:broader    :n14302265 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obermörsbach"@de .
+
+:n33608036  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hefersweiler"@de .
+
+:n33706  a              skos:Concept ;
+        skos:broader    :n337 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maikammer, Verbandsgemeinde"@de .
+
+:n231005020901  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gipsmühle, Baldenauermühle"@de .
+
+:n14107085  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Miehlen"@de .
+
+:n232050720101  a       skos:Concept ;
+        skos:broader    :n23205072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bierendorf"@de .
+
+:n13801044  a           skos:Concept ;
+        skos:broader    :n13801 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neustadt (Wied)"@de .
+
+:n23306235  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reuth"@de .
+
+:n235071110509  a       skos:Concept ;
+        skos:broader    :n23507111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schäferei"@de .
+
+:n33610094  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Selchenbach"@de .
+
+:n33608100  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unterjeckenbach"@de .
+
+:n137020890113  a       skos:Concept ;
+        skos:broader    :n13702089 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruitsch (Ortsbezirk)"@de .
+
+:n14111074  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kördorf"@de .
+
+:n14009016  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birkheim"@de .
+
+:n33610015  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dennweiler-Frohnbach"@de .
+
+:n335090430100  a       skos:Concept ;
+        skos:broader    :n33509043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pörrbach"@de .
+
+:n13807008  a           skos:Concept ;
+        skos:broader    :n13807 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruchhausen"@de .
+
+:n33101014  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dintesheim"@de .
+
+:n13311026  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dorsheim"@de .
+
+:n4133948n4  a          skos:Concept ;
+        skos:broader    :n50 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mainzer Republik"@de .
+
+:n232063180106  a       skos:Concept ;
+        skos:broader    :n23206318 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weißenseifen"@de .
+
+:n33202  a              skos:Concept ;
+        skos:broader    :n332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freinsheim, Verbandsgemeinde"@de .
+
+:n331070150200  a       skos:Concept ;
+        skos:broader    :n33107015 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heßloch"@de .
+
+:n23306214  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hallschlag"@de .
+
+:n13505064  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Moritzheim"@de .
+
+:n13209111  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallmenroth"@de .
+
+:n33306071  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sippersfeld"@de .
+
+:n33608073  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberweiler-Tiefenbach"@de .
+
+:n13101501  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dümpelfeld"@de .
+
+:n337050730103  a       skos:Concept ;
+        skos:broader    :n33705073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kindingermühle, Untermühle"@de .
+
+:n13502009  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Binningen"@de .
+
+:n135035010200  a       skos:Concept ;
+        skos:broader    :n13503501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kennfus (Ortsbezirk)"@de .
+
+:n235010930104  a       skos:Concept ;
+        skos:broader    :n23501093 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zinsershütten"@de .
+
+:n13102017  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dernau"@de .
+
+:n4321205n0  a          skos:Concept ;
+        skos:broader    :n12 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinhessische Schweiz"@de .
+
+:n132070630302  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Euteneuen"@de .
+
+:n231010080100  a       skos:Concept ;
+        skos:broader    :n23101008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Andel (Ortsbezirk)"@de .
+
+:n23301070  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Strohn"@de .
+
+:n23208282  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberkail"@de .
+
+:n33908065  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welgesheim"@de .
+
+:n23207055  a           skos:Concept ;
+        skos:broader    :n23207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hosten"@de .
+
+:n33703066  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhodt unter Rietburg"@de .
+
+:n13502067  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Müllenbach"@de .
+
+:n23304  a              skos:Concept ;
+        skos:broader    :n233 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kelberg, Verbandsgemeinde"@de .
+
+:n33307049  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münsterappel"@de .
+
+:n33303074  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Standenbühl"@de .
+
+:n23208203  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Balesfeld"@de .
+
+:n141091210202  a       skos:Concept ;
+        skos:broader    :n14109121 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrenthal"@de .
+
+:n33610052  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Konken"@de .
+
+:n231061230200  a       skos:Concept ;
+        skos:broader    :n23106123 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thalfang"@de .
+
+:n235030680503  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roscheiderhof"@de .
+
+:n137030430105  a       skos:Concept ;
+        skos:broader    :n13703043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neumühle"@de .
+
+:n140091330204  a       skos:Concept ;
+        skos:broader    :n14009133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fellen"@de .
+
+:n33101051  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nieder-Wiesen"@de .
+
+:n14111032  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörsdorf"@de .
+
+:n235081520108  a       skos:Concept ;
+        skos:broader    :n23508152 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederzerf"@de .
+
+:n23208118  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schleid"@de .
+
+:n141090720102  a       skos:Concept ;
+        skos:broader    :n14109072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberkestert"@de .
+
+:n13704069  a           skos:Concept ;
+        skos:broader    :n13704 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mendig,Stadt"@de .
+
+:n232012540100  a       skos:Concept ;
+        skos:broader    :n23201254 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Greimelscheid"@de .
+
+:n235081310100  a       skos:Concept ;
+        skos:broader    :n23508131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hamm (Ortsbezirk)"@de .
+
+:n33307028  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gundersweiler"@de .
+
+:n13502046  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalenborn"@de .
+
+:n23504135  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thomm"@de .
+
+:n23507111  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ralingen"@de .
+
+:n331010250200  a       skos:Concept ;
+        skos:broader    :n33101025 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Uffhofen"@de .
+
+:n14111011  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berndroth"@de .
+
+:n33701  a              skos:Concept ;
+        skos:broader    :n337 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Annweiler am Trifels, Verbandsgemeinde"@de .
+
+:n337020290101  a       skos:Concept ;
+        skos:broader    :n33702029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gleishorbach"@de .
+
+:n13310116  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winterburg"@de .
+
+:n14107080  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lipporn"@de .
+
+:n332060460105  a       skos:Concept ;
+        skos:broader    :n33206046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Odinstal"@de .
+
+:n131000700800  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unkelbach (Ortsbezirk 6)"@de .
+
+:n13805014  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dürrholz"@de .
+
+:n13802038  a           skos:Concept ;
+        skos:broader    :n13802 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leutesdorf"@de .
+
+:n33202008  a           skos:Concept ;
+        skos:broader    :n33202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dackenheim"@de .
+
+:n13505080  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sosberg"@de .
+
+:n141030300103  a       skos:Concept ;
+        skos:broader    :n14103030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hütte"@de .
+
+:n235081540200  a       skos:Concept ;
+        skos:broader    :n23508154 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kelsen (Ortsbezirk)"@de .
+
+:n133060990103  a       skos:Concept ;
+        skos:broader    :n13306099 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gräfenbacherhütte"@de .
+
+:n33801014  a           skos:Concept ;
+        skos:broader    :n33801 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochdorf-Assenheim"@de .
+
+:n13505001  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alf"@de .
+
+:n340030530102  a       skos:Concept ;
+        skos:broader    :n34003053 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Luthersbrunn, ev.Pfarrhaus"@de .
+
+:n33303032  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Immesheim"@de .
+
+:n13209042  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grünebach"@de .
+
+:n339000050800  a       skos:Concept ;
+        skos:broader    :n33900005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sponsheim"@de .
+
+:n336100030200  a       skos:Concept ;
+        skos:broader    :n33610003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mühlbach (Ortsbezirk)"@de .
+
+:n233060290205  a       skos:Concept ;
+        skos:broader    :n23306029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Crumps Mühle"@de .
+
+:n235075010200  a       skos:Concept ;
+        skos:broader    :n23507501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hofweiler (Ortsbezirk)"@de .
+
+:n335100290200  a       skos:Concept ;
+        skos:broader    :n33510029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morbach (Ortsbezirk)"@de .
+
+:n340030080103  a       skos:Concept ;
+        skos:broader    :n34003008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ransbrunnerhof"@de .
+
+:n235080810102  a       skos:Concept ;
+        skos:broader    :n23508081 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederkell"@de .
+
+:n317000000601  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenbergerhof"@de .
+
+:n33307065  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruppertsecken"@de .
+
+:n33908002  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Aspisheim"@de .
+
+:n235081180303  a       skos:Concept ;
+        skos:broader    :n23508118 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beurig"@de .
+
+:n141090690102  a       skos:Concept ;
+        skos:broader    :n14109069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Gutenfels"@de .
+
+:n4004655n2  a          skos:Concept ;
+        skos:broader    :n50 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unterelsass"@de .
+
+:n138000450200  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Engers (Ortsbezirk)"@de .
+
+:n235040850104  a       skos:Concept ;
+        skos:broader    :n23504085 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maximin Grünhaus"@de .
+
+:n233015010600  a       skos:Concept ;
+        skos:broader    :n23301501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinborn (Ortsbezirk)"@de .
+
+:n320000000800  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederauerbach"@de .
+
+:n23101125  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ürzig"@de .
+
+:n23208134  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiersdorf"@de .
+
+:n332000020200  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hardenburg (Ortsbezirk)"@de .
+
+:n34002014  a           skos:Concept ;
+        skos:broader    :n34002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hauenstein"@de .
+
+:n334030240106  a       skos:Concept ;
+        skos:broader    :n33403024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wanzheimer Mühle"@de .
+
+:n137041010101  a       skos:Concept ;
+        skos:broader    :n13704101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fraukirch"@de .
+
+:n232081250102  a       skos:Concept ;
+        skos:broader    :n23208125 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Looskyllermühle"@de .
+
+:n137002030200  a       skos:Concept ;
+        skos:broader    :n13700203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stromberg"@de .
+
+:n23207050  a           skos:Concept ;
+        skos:broader    :n23207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herforst"@de .
+
+:n138010440101  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brüchen"@de .
+
+:n13502062  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Möntenich"@de .
+
+:n140030180300  a       skos:Concept ;
+        skos:broader    :n14003018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ebschied (Ortsbezirk)"@de .
+
+:n23508126  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Serrig"@de .
+
+:n13709208  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hatzenport"@de .
+
+:n34009023  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höheischweiler"@de .
+
+:n33102045  a           skos:Concept ;
+        skos:broader    :n33102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mettenheim"@de .
+
+:n132105010104  a       skos:Concept ;
+        skos:broader    :n13210501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leuzbach"@de .
+
+:n231010920103  a       skos:Concept ;
+        skos:broader    :n23101092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Papiermühle"@de .
+
+:n333030010102  a       skos:Concept ;
+        skos:broader    :n33303001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heyerhof"@de .
+
+:n23208113  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Thomas"@de .
+
+:n23108049  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hasborn"@de .
+
+:n333040570101  a       skos:Concept ;
+        skos:broader    :n33304057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leithof"@de .
+
+:n13402062  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberbrombach"@de .
+
+:n14004159  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wahlenau"@de .
+
+:n23206279  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nimshuscheid"@de .
+
+:n131010330300  a       skos:Concept ;
+        skos:broader    :n13101033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pitscheid"@de .
+
+:n13701088  a           skos:Concept ;
+        skos:broader    :n13701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Plaidt"@de .
+
+:n137025010500  a       skos:Concept ;
+        skos:broader    :n13702501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörz (Ortsbezirk)"@de .
+
+:n235081420103  a       skos:Concept ;
+        skos:broader    :n23508142 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederkell"@de .
+
+:n133010300101  a       skos:Concept ;
+        skos:broader    :n13301030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bingert"@de .
+
+:n336100150101  a       skos:Concept ;
+        skos:broader    :n33610015 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frohnbacherhof"@de .
+
+:n33704039  a           skos:Concept ;
+        skos:broader    :n33704 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herxheimweyher"@de .
+
+:n33307023  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gaugrehweiler"@de .
+
+:n33304047  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morschheim"@de .
+
+:n336091070100  a       skos:Concept ;
+        skos:broader    :n33609107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gimsbach"@de .
+
+:n231010700400  a       skos:Concept ;
+        skos:broader    :n23101070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ilsbach (Ortsbezirk)"@de .
+
+:n23508105  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Paschel"@de .
+
+:n23108113  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Salmtal"@de .
+
+:n331030230200  a       skos:Concept ;
+        skos:broader    :n33103023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederflörsheim"@de .
+
+:n23306076  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Üxheim"@de .
+
+:n33804018  a           skos:Concept ;
+        skos:broader    :n33804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maxdorf"@de .
+
+:n13310111  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiler bei Monzingen"@de .
+
+:n23101077  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Longkamp"@de .
+
+:n23205116  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scheitenkorb"@de .
+
+:n23208086  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nattenheim"@de .
+
+:n133090460300  a       skos:Concept ;
+        skos:broader    :n13309046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloß Dhaun (Ortsbezirk)"@de .
+
+:n23108  a              skos:Concept ;
+        skos:broader    :n231 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wittlich-Land, Verbandsgemeinde"@de .
+
+:n232051020101  a       skos:Concept ;
+        skos:broader    :n23205102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buscht"@de .
+
+:n23208007  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Badem"@de .
+
+:n231080030103  a       skos:Concept ;
+        skos:broader    :n23108003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mellich"@de .
+
+:n143040480200  a       skos:Concept ;
+        skos:broader    :n14304048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elgendorf (Ortsbezirk)"@de .
+
+:n132100400101  a       skos:Concept ;
+        skos:broader    :n13210040 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Amteroth"@de .
+
+:n337   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Südliche Weinstraße, Landkreis"@de .
+
+:n336080730102  a       skos:Concept ;
+        skos:broader    :n33608073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tiefenbach"@de .
+
+:n33609004  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenkirchen"@de .
+
+:n34002030  a           skos:Concept ;
+        skos:broader    :n34002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lug"@de .
+
+:n320000000105  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freudenbergerhof"@de .
+
+:n33404005  a           skos:Concept ;
+        skos:broader    :n33404 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freckenfeld"@de .
+
+:n13310084  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reiffelbach"@de .
+
+:n23108007  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bergweiler"@de .
+
+:n23101056  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochscheid"@de .
+
+:n23205089  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedergeckler"@de .
+
+:n14301297  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stockhausen-Illfurth"@de .
+
+:n13402020  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dienstweiler"@de .
+
+:n23508142  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldweiler"@de .
+
+:n233060260900  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oos (Ortsbezirk)"@de .
+
+:n13310005  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auen"@de .
+
+:n141110110101  a       skos:Concept ;
+        skos:broader    :n14111011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ackerbach"@de .
+
+:n13405087  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stipshausen"@de .
+
+:n131000901002  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beller"@de .
+
+:n33304005  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bennhausen"@de .
+
+:n131020400104  a       skos:Concept ;
+        skos:broader    :n13102040 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winnen"@de .
+
+:n13103006  a           skos:Concept ;
+        skos:broader    :n13103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Breisig, Stadt"@de .
+
+:n23501112  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rascheid"@de .
+
+:n23508057  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kastel-Staadt"@de .
+
+:n23108065  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Karl"@de .
+
+:n231005020700  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinzerath (Ortsbezirk)"@de .
+
+:n13803069  a           skos:Concept ;
+        skos:broader    :n13803 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stebach"@de .
+
+:n34003008  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eppenbrunn"@de .
+
+:n33510017  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katzweiler"@de .
+
+:n335110470113  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meisertal"@de .
+
+:n23206295  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pronsfeld"@de .
+
+:n23208044  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gondorf"@de .
+
+:n23205068  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Koxhausen"@de .
+
+:n332000020110  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hausen"@de .
+
+:n23304206  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bongard"@de .
+
+:n231085030301  a       skos:Concept ;
+        skos:broader    :n23108503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mulbach"@de .
+
+:n14110129  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Singhofen"@de .
+
+:n319000000700  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ibersheim (Ortsbezirk)"@de .
+
+:n132100820100  a       skos:Concept ;
+        skos:broader    :n13210082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marenbach"@de .
+
+:n23206216  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dingdorf"@de .
+
+:n23201315  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Strickscheid"@de .
+
+:n13405066  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberreidenbach"@de .
+
+:n33609041  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herschweiler-Pettersheim"@de .
+
+:n232013330300  a       skos:Concept ;
+        skos:broader    :n23201333 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederüttfeld"@de .
+
+:n235070510200  a       skos:Concept ;
+        skos:broader    :n23507051 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Liersberg (Ortsbezirk)"@de .
+
+:n33807010  a           skos:Concept ;
+        skos:broader    :n33807 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hanhofen"@de .
+
+:n23108044  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Greimerath"@de .
+
+:n23205132  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weidingen"@de .
+
+:n132101150100  a       skos:Concept ;
+        skos:broader    :n13210115 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hilkhausen (Ortsbezirk)"@de .
+
+:n14004154  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unzenberg"@de .
+
+:n131000700100  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bandorf (T.a.Ortsbezirk 3)"@de .
+
+:n33906057  a           skos:Concept ;
+        skos:broader    :n33906 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stadecken-Elsheim"@de .
+
+:n132080080104  a       skos:Concept ;
+        skos:broader    :n13208008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruchen"@de .
+
+:n23205047  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heilbach"@de .
+
+:n14301255  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lautzenbrücken"@de .
+
+:n31300000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Landau in der Pfalz, Kreisfreie Stadt"@de .
+
+:n33106073  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wörrstadt,Stadt"@de .
+
+:n13503035  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gillenbeuren"@de .
+
+:n13207076  a           skos:Concept ;
+        skos:broader    :n13207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederfischbach"@de .
+
+:n13301012  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biebelsheim"@de .
+
+:n111000000400  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bubenheim (Ortsbezirk 3)"@de .
+
+:n333065030300  a       skos:Concept ;
+        skos:broader    :n33306503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Potzbach (Ortsbezirk)"@de .
+
+:n138010030303  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dasbach"@de .
+
+:n23208081  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Metterich"@de .
+
+:n23108023  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dodenburg"@de .
+
+:n14009  a              skos:Concept ;
+        skos:broader    :n140 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hunsrück-Mittelrhein, Verbandsgemeinde"@de .
+
+:n31200000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaiserslautern, Kreisfreie Stadt"@de .
+
+:n23304243  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ueß"@de .
+
+:n335110450101  a       skos:Concept ;
+        skos:broader    :n33511045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alte Schmelz"@de .
+
+:n336080300200  a       skos:Concept ;
+        skos:broader    :n33608030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedereisenbach"@de .
+
+:n231005021800  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wenigerath (Ortsbezirk)"@de .
+
+:n14301234  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hardt"@de .
+
+:n312000000403  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lampertsmühle"@de .
+
+:n131000900900  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nierendorf (Ortsbezirk)"@de .
+
+:n14004048  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hecken"@de .
+
+:n135010240100  a       skos:Concept ;
+        skos:broader    :n13501024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ediger"@de .
+
+:n233062110102  a       skos:Concept ;
+        skos:broader    :n23306211 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiermühle"@de .
+
+:n334020270101  a       skos:Concept ;
+        skos:broader    :n33402027 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bienwaldmühle"@de .
+
+:n34008226  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Walshausen"@de .
+
+:n332   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Dürkheim, Landkreis"@de .
+
+:n23201267  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mauel"@de .
+
+:n23306050  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neroth"@de .
+
+:n33510033  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Olsbrücken"@de .
+
+:n14008166  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wüschheim"@de .
+
+:n131000770100  a       skos:Concept ;
+        skos:broader    :n13100077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Bodendorf (Ortsbezirk)"@de .
+
+:n138090060114  a       skos:Concept ;
+        skos:broader    :n13809006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siebenmorgen"@de .
+
+:n235080430103  a       skos:Concept ;
+        skos:broader    :n23508043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinbachweier"@de .
+
+:n337015010105  a       skos:Concept ;
+        skos:broader    :n33701501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sarnstall (Ortsbezirk)"@de .
+
+:n23208060  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Idenheim"@de .
+
+:n23205084  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Muxerath"@de .
+
+:n231060540102  a       skos:Concept ;
+        skos:broader    :n23106054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forsthaus Röderbach"@de .
+
+:n23304222  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kolverath"@de .
+
+:n132060140102  a       skos:Concept ;
+        skos:broader    :n13206014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hofacker"@de .
+
+:n141090660102  a       skos:Concept ;
+        skos:broader    :n14109066 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Liebenstein"@de .
+
+:n13210118  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wölmersen"@de .
+
+:n231060790108  a       skos:Concept ;
+        skos:broader    :n23106079 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thiergarten (Ortsbezirk)"@de .
+
+:n132100550102  a       skos:Concept ;
+        skos:broader    :n13210055 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Huf"@de .
+
+:n235031320100  a       skos:Concept ;
+        skos:broader    :n23503132 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fellerich (Ortsbezirk)"@de .
+
+:n23205005  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ammeldingen bei Neuerburg"@de .
+
+:n13405082  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sien"@de .
+
+:n137000680200  a       skos:Concept ;
+        skos:broader    :n13700068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hausen (Ortsbezirk)"@de .
+
+:n23508052  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Irsch"@de .
+
+:n23201246  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jucken"@de .
+
+:n13405003  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Allenbach"@de .
+
+:n232000180300  a       skos:Concept ;
+        skos:broader    :n23200018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Irsch (Ortsbezirk)"@de .
+
+:n23207289  a           skos:Concept ;
+        skos:broader    :n23207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Orenhofen"@de .
+
+:n23206290  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Orlenbach"@de .
+
+:n111000001500  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuendorf"@de .
+
+:n23101030  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erden"@de .
+
+:n23205063  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Irrel"@de .
+
+:n23304201  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arbach"@de .
+
+:n232071070101  a       skos:Concept ;
+        skos:broader    :n23207107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heinzkyller Mühle"@de .
+
+:n33701074  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Silz"@de .
+
+:n132070630600  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wingendorf (Ortsbezirk)"@de .
+
+:n14110  a              skos:Concept ;
+        skos:broader    :n141 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Ems-Nassau, Verbandsgemeinde"@de .
+
+:n333040400103  a       skos:Concept ;
+        skos:broader    :n33304040 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schniftenbergerhof"@de .
+
+:n23201310  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sevenig (Our)"@de .
+
+:n33107009  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bermersheim"@de .
+
+:n312000002104  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiesenthalerhof"@de .
+
+:n14004006  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bärenbach"@de .
+
+:n233010200100  a       skos:Concept ;
+        skos:broader    :n23301020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brück"@de .
+
+:n14306309  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westernohe"@de .
+
+:n14304077  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Untershausen"@de .
+
+:n137010560105  a       skos:Concept ;
+        skos:broader    :n13701056 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grube Meurin"@de .
+
+:n135020840102  a       skos:Concept ;
+        skos:broader    :n13502084 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schuwerackerhof"@de .
+
+:n23208501  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wißmannsdorf"@de .
+
+:n317000000400  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hengsberg (Ortsbezirk)"@de .
+
+:n132080540106  a       skos:Concept ;
+        skos:broader    :n13208054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obergüdeln"@de .
+
+:n23205042  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gentingen"@de .
+
+:n14110103  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obernhof"@de .
+
+:n13503030  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Filz"@de .
+
+:n14008039  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fronhofen"@de .
+
+:n13809007  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hausen (Wied)"@de .
+
+:n337020720103  a       skos:Concept ;
+        skos:broader    :n33702072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Windhof"@de .
+
+:n13405040  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hettenrodt"@de .
+
+:n340010010101  a       skos:Concept ;
+        skos:broader    :n34001001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Germanshof"@de .
+
+:n34003040  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruppertsweiler"@de .
+
+:n232012850203  a       skos:Concept ;
+        skos:broader    :n23201285 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Luppertsseifen"@de .
+
+:n211000000201  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenhof"@de .
+
+:n140005010401  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloß Schöneck"@de .
+
+:n141031300103  a       skos:Concept ;
+        skos:broader    :n14103130 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rupbach"@de .
+
+:n14302313  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winkelbach"@de .
+
+:n14004  a              skos:Concept ;
+        skos:broader    :n140 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchberg / Hunsrück, Verbandsgemeinde"@de .
+
+:n232012010200  a       skos:Concept ;
+        skos:broader    :n23201201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Halenbach"@de .
+
+:n132070630409  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wehbach (Ortsbezirk)"@de .
+
+:n33906031  a           skos:Concept ;
+        skos:broader    :n33906 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jugenheim in Rheinhessen"@de .
+
+:n13809065  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roßbach"@de .
+
+:n13210049  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hemmelzen"@de .
+
+:n33705007  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Billigheim-Ingenheim"@de .
+
+:n233060260200  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büscheich (Ortsbezirk)"@de .
+
+:n13405502  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langweiler"@de .
+
+:n13104016  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dedenbach"@de .
+
+:n34008221  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Riedelberg"@de .
+
+:n23201262  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lünebach"@de .
+
+:n333070040102  a       skos:Concept ;
+        skos:broader    :n33307004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neubau"@de .
+
+:n33511027  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelbrunn"@de .
+
+:n231091240101  a       skos:Concept ;
+        skos:broader    :n23109124 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Wildstein"@de .
+
+:n23207311  a           skos:Concept ;
+        skos:broader    :n23207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spangdahlem"@de .
+
+:n14109042  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Filsen"@de .
+
+:n13309073  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhausen bei Kirn"@de .
+
+:n33705065  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ranschbach"@de .
+
+:n14008076  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Külz (Hunsrück)"@de .
+
+:n137092040101  a       skos:Concept ;
+        skos:broader    :n13709204 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siebenborn"@de .
+
+:n33808020  a           skos:Concept ;
+        skos:broader    :n33808 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhofen"@de .
+
+:n333065030104  a       skos:Concept ;
+        skos:broader    :n33306503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wäschbacherhof"@de .
+
+:n143022360102  a       skos:Concept ;
+        skos:broader    :n14302236 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lützelau"@de .
+
+:n23106078  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lückenburg"@de .
+
+:n340090510100  a       skos:Concept ;
+        skos:broader    :n34009051 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thaleischweiler"@de .
+
+:n33207004  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bissersheim"@de .
+
+:n134000450400  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hammerstein"@de .
+
+:n336080290101  a       skos:Concept ;
+        skos:broader    :n33608029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Naumburgerhof"@de .
+
+:n135010820206  a       skos:Concept ;
+        skos:broader    :n13501082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lützbach"@de .
+
+:n13309052  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirn, Stadt"@de .
+
+:n14302265  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörsbach"@de .
+
+:n14111118  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roth"@de .
+
+:n13210086  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwambach"@de .
+
+:n13501069  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nehren"@de .
+
+:n33808  a              skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinauen, Verbandsgemeinde"@de .
+
+:n23506134  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thörnich"@de .
+
+:n211000000700  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Filsch (Ortsbezirk 14)"@de .
+
+:n233060830100  a       skos:Concept ;
+        skos:broader    :n23306083 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mirbach (Ortsbezirk)"@de .
+
+:n140005010900  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Udenhausen (Ortsbezirk)"@de .
+
+:n132030260102  a       skos:Concept ;
+        skos:broader    :n13203026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stegskopf"@de .
+
+:n14103133  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wasenbach"@de .
+
+:n23109033  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flußbach"@de .
+
+:n23201220  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eschfeld"@de .
+
+:n13804037  a           skos:Concept ;
+        skos:broader    :n13804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leubsdorf"@de .
+
+:n134010050101  a       skos:Concept ;
+        skos:broader    :n13401005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitsesterhof"@de .
+
+:n14304072  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stahlhofen"@de .
+
+:n36    a               skos:Concept ;
+        skos:broader    :n3 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katholische Kirche / Diözese Mainz"@de .
+
+:n335100350106  a       skos:Concept ;
+        skos:broader    :n33510035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Drehenthalerhof (Ortsbezirk)"@de .
+
+:n131000070200  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Neuenahr (Ortsbezirk)"@de .
+
+:n13210065  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krunkel"@de .
+
+:n231005021100  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merscheid (Ortsbezirk)"@de .
+
+:n131030140106  a       skos:Concept ;
+        skos:broader    :n13103014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweppenburg (ehem. Gem. Niederlützingen)"@de .
+
+:n134050040101  a       skos:Concept ;
+        skos:broader    :n13405004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Asbacherhütte, Pflegeanst."@de .
+
+:n33304  a              skos:Concept ;
+        skos:broader    :n333 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchheimbolanden, Verbandsgemeinde"@de .
+
+:n318000000108  a       skos:Concept ;
+        skos:broader    :n31800000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rinkenbergerhof"@de .
+
+:n13809002  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Anhausen"@de .
+
+:n131000900200  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birresdorf (Ortsbezirk)"@de .
+
+:n33207041  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obrigheim (Pfalz)"@de .
+
+:n317000000708  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schelermühle"@de .
+
+:n13203079  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nisterberg"@de .
+
+:n334005010102  a       skos:Concept ;
+        skos:broader    :n33400501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenberg"@de .
+
+:n94    a               skos:Concept ;
+        skos:broader    :n5 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Nahe-Raum"@de .
+
+:n232000180104  a       skos:Concept ;
+        skos:broader    :n23200018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pützhöhe"@de .
+
+:n319000001100  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfeddersheim (Ortsbezirk)"@de .
+
+:n141101280104  a       skos:Concept ;
+        skos:broader    :n14110128 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalkofen"@de .
+
+:n14304051  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nentershausen"@de .
+
+:n337020130101  a       skos:Concept ;
+        skos:broader    :n33702013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reisdorf"@de .
+
+:n141000750218  a       skos:Concept ;
+        skos:broader    :n14100075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lahnstein auf der Höhe"@de .
+
+:n232080130102  a       skos:Concept ;
+        skos:broader    :n23208013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenhof"@de .
+
+:n231085030100  a       skos:Concept ;
+        skos:broader    :n23108503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg/Salm (Ortsbezirk)"@de .
+
+:n14008092  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mengerschied"@de .
+
+:n314000000700  a       skos:Concept ;
+        skos:broader    :n31400000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheingönheim (Ortsbezirk)"@de .
+
+:n15    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfälzer Wald"@de .
+
+:n132070630404  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grindel"@de .
+
+:n33907025  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahnheim"@de .
+
+:n13309010  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Becherbach bei Kirn"@de .
+
+:n14302223  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gehlert"@de .
+
+:n4107291n1  a          skos:Concept ;
+        skos:broader    :n19 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwarzwälder Hochwald"@de .
+
+:n333060800102  a       skos:Concept ;
+        skos:broader    :n33306080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rohrbach"@de .
+
+:n14110071  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kemmenau"@de .
+
+:n13501027  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ernst"@de .
+
+:n232080750101  a       skos:Concept ;
+        skos:broader    :n23208075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mohrweiler"@de .
+
+:n33306009  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Börrstadt"@de .
+
+:n34009215  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Knopp-Labach"@de .
+
+:n138010440208  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fernthal"@de .
+
+:n337020710200  a       skos:Concept ;
+        skos:broader    :n33702071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweigen"@de .
+
+:n14009155  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Urbar"@de .
+
+:n33511022  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Landstuhl, Sickingenstadt, Stadt"@de .
+
+:n340082110106  a       skos:Concept ;
+        skos:broader    :n34008211 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unterbeiwalderhof"@de .
+
+:n211000001800  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tarforst (Ortsbezirk 13)"@de .
+
+:n14306256  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Liebenscheid"@de .
+
+:n335012030101  a       skos:Concept ;
+        skos:broader    :n33501203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schernau"@de .
+
+:n13401027  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frauenberg"@de .
+
+:n23301008  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bleckhausen"@de .
+
+:n231011050100  a       skos:Concept ;
+        skos:broader    :n23101105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederemmel"@de .
+
+:n143030320105  a       skos:Concept ;
+        skos:broader    :n14303032 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grenzhausen"@de .
+
+:n13209107  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinebach (Sieg)"@de .
+
+:n13702030  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gierschnach"@de .
+
+:n14302202  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alpenrod"@de .
+
+:n131020270106  a       skos:Concept ;
+        skos:broader    :n13102027 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fronrath"@de .
+
+:n13306013  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bockenau"@de .
+
+:n33608069  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nußbach"@de .
+
+:n320000000403  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wahlerhof"@de .
+
+:n138090070112  a       skos:Concept ;
+        skos:broader    :n13809007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seidenhahn"@de .
+
+:n13210023  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eichen"@de .
+
+:n33702005  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Bergzabern, Stadt"@de .
+
+:n13801077  a           skos:Concept ;
+        skos:broader    :n13801 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Windhagen"@de .
+
+:n143022960102  a       skos:Concept ;
+        skos:broader    :n14302296 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altburg"@de .
+
+:n52    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinere Territorien des 19. und 20. Jh."@de .
+
+:n13207  a              skos:Concept ;
+        skos:broader    :n132 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchen(Sieg), Verbandsgemeinde"@de .
+
+:n14103064  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Isselbach"@de .
+
+:n132100690102  a       skos:Concept ;
+        skos:broader    :n13210069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seifen"@de .
+
+:n13306071  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Norheim"@de .
+
+:n14302260  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Luckenbach"@de .
+
+:n13210081  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obererbach (Westerwald)"@de .
+
+:n14111113  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reckenroth"@de .
+
+:n4025288n7  a          skos:Concept ;
+        skos:broader    :n19 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochwald / Hunsrück"@de .
+
+:n13505039  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haserich"@de .
+
+:n339010030105  a       skos:Concept ;
+        skos:broader    :n33901003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Henschhausen (Ortsbezirk)"@de .
+
+:n13101072  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodder"@de .
+
+:n315000001501  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zahlbach"@de .
+
+:n316000000300  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Duttweiler (Ortsbezirk)"@de .
+
+:n33608048  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jettenbach"@de .
+
+:n141100910101  a       skos:Concept ;
+        skos:broader    :n14110091 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Nassau"@de .
+
+:n131   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ahrweiler, Landkreis"@de .
+
+:n315000000900  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lerchenberg (Ortsbezirk)"@de .
+
+:n23503068  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Konz,Stadt"@de .
+
+:n33406025  a           skos:Concept ;
+        skos:broader    :n33406 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rülzheim"@de .
+
+:n13203101  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schutzbach"@de .
+
+:n14107097  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederwallmenach"@de .
+
+:n331020180103  a       skos:Concept ;
+        skos:broader    :n33102018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sandhof"@de .
+
+:n335020040203  a       skos:Concept ;
+        skos:broader    :n33502004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daubenbornerhof"@de .
+
+:n31    a               skos:Concept ;
+        skos:broader    :n3 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Evangelische Kirche in Hessen und Nassau"@de .
+
+:n13703066  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Luxem"@de .
+
+:n137092120300  a       skos:Concept ;
+        skos:broader    :n13709212 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kobern"@de .
+
+:n14306214  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bretthausen"@de .
+
+:n13210060  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kescheid"@de .
+
+:n235075010302  a       skos:Concept ;
+        skos:broader    :n23507501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kyll"@de .
+
+:n23503132  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tawern"@de .
+
+:n13101051  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Müllenbach"@de .
+
+:n13209059  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kausen"@de .
+
+:n138010440224  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rott (ehem.Gem.Elsaffthal)"@de .
+
+:n131000070110  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienthal"@de .
+
+:n132060910102  a       skos:Concept ;
+        skos:broader    :n13206091 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hassel"@de .
+
+:n33101026  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Framersheim"@de .
+
+:n235081050102  a       skos:Concept ;
+        skos:broader    :n23508105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinbachweier"@de .
+
+:n135010560101  a       skos:Concept ;
+        skos:broader    :n13501056 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lützbachtal (ehem.Gem.Burgen)"@de .
+
+:n138030120301  a       skos:Concept ;
+        skos:broader    :n13803012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiedischhausen"@de .
+
+:n14306272  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neustadt (Westerwald)"@de .
+
+:n340082060200  a       skos:Concept ;
+        skos:broader    :n34008206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stambach"@de .
+
+:n4117847n6  a          skos:Concept ;
+        skos:broader    :n22 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuwieder Becken"@de .
+
+:n13505076  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Aldegund"@de .
+
+:n137095040200  a       skos:Concept ;
+        skos:broader    :n13709504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Moselsürsch"@de .
+
+:n10    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westerwald"@de .
+
+:n14103022  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Cramberg"@de .
+
+:n140030090300  a       skos:Concept ;
+        skos:broader    :n14003009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krastel (Ortsbezirk)"@de .
+
+:n131010010200  a       skos:Concept ;
+        skos:broader    :n13101001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breidscheid"@de .
+
+:n33608085  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reipoltskirchen"@de .
+
+:n14111065  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaltenholzhausen"@de .
+
+:n13101030  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hoffeld"@de .
+
+:n13102029  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hönningen"@de .
+
+:n14307  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Selters(Ww), Verbandsgemeinde"@de .
+
+:n14107140  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winterwerb"@de .
+
+:n33610006  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Blaubach"@de .
+
+:n138010440203  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Borscheid"@de .
+
+:n33101005  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bechenheim"@de .
+
+:n14003204  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mastershausen"@de .
+
+:n340082110101  a       skos:Concept ;
+        skos:broader    :n34008211 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bickenaschbacherhof"@de .
+
+:n338010220100  a       skos:Concept ;
+        skos:broader    :n33801022 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gronau"@de .
+
+:n14107055  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Himmighofen"@de .
+
+:n235030680600  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krettnach (T.a. Ortsbezirk 4)"@de .
+
+:n233062230103  a       skos:Concept ;
+        skos:broader    :n23306223 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eigelbach"@de .
+
+:n13210501  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenkirchen (Westerwald), Stadt"@de .
+
+:n131020270101  a       skos:Concept ;
+        skos:broader    :n13102027 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beilstein"@de .
+
+:n340082010101  a       skos:Concept ;
+        skos:broader    :n34008201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bödingerhof"@de .
+
+:n23506060  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kenn"@de .
+
+:n34001011  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fischbach bei Dahn"@de .
+
+:n14305082  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wirscheid"@de .
+
+:n23301061  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sarmersbach"@de .
+
+:n23208273  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuheilenbach"@de .
+
+:n33908056  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sprendlingen"@de .
+
+:n332050140116  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolfsgrube, Forsthaus"@de .
+
+:n13502058  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Masburg"@de .
+
+:n232062270400  a       skos:Concept ;
+        skos:broader    :n23206227 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wascheid"@de .
+
+:n333070430101  a       skos:Concept ;
+        skos:broader    :n33307043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morsbacherhof"@de .
+
+:n231010120200  a       skos:Concept ;
+        skos:broader    :n23101012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Filzen"@de .
+
+:n23205218  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eisenach"@de .
+
+:n33608043  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hohenöllen"@de .
+
+:n33101042  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kettenheim"@de .
+
+:n33105017  a           skos:Concept ;
+        skos:broader    :n33105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eckelsheim"@de .
+
+:n233042180100  a       skos:Concept ;
+        skos:broader    :n23304218 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hünerbach (Ortsbezirk)"@de .
+
+:n235080620300  a       skos:Concept ;
+        skos:broader    :n23508062 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meurich (Ortsbezirk)"@de .
+
+:n33806012  a           skos:Concept ;
+        skos:broader    :n33806 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heßheim"@de .
+
+:n13311054  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenlonsheim"@de .
+
+:n138000450801  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Torney (Ortsbezirk)"@de .
+
+:n14107092  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nastätten, Stadt"@de .
+
+:n23208109  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rittersdorf"@de .
+
+:n337020050200  a       skos:Concept ;
+        skos:broader    :n33702005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Blankenborn (Ortsbezirk)"@de .
+
+:n336100340102  a       skos:Concept ;
+        skos:broader    :n33610034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Remigiusberg"@de .
+
+:n235081260105  a       skos:Concept ;
+        skos:broader    :n23508126 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saarfels, Schloß"@de .
+
+:n23301040  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kradenbach"@de .
+
+:n13402058  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhambach"@de .
+
+:n13505092  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zell (Mosel), Stadt"@de .
+
+:n13703061  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langscheid"@de .
+
+:n14111081  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lohrheim"@de .
+
+:n33306503  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winnweiler"@de .
+
+:n33105075  a           skos:Concept ;
+        skos:broader    :n33105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wonsheim"@de .
+
+:n232080340100  a       skos:Concept ;
+        skos:broader    :n23208034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Badenborn"@de .
+
+:n33703036  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hainfeld"@de .
+
+:n340090550100  a       skos:Concept ;
+        skos:broader    :n34009055 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Harsberg"@de .
+
+:n13505013  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Briedel"@de .
+
+:n14310049  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Moschheim"@de .
+
+:n33306020  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Falkenstein"@de .
+
+:n312000001801  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bremerhof"@de .
+
+:n313000000600  a       skos:Concept ;
+        skos:broader    :n31300000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nußdorf (Ortsbezirk)"@de .
+
+:n33610022  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erdesbach"@de .
+
+:n34002047  a           skos:Concept ;
+        skos:broader    :n34002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwanheim"@de .
+
+:n33101021  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erbes-Büdesheim"@de .
+
+:n134020100104  a       skos:Concept ;
+        skos:broader    :n13402010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ulmenhof"@de .
+
+:n211000001100  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kürenz (Ortsbezirk 12)"@de .
+
+:n33706070  a           skos:Concept ;
+        skos:broader    :n33706 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Martin"@de .
+
+:n13505071  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Peterswald-Löffelscheid"@de .
+
+:n33307077  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Teschenmoschel"@de .
+
+:n33901063  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiler bei Bingen"@de .
+
+:n13807073  a           skos:Concept ;
+        skos:broader    :n13807 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unkel, Stadt"@de .
+
+:n340040070101  a       skos:Concept ;
+        skos:broader    :n34004007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biebermühle"@de .
+
+:n33703015  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burrweiler"@de .
+
+:n13311091  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schöneberg"@de .
+
+:n13502016  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brohl"@de .
+
+:n138020040102  a       skos:Concept ;
+        skos:broader    :n13802004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ariendorf"@de .
+
+:n14302  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hachenburg, Verbandsgemeinde"@de .
+
+:n14310028  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Helferskirchen"@de .
+
+:n335020100107  a       skos:Concept ;
+        skos:broader    :n33502010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klaftertalerhof"@de .
+
+:n33608001  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Adenbach"@de .
+
+:n13701  a              skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pellenz, Verbandsgemeinde"@de .
+
+:n335080200102  a       skos:Concept ;
+        skos:broader    :n33508020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwanden"@de .
+
+:n23206318  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallersheim"@de .
+
+:n335095010200  a       skos:Concept ;
+        skos:broader    :n33509501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fockenberg-Limbach (Ortsbezirk)"@de .
+
+:n232063320201  a       skos:Concept ;
+        skos:broader    :n23206332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Anzelterhof"@de .
+
+:n231010920200  a       skos:Concept ;
+        skos:broader    :n23101092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neumagen"@de .
+
+:n13402016  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buhlenberg"@de .
+
+:n132105010201  a       skos:Concept ;
+        skos:broader    :n13210501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Landgut Honneroth"@de .
+
+:n235075010106  a       skos:Concept ;
+        skos:broader    :n23507501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kunkelborn"@de .
+
+:n14009060  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hungenroth"@de .
+
+:n33303081  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weitersweiler"@de .
+
+:n23208210  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burbach"@de .
+
+:n231060170101  a       skos:Concept ;
+        skos:broader    :n23106017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flakhaus"@de .
+
+:n33103  a              skos:Concept ;
+        skos:broader    :n331 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Monsheim, Verbandsgemeinde"@de .
+
+:n34009035  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nünschweiler"@de .
+
+:n317000000507  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruhbank"@de .
+
+:n13102003  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenahr"@de .
+
+:n132070370145  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhausen"@de .
+
+:n23208125  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sülm"@de .
+
+:n315000000200  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bretzenheim (Ortsbezirk)"@de .
+
+:n34002005  a           skos:Concept ;
+        skos:broader    :n34002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Darstein"@de .
+
+:n337050070200  a       skos:Concept ;
+        skos:broader    :n33705007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Billigheim"@de .
+
+:n332050140111  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schafhof"@de .
+
+:n140030090104  a       skos:Concept ;
+        skos:broader    :n14003009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rothenbergerhof, Hsgr."@de .
+
+:n143062920102  a       skos:Concept ;
+        skos:broader    :n14306292 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dappricher Hof"@de .
+
+:n131030060200  a       skos:Concept ;
+        skos:broader    :n13103006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberbreisig"@de .
+
+:n332070410100  a       skos:Concept ;
+        skos:broader    :n33207041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Albsheim"@de .
+
+:n337030840101  a       skos:Concept ;
+        skos:broader    :n33703084 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buschmühle"@de .
+
+:n334050180200  a       skos:Concept ;
+        skos:broader    :n33405018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberlustadt"@de .
+
+:n33502028  a           skos:Concept ;
+        skos:broader    :n33502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhemsbach"@de .
+
+:n33609037  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Henschtal"@de .
+
+:n235060220100  a       skos:Concept ;
+        skos:broader    :n23506022 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fastrau (Ortsbezirk)"@de .
+
+:n138010770107  a       skos:Concept ;
+        skos:broader    :n13801077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweifeld"@de .
+
+:n13104208  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spessart"@de .
+
+:n23205  a              skos:Concept ;
+        skos:broader    :n232 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Südeifel, Verbandsgemeinde"@de .
+
+:n233062270108  a       skos:Concept ;
+        skos:broader    :n23306227 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weißenseifen"@de .
+
+:n137092190104  a       skos:Concept ;
+        skos:broader    :n13709219 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfaffenheck"@de .
+
+:n331060730100  a       skos:Concept ;
+        skos:broader    :n33106073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rommersheim (Ortsbezirk)"@de .
+
+:n23205128  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Uppershausen"@de .
+
+:n23208098  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberweiler"@de .
+
+:n33202015  a           skos:Concept ;
+        skos:broader    :n33202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erpolzheim"@de .
+
+:n13402053  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meckenbach"@de .
+
+:n131020020200  a       skos:Concept ;
+        skos:broader    :n13102002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brück"@de .
+
+:n33609101  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wahnwegen"@de .
+
+:n33105070  a           skos:Concept ;
+        skos:broader    :n33105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wendelsheim"@de .
+
+:n33307014  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dielkirchen"@de .
+
+:n13102040  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchsahr"@de .
+
+:n23108104  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pantenburg"@de .
+
+:n33502007  a           skos:Concept ;
+        skos:broader    :n33502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fischbach"@de .
+
+:n33609016  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dittweiler"@de .
+
+:n235081490200  a       skos:Concept ;
+        skos:broader    :n23508149 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Söst (Ortsbezirk)"@de .
+
+:n141110890101  a       skos:Concept ;
+        skos:broader    :n14111089 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bonscheuer"@de .
+
+:n13310102  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Staudernheim"@de .
+
+:n132070370103  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Busenbach"@de .
+
+:n23208077  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meckel"@de .
+
+:n13802024  a           skos:Concept ;
+        skos:broader    :n13802 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hammerstein"@de .
+
+:n231001340300  a       skos:Concept ;
+        skos:broader    :n23100134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lüxem (Ortsbezirk)"@de .
+
+:n13503089  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiler"@de .
+
+:n14004129  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rödern"@de .
+
+:n33307072  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sitters"@de .
+
+:n23508154  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merzkirchen"@de .
+
+:n13310017  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitenheim"@de .
+
+:n143092420103  a       skos:Concept ;
+        skos:broader    :n14309242 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hilpischmühle"@de .
+
+:n315000001300  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altstadt (Ortsbezirk)"@de .
+
+:n34009051  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thaleischweiler-Fröschen"@de .
+
+:n131000700701  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Insel Nonnenwerth"@de .
+
+:n33303501  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zellertal"@de .
+
+:n140090430200  a       skos:Concept ;
+        skos:broader    :n14009043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obergondershausen"@de .
+
+:n13502011  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brachtendorf"@de .
+
+:n143092890201  a       skos:Concept ;
+        skos:broader    :n14309289 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Himburg"@de .
+
+:n235081190102  a       skos:Concept ;
+        skos:broader    :n23508119 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Heid, Hof"@de .
+
+:n23504100  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ollmuth"@de .
+
+:n233060760400  a       skos:Concept ;
+        skos:broader    :n23306076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Üxheim-Ahütte (Ortsbezirk)"@de .
+
+:n33510029  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederkirchen"@de .
+
+:n340010020101  a       skos:Concept ;
+        skos:broader    :n34001002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bärenbrunnerhof"@de .
+
+:n4     a               skos:Concept ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Historische Territorien und Gebiete"@de .
+
+:n143012060300  a       skos:Concept ;
+        skos:broader    :n14301206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenbach"@de .
+
+:n14308239  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herschbach (Oberwesterwald)"@de .
+
+:n23304218  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kelberg"@de .
+
+:n13402011  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Börfink"@de .
+
+:n33307051  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedermoschel"@de .
+
+:n13709215  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Macken"@de .
+
+:n14310081  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wirges, Stadt"@de .
+
+:n335100290101  a       skos:Concept ;
+        skos:broader    :n33510029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holbornerhof"@de .
+
+:n231080010103  a       skos:Concept ;
+        skos:broader    :n23108001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchhof"@de .
+
+:n13301045  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochstätten"@de .
+
+:n34006054  a           skos:Concept ;
+        skos:broader    :n34006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldfischbach-Burgalben"@de .
+
+:n340092190101  a       skos:Concept ;
+        skos:broader    :n34009219 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchenarnbach"@de .
+
+:n23208120  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sefferweich"@de .
+
+:n138030120100  a       skos:Concept ;
+        skos:broader    :n13803012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brückrachdorf (Ortsbezirk)"@de .
+
+:n131042020200  a       skos:Concept ;
+        skos:broader    :n13104202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lützingen"@de .
+
+:n23208035  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Etteldorf"@de .
+
+:n23205059  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hüttingen bei Lahr"@de .
+
+:n336100550100  a       skos:Concept ;
+        skos:broader    :n33610055 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bledesbach (Ortsbezirk)"@de .
+
+:n211000000303  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bahnhof Ehrang"@de .
+
+:n23206207  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brandscheid"@de .
+
+:n337010240104  a       skos:Concept ;
+        skos:broader    :n33701024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vogelstockerhof"@de .
+
+:n14310060  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ötzingen"@de .
+
+:n13309202  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kellenbach"@de .
+
+:n235061250100  a       skos:Concept ;
+        skos:broader    :n23506125 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Issel (Ortsbezirk)"@de .
+
+:n33609032  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gries"@de .
+
+:n336080750100  a       skos:Concept ;
+        skos:broader    :n33608075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hundheim"@de .
+
+:n23306083  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiesbaum"@de .
+
+:n138010030315  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krumscheid"@de .
+
+:n13505  a              skos:Concept ;
+        skos:broader    :n135 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zell (Mosel), Verbandsgemeinde"@de .
+
+:n231095010100  a       skos:Concept ;
+        skos:broader    :n23109501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beuren"@de .
+
+:n4118625n4  a          skos:Concept ;
+        skos:broader    :n16 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sickinger Höhe"@de .
+
+:n13206010  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bitzen"@de .
+
+:n138050140103  a       skos:Concept ;
+        skos:broader    :n13805014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Werlenbach"@de .
+
+:n312000000500  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erlenbach (Ortsbezirk)"@de .
+
+:n140091330100  a       skos:Concept ;
+        skos:broader    :n14009133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biebernheim (Ortsbezirk)"@de .
+
+:n23306004  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berlingen"@de .
+
+:n14004145  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sohren"@de .
+
+:n23206265  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Masthorn"@de .
+
+:n23208014  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bickendorf"@de .
+
+:n235081540600  a       skos:Concept ;
+        skos:broader    :n23508154 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rommelfangen (Ortsbezirk)"@de .
+
+:n33106064  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Udenheim"@de .
+
+:n143062560200  a       skos:Concept ;
+        skos:broader    :n14306256 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Löhnfeld"@de .
+
+:n13301003  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenbamberg"@de .
+
+:n34006012  a           skos:Concept ;
+        skos:broader    :n34006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geiselberg"@de .
+
+:n33609011  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brücken (Pfalz)"@de .
+
+:n34003036  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obersimten"@de .
+
+:n320000000112  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rothenbergerhof"@de .
+
+:n33401036  a           skos:Concept ;
+        skos:broader    :n33401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zeiskam"@de .
+
+:n23205102  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Utscheid"@de .
+
+:n23205096  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obergeckler"@de .
+
+:n23304234  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Retterath"@de .
+
+:n13709231  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolken"@de .
+
+:n137030070104  a       skos:Concept ;
+        skos:broader    :n13703007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelbaar"@de .
+
+:n134000451103  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederreidenbacherhof, Heil-und Pflegeanstalt"@de .
+
+:n340090510202  a       skos:Concept ;
+        skos:broader    :n34009051 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biebermühle"@de .
+
+:n13503005  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auderath"@de .
+
+:n333070370101  a       skos:Concept ;
+        skos:broader    :n33307037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kolbenmühle"@de .
+
+:n235071110400  a       skos:Concept ;
+        skos:broader    :n23507111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Olk (Ortsbezirk)"@de .
+
+:n133090460201  a       skos:Concept ;
+        skos:broader    :n13309046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Karlshof"@de .
+
+:n138000450600  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Irlich (Ortsbezirk)"@de .
+
+:n23201258  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lauperath"@de .
+
+:n211000001403  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trimmelterberg"@de .
+
+:n33206022  a           skos:Concept ;
+        skos:broader    :n33206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gönnheim"@de .
+
+:n23306041  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lissendorf"@de .
+
+:n335110470120  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiherfelderhof"@de .
+
+:n4049803n7  a          skos:Concept ;
+        skos:broader    :n50 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Mosel-Département"@de .
+
+:n4090730n2  a          skos:Concept ;
+        skos:broader    :n14 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Deutsche Weinstraße"@de .
+
+:n23504010  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bonerath"@de .
+
+:n336101060101  a       skos:Concept ;
+        skos:broader    :n33610106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sulzbacher Hof"@de .
+
+:n23304213  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gunderath"@de .
+
+:n14303032  a           skos:Concept ;
+        skos:broader    :n14303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höhr-Grenzhausen, Stadt"@de .
+
+:n13210109  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stürzelbach"@de .
+
+:n23206223  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fleringen"@de .
+
+:n00Sn02s0016a  a       skos:Concept ;
+        skos:broader    :n18 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unteres Nahebergland"@de .
+
+:n231085040100  a       skos:Concept ;
+        skos:broader    :n23108504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Greverath"@de .
+
+:n340060540105  a       skos:Concept ;
+        skos:broader    :n34006054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Moschelmühle"@de .
+
+:n23201322  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waxweiler"@de .
+
+:n14003502  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lahr"@de .
+
+:n333060330101  a       skos:Concept ;
+        skos:broader    :n33306033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langheckerhof"@de .
+
+:n33103046  a           skos:Concept ;
+        skos:broader    :n33103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mölsheim"@de .
+
+:n231080260104  a       skos:Concept ;
+        skos:broader    :n23108026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haus Bergfeld"@de .
+
+:n133100760106  a       skos:Concept ;
+        skos:broader    :n13310076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heddarterhof"@de .
+
+:n23508043  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hentern"@de .
+
+:n23501092  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Naurath (Wald)"@de .
+
+:n231090040200  a       skos:Concept ;
+        skos:broader    :n23109004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Olkenbach (Ortsbezirk)"@de .
+
+:n332050160104  a       skos:Concept ;
+        skos:broader    :n33205016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sattelmühle"@de .
+
+:n23108051  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heidweiler"@de .
+
+:n340040320102  a       skos:Concept ;
+        skos:broader    :n34004032 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hombrunnerhof"@de .
+
+:n132060960105  a       skos:Concept ;
+        skos:broader    :n13206096 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oettershagen"@de .
+
+:n133110350100  a       skos:Concept ;
+        skos:broader    :n13311035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heddesheim"@de .
+
+:n340030280109  a       skos:Concept ;
+        skos:broader    :n34003028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stephanshof"@de .
+
+:n13702089  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Polch, Stadt"@de .
+
+:n132080080111  a       skos:Concept ;
+        skos:broader    :n13208008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Honigsessen"@de .
+
+:n33406  a              skos:Concept ;
+        skos:broader    :n334 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rülzheim, Verbandsgemeinde"@de .
+
+:n23208030  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehlenz"@de .
+
+:n333070650102  a       skos:Concept ;
+        skos:broader    :n33307065 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ober-Tierwasen"@de .
+
+:n23206202  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auw bei Prüm"@de .
+
+:n23201301  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roscheid"@de .
+
+:n13405052  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mackenrodt"@de .
+
+:n335080380100  a       skos:Concept ;
+        skos:broader    :n33508038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Miesenbach"@de .
+
+:n34003052  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trulben"@de .
+
+:n231085030202  a       skos:Concept ;
+        skos:broader    :n23108503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hof Hau"@de .
+
+:n138010030310  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalscheid"@de .
+
+:n335010030300  a       skos:Concept ;
+        skos:broader    :n33501003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elschbacherhof"@de .
+
+:n23109029  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Enkirch"@de .
+
+:n13803034  a           skos:Concept ;
+        skos:broader    :n13803 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinmaischeid"@de .
+
+:n14307044  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienrachdorf"@de .
+
+:n14008115  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oppertshausen"@de .
+
+:n338070230100  a       skos:Concept ;
+        skos:broader    :n33807023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berghausen"@de .
+
+:n23106202  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breit"@de .
+
+:n23205033  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ernzen"@de .
+
+:n23508  a              skos:Concept ;
+        skos:broader    :n235 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saarburg-Kell, Verbandsgemeinde"@de .
+
+:n333075020305  a       skos:Concept ;
+        skos:broader    :n33307502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Inkeltalerhof"@de .
+
+:n33405006  a           skos:Concept ;
+        skos:broader    :n33405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freisbach"@de .
+
+:n13306115  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winterbach"@de .
+
+:n14309249  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kölbingen"@de .
+
+:n132100810103  a       skos:Concept ;
+        skos:broader    :n13210081 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedererbach"@de .
+
+:n13400045  a           skos:Concept ;
+        skos:broader    :n134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Idar-Oberstein, große kreisangehörige Stadt"@de .
+
+:n140035020101  a       skos:Concept ;
+        skos:broader    :n14003502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lahrer Mühle"@de .
+
+:n141070350101  a       skos:Concept ;
+        skos:broader    :n14107035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrer Bachmühle"@de .
+
+:n33903046  a           skos:Concept ;
+        skos:broader    :n33903 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ober-Hilbersheim"@de .
+
+:n336090920200  a       skos:Concept ;
+        skos:broader    :n33609092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sand"@de .
+
+:n333040070102  a       skos:Concept ;
+        skos:broader    :n33304007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heubergerhof"@de .
+
+:n23205012  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berscheid"@de .
+
+:n138090760105  a       skos:Concept ;
+        skos:broader    :n13809076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienhaus, Kloster"@de .
+
+:n339010620204  a       skos:Concept ;
+        skos:broader    :n33901062 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jagdhaus Marbach"@de .
+
+:n33107037  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gundheim"@de .
+
+:n235041070102  a       skos:Concept ;
+        skos:broader    :n23504107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geizenburg"@de .
+
+:n135050040102  a       skos:Concept ;
+        skos:broader    :n13505004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pulgersmühle"@de .
+
+:n132070720104  a       skos:Concept ;
+        skos:broader    :n13207072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederschelderhütte"@de .
+
+:n13309  a              skos:Concept ;
+        skos:broader    :n133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirner Land, Verbandsgemeinde"@de .
+
+:n34008212  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Käshofen"@de .
+
+:n23201253  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krautscheid"@de .
+
+:n33511018  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kindsbach"@de .
+
+:n14309228  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Guckheim"@de .
+
+:n13306088  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Katharinen"@de .
+
+:n233   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vulkaneifel, Landkreis"@de .
+
+:n14304026  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heilberscheid"@de .
+
+:n13210104  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seifen"@de .
+
+:n33701081  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldrohrbach"@de .
+
+:n133110910102  a       skos:Concept ;
+        skos:broader    :n13311091 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neupfalz"@de .
+
+:n13100090  a           skos:Concept ;
+        skos:broader    :n131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grafschaft"@de .
+
+:n333060090105  a       skos:Concept ;
+        skos:broader    :n33306009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kreuzhof"@de .
+
+:n340060540100  a       skos:Concept ;
+        skos:broader    :n34006054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burgalben"@de .
+
+:n231080800200  a       skos:Concept ;
+        skos:broader    :n23108080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedermanderscheid"@de .
+
+:n232080390103  a       skos:Concept ;
+        skos:broader    :n23208039 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Otrang"@de .
+
+:n33103041  a           skos:Concept ;
+        skos:broader    :n33103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hohen-Sülzen"@de .
+
+:n14110046  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geisig"@de .
+
+:n133105010200  a       skos:Concept ;
+        skos:broader    :n13310501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pferdsfeld"@de .
+
+:n132080800107  a       skos:Concept ;
+        skos:broader    :n13208080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ebertseifen"@de .
+
+:n34002  a              skos:Concept ;
+        skos:broader    :n340 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hauenstein, Verbandsgemeinde"@de .
+
+:n231081130200  a       skos:Concept ;
+        skos:broader    :n23108113 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Salmrohr"@de .
+
+:n48    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochstift Worms"@de .
+
+:n33401  a              skos:Concept ;
+        skos:broader    :n334 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bellheim, Verbandsgemeinde"@de .
+
+:n14309207  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bellingen"@de .
+
+:n143040130102  a       skos:Concept ;
+        skos:broader    :n14304013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Denzerheide"@de .
+
+:n13309043  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hennweiler"@de .
+
+:n135020510106  a       skos:Concept ;
+        skos:broader    :n13502051 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhof"@de .
+
+:n311000000400  a       skos:Concept ;
+        skos:broader    :n31100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörsch (Ortsbezirk)"@de .
+
+:n14304005  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Boden"@de .
+
+:n33702059  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberotterbach"@de .
+
+:n14004071  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kludenbach"@de .
+
+:n23506125  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweich, Stadt"@de .
+
+:n333020380106  a       skos:Concept ;
+        skos:broader    :n33302038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rosenthalerhof (T.a.Ortsbezirk Rosenthal)"@de .
+
+:n232062220107  a       skos:Concept ;
+        skos:broader    :n23206222 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwarzbach"@de .
+
+:n231081030200  a       skos:Concept ;
+        skos:broader    :n23108103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Osann"@de .
+
+:n14110025  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dausenau"@de .
+
+:n232063280102  a       skos:Concept ;
+        skos:broader    :n23206328 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heltenbachermühle"@de .
+
+:n14103124  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scheidt"@de .
+
+:n111000000800  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Immendorf (T.a.Ortsbezirk 1)"@de .
+
+:n339000050500  a       skos:Concept ;
+        skos:broader    :n33900005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dromersheim"@de .
+
+:n336081050100  a       skos:Concept ;
+        skos:broader    :n33608105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roßbach"@de .
+
+:n23201211  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dackscheid"@de .
+
+:n134020420100  a       skos:Concept ;
+        skos:broader    :n13402042 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hoppstädten"@de .
+
+:n336080950200  a       skos:Concept ;
+        skos:broader    :n33608095 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gumbsweiler"@de .
+
+:n33907037  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mommenheim"@de .
+
+:n27    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Untere-Saar-Tal"@de .
+
+:n13809072  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thalhausen"@de .
+
+:n132081170105  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bodenseifen"@de .
+
+:n14302235  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hattert"@de .
+
+:n23503  a              skos:Concept ;
+        skos:broader    :n235 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Konz, Verbandsgemeinde"@de .
+
+:n13210056  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Idelberg"@de .
+
+:n14004050  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Henau"@de .
+
+:n23106112  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rorodt"@de .
+
+:n133010390101  a       skos:Concept ;
+        skos:broader    :n13301039 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreiweiherhof"@de .
+
+:n232050160102  a       skos:Concept ;
+        skos:broader    :n23205016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gaybach"@de .
+
+:n23506019  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ensch"@de .
+
+:n233015010300  a       skos:Concept ;
+        skos:broader    :n23301501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neunkirchen (Ortsbezirk)"@de .
+
+:n141102010101  a       skos:Concept ;
+        skos:broader    :n14110201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bierhaus"@de .
+
+:n320000000500  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ixheim"@de .
+
+:n333070340101  a       skos:Concept ;
+        skos:broader    :n33307034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Felsbergerhof"@de .
+
+:n33903041  a           skos:Concept ;
+        skos:broader    :n33903 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nieder-Hilbersheim"@de .
+
+:n336100700101  a       skos:Concept ;
+        skos:broader    :n33610070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mayweilerhof"@de .
+
+:n33701501  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Annweiler am Trifels, Stadt"@de .
+
+:n140090450103  a       skos:Concept ;
+        skos:broader    :n14009045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrerheide"@de .
+
+:n13210035  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forstmehren"@de .
+
+:n13101026  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Harscheid"@de .
+
+:n23506077  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Longen"@de .
+
+:n235070690104  a       skos:Concept ;
+        skos:broader    :n23507069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kimmlingen"@de .
+
+:n131010370201  a       skos:Concept ;
+        skos:broader    :n13101037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herschbach"@de .
+
+:n13703105  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Virneburg"@de .
+
+:n13703099  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siebenbach"@de .
+
+:n14103076  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenscheid"@de .
+
+:n23106006  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berglicht"@de .
+
+:n14304021  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Girod"@de .
+
+:n232000180700  a       skos:Concept ;
+        skos:broader    :n23200018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stahl (Ortsbezirk)"@de .
+
+:n14111125  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schiesheim"@de .
+
+:n13210093  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reiferscheid"@de .
+
+:n33705051  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leinsweiler"@de .
+
+:n335022050101  a       skos:Concept ;
+        skos:broader    :n33502205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eichenbachermühle"@de .
+
+:n13104060  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberzissen"@de .
+
+:n13101084  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wimbach"@de .
+
+:n111000001900  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rauental"@de .
+
+:n13809030  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hümmerich"@de .
+
+:n13306004  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Argenschwang"@de .
+
+:n137025010200  a       skos:Concept ;
+        skos:broader    :n13702501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Küttig (Ortsbezirk)"@de .
+
+:n143   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westerwald-Kreis"@de .
+
+:n33107011  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochborn"@de .
+
+:n14110041  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fachbach"@de .
+
+:n13101005  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Aremberg"@de .
+
+:n231010810108  a       skos:Concept ;
+        skos:broader    :n23101081 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Noviand"@de .
+
+:n13203113  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weitefeld"@de .
+
+:n231010700100  a       skos:Concept ;
+        skos:broader    :n23101070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Emmeroth (Ortsbezirk)"@de .
+
+:n23106064  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Immert"@de .
+
+:n14306311  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Willingen"@de .
+
+:n140032020300  a       skos:Concept ;
+        skos:broader    :n14003202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eveshausen (Ortsbezirk)"@de .
+
+:n43    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erzstift Mainz"@de .
+
+:n33907053  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Selzen"@de .
+
+:n335100350113  a       skos:Concept ;
+        skos:broader    :n33510035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Messerschwanderhof"@de .
+
+:n137072260107  a       skos:Concept ;
+        skos:broader    :n13707226 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mallendar"@de .
+
+:n138000451000  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodenbach (Ortsbezirk)"@de .
+
+:n23503144  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wawern"@de .
+
+:n23506120  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schleich"@de .
+
+:n33610039  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herchweiler"@de .
+
+:n232062220102  a       skos:Concept ;
+        skos:broader    :n23206222 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gesotz"@de .
+
+:n141090160103  a       skos:Concept ;
+        skos:broader    :n14109016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Loreley"@de .
+
+:n133110950107  a       skos:Concept ;
+        skos:broader    :n13311095 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienborn"@de .
+
+:n33406016  a           skos:Concept ;
+        skos:broader    :n33406 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leimersheim"@de .
+
+:n211000000601  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Estricherhof"@de .
+
+:n135030830102  a       skos:Concept ;
+        skos:broader    :n13503083 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forsthaus Hochpochten"@de .
+
+:n143022940102  a       skos:Concept ;
+        skos:broader    :n14302294 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seeburg"@de .
+
+:n33201017  a           skos:Concept ;
+        skos:broader    :n33201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forst an der Weinstraße"@de .
+
+:n13505088  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Walhausen"@de .
+
+:n14009104  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederburg"@de .
+
+:n22    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelrhein-Gebiet"@de .
+
+:n33610103  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welchweiler"@de .
+
+:n33610097  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thallichtenberg"@de .
+
+:n14107009  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berg"@de .
+
+:n138010440300  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rahms"@de .
+
+:n13803  a              skos:Concept ;
+        skos:broader    :n138 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dierdorf, Verbandsgemeinde"@de .
+
+:n13210051  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heupelzen"@de .
+
+:n133110250102  a       skos:Concept ;
+        skos:broader    :n13311025 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gollenfels, Burg"@de .
+
+:n4060881n5  a          skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Regierungsbezirk Trier (1946-1999)"@de .
+
+:n137030740104  a       skos:Concept ;
+        skos:broader    :n13703074 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Müsch"@de .
+
+:n13311114  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Windesheim"@de .
+
+:n337060520100  a       skos:Concept ;
+        skos:broader    :n33706052 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alsterweiler"@de .
+
+:n14008020  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bubach"@de .
+
+:n13101042  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kottenborn"@de .
+
+:n33610018  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehweiler"@de .
+
+:n34009222  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rieschweiler-Mühlbach"@de .
+
+:n233060260600  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lissingen (Ortsbezirk)"@de .
+
+:n134050370102  a       skos:Concept ;
+        skos:broader    :n13405037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hammerbirkenfeld"@de .
+
+:n14107067  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kasdorf"@de .
+
+:n33205  a              skos:Concept ;
+        skos:broader    :n332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lambrecht (Pfalz), Verbandsgemeinde"@de .
+
+:n231005020400  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gutenthal (Ortsbezirk)"@de .
+
+:n4639983n5  a          skos:Concept ;
+        skos:broader    :n24 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obermosel-Gebiet"@de .
+
+:n33907011  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dexheim"@de .
+
+:n01    a               skos:Concept ;
+        skos:broader    :n1 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinland-Pfalz"@de .
+
+:n13703036  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirten"@de .
+
+:n131020030200  a       skos:Concept ;
+        skos:broader    :n13102003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kreuzberg (Ortsbezirk)"@de .
+
+:n13311087  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rümmelsheim"@de .
+
+:n143022870104  a       skos:Concept ;
+        skos:broader    :n14302287 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roßbacher Mühle"@de .
+
+:n319000000400  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herrnsheim (Ortsbezirk)"@de .
+
+:n13101021  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eichenbach"@de .
+
+:n23503096  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberbillig"@de .
+
+:n14107131  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Strüth"@de .
+
+:n23100134  a           skos:Concept ;
+        skos:broader    :n231 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wittlich, Stadt"@de .
+
+:n13805059  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Raubach"@de .
+
+:n33908068  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zotzenheim"@de .
+
+:n134000450800  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nahbollenbach"@de .
+
+:n33703069  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roschbach"@de .
+
+:n33901038  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münster-Sarmsheim"@de .
+
+:n33610055  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kusel,Stadt"@de .
+
+:n132100850103  a       skos:Concept ;
+        skos:broader    :n13210085 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heiderhof"@de .
+
+:n33307201  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rathskirchen"@de .
+
+:n316000000705  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lachener Holzweg"@de .
+
+:n14107110  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hainau"@de .
+
+:n14307305  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weidenhahn"@de .
+
+:n34001002  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Busenberg"@de .
+
+:n333040460101  a       skos:Concept ;
+        skos:broader    :n33304046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daimbacherhof"@de .
+
+:n23301052  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederstadtfeld"@de .
+
+:n111000000100  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arenberg (T.a.Ortsbezirk 1)"@de .
+
+:n132060340103  a       skos:Concept ;
+        skos:broader    :n13206034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaltau"@de .
+
+:n232063290303  a       skos:Concept ;
+        skos:broader    :n23206329 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elcherath"@de .
+
+:n141035030201  a       skos:Concept ;
+        skos:broader    :n14103503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Talhof"@de .
+
+:n135010200103  a       skos:Concept ;
+        skos:broader    :n13501020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Cond"@de .
+
+:n137072260102  a       skos:Concept ;
+        skos:broader    :n13707226 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bembermühle"@de .
+
+:n332050140107  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hornesselwiese"@de .
+
+:n14111093  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Netzbach"@de .
+
+:n33703048  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinfischlingen"@de .
+
+:n13209066  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Malberg"@de .
+
+:n131000070600  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lohrsdorf (Ortsbezirk)"@de .
+
+:n33610034  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haschbach am Remigiusberg"@de .
+
+:n231005021500  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rapperath (Ortsbezirk)"@de .
+
+:n232062020300  a       skos:Concept ;
+        skos:broader    :n23206202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schlausenbach"@de .
+
+:n33704  a              skos:Concept ;
+        skos:broader    :n337 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herxheim , Verbandsgemeinde"@de .
+
+:n13804501  a           skos:Concept ;
+        skos:broader    :n13804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kasbach-Ohlenberg"@de .
+
+:n138010800204  a       skos:Concept ;
+        skos:broader    :n13801080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberscheid"@de .
+
+:n131000900600  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Karweiler (Ortsbezirk)"@de .
+
+:n235071510101  a       skos:Concept ;
+        skos:broader    :n23507151 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daufenbach (Ortsbezirk)"@de .
+
+:n33406011  a           skos:Concept ;
+        skos:broader    :n33406 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hördt"@de .
+
+:n23301031  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hörscheid"@de .
+
+:n319000001500  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiesoppenheim (Ortsbezirk)"@de .
+
+:n14003147  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Spesenroth"@de .
+
+:n14009093  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mermuth"@de .
+
+:n33703027  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freimersheim (Pfalz)"@de .
+
+:n13505004  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altstrimmig"@de .
+
+:n13502028  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eulgem"@de .
+
+:n33306011  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breunigweiler"@de .
+
+:n14009014  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bickenbach"@de .
+
+:n13102036  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalenborn"@de .
+
+:n338000040201  a       skos:Concept ;
+        skos:broader    :n33800004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scharrau"@de .
+
+:n33608013  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Cronenberg"@de .
+
+:n33101012  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bornheim"@de .
+
+:n233062140105  a       skos:Concept ;
+        skos:broader    :n23306214 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zur Kehr"@de .
+
+:n137000030300  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kell (Ortsbezirk)"@de .
+
+:n33307068  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönborn"@de .
+
+:n23507151  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zemmer"@de .
+
+:n33610071  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberstaufenbach"@de .
+
+:n235081180306  a       skos:Concept ;
+        skos:broader    :n23508118 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederleuken"@de .
+
+:n337050730101  a       skos:Concept ;
+        skos:broader    :n33705073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geilweilerhof, Rebschule"@de .
+
+:n14111051  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahnstätten"@de .
+
+:n111000001200  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lützel"@de .
+
+:n13209024  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elben"@de .
+
+:n235010930102  a       skos:Concept ;
+        skos:broader    :n23501093 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Muhl (ehemals Gemeinde Börfink-Muhl)"@de .
+
+:n34001501  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruchweiler-Bärenbach"@de .
+
+:n132070630300  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katzenbach (Ortsbezirk)"@de .
+
+:n23208137  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolsfeld"@de .
+
+:n332000020118  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Limburg"@de .
+
+:n138010770204  a       skos:Concept ;
+        skos:broader    :n13801077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Johannisberg"@de .
+
+:n13505041  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hesweiler"@de .
+
+:n141091210200  a       skos:Concept ;
+        skos:broader    :n14109121 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wellmich"@de .
+
+:n132090710102  a       skos:Concept ;
+        skos:broader    :n13209071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seifen"@de .
+
+:n23205225  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gilzem"@de .
+
+:n317000000100  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erlenbrunn (Ortsbezirk)"@de .
+
+:n235030680501  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Karthaus"@de .
+
+:n33608050  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirrweiler"@de .
+
+:n316000000700  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hambach (Ortsbezirk)"@de .
+
+:n141070850103  a       skos:Concept ;
+        skos:broader    :n14107085 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hof Aftholderbach"@de .
+
+:n232080600101  a       skos:Concept ;
+        skos:broader    :n23208060 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meilbrück"@de .
+
+:n33509049  a           skos:Concept ;
+        skos:broader    :n33509 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weilerbach"@de .
+
+:n332050140102  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Appenthal"@de .
+
+:n13502044  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kail"@de .
+
+:n333070140103  a       skos:Concept ;
+        skos:broader    :n33307014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hoferhof"@de .
+
+:n23108116  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwarzenborn"@de .
+
+:n13103  a              skos:Concept ;
+        skos:broader    :n131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Breisig, Verbandsgemeinde"@de .
+
+:n331060040200  a       skos:Concept ;
+        skos:broader    :n33106004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schimsheim"@de .
+
+:n333060200103  a       skos:Concept ;
+        skos:broader    :n33306020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merzauerhof"@de .
+
+:n131030060106  a       skos:Concept ;
+        skos:broader    :n13103006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wohnplatz Weiler"@de .
+
+:n4221819n6  a          skos:Concept ;
+        skos:broader    :n22 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelrheintal / Süd"@de .
+
+:n232012630200  a       skos:Concept ;
+        skos:broader    :n23201263 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stupbach"@de .
+
+:n143092420200  a       skos:Concept ;
+        skos:broader    :n14309242 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhochstein"@de .
+
+:n337030200102  a       skos:Concept ;
+        skos:broader    :n33703020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ludwigshöhe"@de .
+
+:n137020860116  a       skos:Concept ;
+        skos:broader    :n13702086 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldorferhof"@de .
+
+:n141030300101  a       skos:Concept ;
+        skos:broader    :n14103030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bergerhof"@de .
+
+:n33307084  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Würzweiler"@de .
+
+:n133060990101  a       skos:Concept ;
+        skos:broader    :n13306099 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Aschbornerhof"@de .
+
+:n33908021  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gensingen"@de .
+
+:n211000001505  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kockelsberg"@de .
+
+:n13301078  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfaffen-Schwabenheim"@de .
+
+:n131042080103  a       skos:Concept ;
+        skos:broader    :n13104208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wollscheid"@de .
+
+:n13502023  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Düngenheim"@de .
+
+:n13805070  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steimel"@de .
+
+:n23306058  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rockeskyll"@de .
+
+:n13402023  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellenberg"@de .
+
+:n337010010101  a       skos:Concept ;
+        skos:broader    :n33701001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenscheiderhof"@de .
+
+:n13709227  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldesch"@de .
+
+:n134000450100  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Enzweiler"@de .
+
+:n34009042  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schauerberg"@de .
+
+:n23504085  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mertesdorf"@de .
+
+:n132070370152  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmalenbach"@de .
+
+:n33508  a              skos:Concept ;
+        skos:broader    :n335 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ramstein-Miesenbach, Verbandsgemeinde"@de .
+
+:n133000060500  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winzenheim (Ortsbezirk)"@de .
+
+:n140030100400  a       skos:Concept ;
+        skos:broader    :n14003010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mannebach (Ortsbezirk)"@de .
+
+:n211000000400  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eitelsbach (T.a. Ortsbezirk 7)"@de .
+
+:n335110470116  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhammer"@de .
+
+:n140005010600  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holzfeld (Ortsbezirk)"@de .
+
+:n23206304  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönecken"@de .
+
+:n13310066  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merxheim"@de .
+
+:n14301279  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nistertal"@de .
+
+:n332000020113  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kehr dich an nichts, Forsthaus"@de .
+
+:n143012790201  a       skos:Concept ;
+        skos:broader    :n14301279 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auf dem Birkenhof"@de .
+
+:n13402002  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Achtelsbach"@de .
+
+:n335010030402  a       skos:Concept ;
+        skos:broader    :n33501003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schanzerhof"@de .
+
+:n13709206  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burgen"@de .
+
+:n233060261000  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roth (Ortsbezirk)"@de .
+
+:n336090110103  a       skos:Concept ;
+        skos:broader    :n33609011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neumühle"@de .
+
+:n13405069  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhaunen"@de .
+
+:n23208111  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Röhl"@de .
+
+:n233042180500  a       skos:Concept ;
+        skos:broader    :n23304218 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zermüllen (Ortsbezirk)"@de .
+
+:n339010440102  a       skos:Concept ;
+        skos:broader    :n33901044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheindiebach"@de .
+
+:n231091240300  a       skos:Concept ;
+        skos:broader    :n23109124 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolf (Ortsbezirk)"@de .
+
+:n137000030104  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienstätterhof"@de .
+
+:n23208026  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dockendorf"@de .
+
+:n235070940100  a       skos:Concept ;
+        skos:broader    :n23507094 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beßlich (Ortsbezirk)"@de .
+
+:n233062320101  a       skos:Concept ;
+        skos:broader    :n23306232 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuenstein"@de .
+
+:n134020850104  a       skos:Concept ;
+        skos:broader    :n13402085 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sonnenberg"@de .
+
+:n340030260102  a       skos:Concept ;
+        skos:broader    :n34003026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stausteinerhof"@de .
+
+:n335100130103  a       skos:Concept ;
+        skos:broader    :n33510013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rohmühle"@de .
+
+:n33902006  a           skos:Concept ;
+        skos:broader    :n33902 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bodenheim"@de .
+
+:n33307021  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Finkenbach-Gersweiler"@de .
+
+:n14003073  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Korweiler"@de .
+
+:n33304045  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marnheim"@de .
+
+:n314000000400  a       skos:Concept ;
+        skos:broader    :n31400000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mundenheim (Ortsbezirk)"@de .
+
+:n23108111  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rivenich"@de .
+
+:n235010470200  a       skos:Concept ;
+        skos:broader    :n23501047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pölert"@de .
+
+:n34003048  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweix"@de .
+
+:n138010030306  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrenstein"@de .
+
+:n338000170105  a       skos:Concept ;
+        skos:broader    :n33800017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kohlhof"@de .
+
+:n23205114  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schankweiler"@de .
+
+:n23108026  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eisenschmitt"@de .
+
+:n23101075  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lieser"@de .
+
+:n335110450104  a       skos:Concept ;
+        skos:broader    :n33511045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horst, Forsthaus"@de .
+
+:n135050920100  a       skos:Concept ;
+        skos:broader    :n13505092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaimt"@de .
+
+:n141101060101  a       skos:Concept ;
+        skos:broader    :n14110106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörstheck"@de .
+
+:n141031330101  a       skos:Concept ;
+        skos:broader    :n14103133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Habenscheid"@de .
+
+:n131045020100  a       skos:Concept ;
+        skos:broader    :n13104502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Engeln (Ortsbezirk)"@de .
+
+:n23106  a              skos:Concept ;
+        skos:broader    :n231 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thalfang am Erbeskopf, Verbandsgemeinde"@de .
+
+:n13310024  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Desloch"@de .
+
+:n23206256  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lasel"@de .
+
+:n211000001500  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pallien (T.a. Ortsbezirk 8)"@de .
+
+:n13103025  a           skos:Concept ;
+        skos:broader    :n13103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gönnersdorf"@de .
+
+:n132060380103  a       skos:Concept ;
+        skos:broader    :n13206038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oppertsau"@de .
+
+:n335   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaiserslautern, Landkreis"@de .
+
+:n23306053  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberbettingen"@de .
+
+:n23206320  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Watzerath"@de .
+
+:n13310082  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rehbach"@de .
+
+:n00Sn02t0429a  a       skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kyllwald"@de .
+
+:n23304225  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mannebach"@de .
+
+:n14307019  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freirachdorf"@de .
+
+:n338010140100  a       skos:Concept ;
+        skos:broader    :n33801014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Assenheim"@de .
+
+:n23508140  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vierherrenborn"@de .
+
+:n138030230200  a       skos:Concept ;
+        skos:broader    :n13803023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kausen (Ortsbezirk)"@de .
+
+:n335010110102  a       skos:Concept ;
+        skos:broader    :n33501011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scharrmühle"@de .
+
+:n23205008  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bauler"@de .
+
+:n14301216  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreisbach"@de .
+
+:n131000901000  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ringen (Ortsbezirk)"@de .
+
+:n137030490200  a       skos:Concept ;
+        skos:broader    :n13703049 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldesch"@de .
+
+:n131020400102  a       skos:Concept ;
+        skos:broader    :n13102040 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burgsahr"@de .
+
+:n13207037  a           skos:Concept ;
+        skos:broader    :n13207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Friesenhagen"@de .
+
+:n23504080  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lorscheid"@de .
+
+:n14109114  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reichenberg"@de .
+
+:n34008208  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dietrichingen"@de .
+
+:n13405006  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bergen"@de .
+
+:n33206013  a           skos:Concept ;
+        skos:broader    :n33206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellerstadt"@de .
+
+:n334005010301  a       skos:Concept ;
+        skos:broader    :n33400501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schaidter Mühle"@de .
+
+:n14008148  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinbach"@de .
+
+:n335110470111  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lauberhof"@de .
+
+:n315000000600  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gonsenheim (Ortsbezirk)"@de .
+
+:n23205066  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Keppeshausen"@de .
+
+:n14110127  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweighausen"@de .
+
+:n13709201  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alken"@de .
+
+:n111000000902  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forsthaus Remstecken"@de .
+
+:n336081050202  a       skos:Concept ;
+        skos:broader    :n33608105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reckweilerhof"@de .
+
+:n13301031  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frei-Laubersheim"@de .
+
+:n13405064  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhosenbach"@de .
+
+:n143022290100  a       skos:Concept ;
+        skos:broader    :n14302229 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altstadt (Ortsbezirk)"@de .
+
+:n138020380106  a       skos:Concept ;
+        skos:broader    :n13802038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Windhausen"@de .
+
+:n13104210  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wehr"@de .
+
+:n331000030500  a       skos:Concept ;
+        skos:broader    :n33100003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weinheim (Ortsbezirk)"@de .
+
+:n336080950302  a       skos:Concept ;
+        skos:broader    :n33608095 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obereisenbach"@de .
+
+:n14003010  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beltheim"@de .
+
+:n13100007  a           skos:Concept ;
+        skos:broader    :n131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Neuenahr-Ahrweiler, Stadt"@de .
+
+:n132100230101  a       skos:Concept ;
+        skos:broader    :n13210023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gollershoben"@de .
+
+:n23205130  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldhof-Falkenstein"@de .
+
+:n233010340101  a       skos:Concept ;
+        skos:broader    :n23301034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heckenmühle"@de .
+
+:n14307056  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nordhofen"@de .
+
+:n23206272  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuendorf"@de .
+
+:n14008127  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Riesweiler"@de .
+
+:n339000300300  a       skos:Concept ;
+        skos:broader    :n33900030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heidesheim am Rhein"@de .
+
+:n231011360104  a       skos:Concept ;
+        skos:broader    :n23101136 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zeltingen (Ortsbezirk)"@de .
+
+:n132080540109  a       skos:Concept ;
+        skos:broader    :n13208054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siegenthal"@de .
+
+:n13701081  a           skos:Concept ;
+        skos:broader    :n13701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nickenich"@de .
+
+:n132080080102  a       skos:Concept ;
+        skos:broader    :n13208008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birken"@de .
+
+:n14301253  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenbach bei Kirburg"@de .
+
+:n23101012  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brauneberg"@de .
+
+:n138090530102  a       skos:Concept ;
+        skos:broader    :n13809053 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gierenderhöhe"@de .
+
+:n131042020101  a       skos:Concept ;
+        skos:broader    :n13104202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Tönisstein"@de .
+
+:n14110106  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwies"@de .
+
+:n33304040  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kriegsfeld"@de .
+
+:n231091240210  a       skos:Concept ;
+        skos:broader    :n23109124 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rißbach"@de .
+
+:n14004067  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchberg (Hunsrück), Stadt"@de .
+
+:n33609501  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Quirnbach (Pfalz)"@de .
+
+:n140090360103  a       skos:Concept ;
+        skos:broader    :n14009036 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Liesenfeld"@de .
+
+:n13405043  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horbruch"@de .
+
+:n23108504  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niersbach"@de .
+
+:n138010030301  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenburg"@de .
+
+:n134020940201  a       skos:Concept ;
+        skos:broader    :n13402094 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wilzenberg"@de .
+
+:n340020570103  a       skos:Concept ;
+        skos:broader    :n34002057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hermersbergerhof (Ortsbezirk)"@de .
+
+:n33405018  a           skos:Concept ;
+        skos:broader    :n33405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lustadt"@de .
+
+:n14109066  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kamp-Bornhofen"@de .
+
+:n23108021  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dierfeld"@de .
+
+:n23101070  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinich"@de .
+
+:n13503091  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wollmerath"@de .
+
+:n14008106  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederkumbd"@de .
+
+:n33509501  a           skos:Concept ;
+        skos:broader    :n33509 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reichenbach-Steegen"@de .
+
+:n23101  a              skos:Concept ;
+        skos:broader    :n231 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bernkastel-Kues, Verbandsgemeinde"@de .
+
+:n138070190200  a       skos:Concept ;
+        skos:broader    :n13807019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Orsberg"@de .
+
+:n133061150103  a       skos:Concept ;
+        skos:broader    :n13306115 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kuhpferch"@de .
+
+:n33107049  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Monzernheim"@de .
+
+:n235030680300  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Könen (Ortsbezirk 2)"@de .
+
+:n315000001700  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Layenhof"@de .
+
+:n235070730400  a       skos:Concept ;
+        skos:broader    :n23507073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Metzdorf (Ortsbezirk)"@de .
+
+:n141100910300  a       skos:Concept ;
+        skos:broader    :n14110091 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scheuern"@de .
+
+:n333070040105  a       skos:Concept ;
+        skos:broader    :n33307004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stolzenbergerhof"@de .
+
+:n13210201  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berod bei Hachenburg"@de .
+
+:n141030290200  a       skos:Concept ;
+        skos:broader    :n14103029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freiendiez"@de .
+
+:n140041630101  a       skos:Concept ;
+        skos:broader    :n14004163 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallenbrück"@de .
+
+:n138090060112  a       skos:Concept ;
+        skos:broader    :n13809006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hollig"@de .
+
+:n335090060102  a       skos:Concept ;
+        skos:broader    :n33509006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Untere Pfeifermühle"@de .
+
+:n131010330102  a       skos:Concept ;
+        skos:broader    :n13101033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marthel"@de .
+
+:n23205082  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Minden"@de .
+
+:n23304220  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirsbach"@de .
+
+:n13210116  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Willroth"@de .
+
+:n14008079  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laubach"@de .
+
+:n23206230  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großlangenfeld"@de .
+
+:n232012670200  a       skos:Concept ;
+        skos:broader    :n23201267 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Staudenhof"@de .
+
+:n140080700104  a       skos:Concept ;
+        skos:broader    :n14008070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kloster"@de .
+
+:n13809047  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederbreitbach"@de .
+
+:n23205003  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altscheid"@de .
+
+:n14301211  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bölsberg"@de .
+
+:n33107028  a           skos:Concept ;
+        skos:broader    :n33107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frettenheim"@de .
+
+:n14110058  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hömberg"@de .
+
+:n23109057  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hontheim"@de .
+
+:n34008203  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bechhofen"@de .
+
+:n14309298  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stockum-Püschen"@de .
+
+:n140091120306  a       skos:Concept ;
+        skos:broader    :n14009112 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönburg"@de .
+
+:n33207007  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Carlsberg"@de .
+
+:n232080090102  a       skos:Concept ;
+        skos:broader    :n23208009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berghausen"@de .
+
+:n138030120500  a       skos:Concept ;
+        skos:broader    :n13803012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wienau (Ortsbezirk)"@de .
+
+:n33401001  a           skos:Concept ;
+        skos:broader    :n33401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bellheim"@de .
+
+:n13702102  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trimbs"@de .
+
+:n14309219  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Enspel"@de .
+
+:n14109024  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dahlheim"@de .
+
+:n14308220  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ettinghausen"@de .
+
+:n138000450501  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Block (Ortsbezirk)"@de .
+
+:n14302268  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mündersbach"@de .
+
+:n135010170100  a       skos:Concept ;
+        skos:broader    :n13501017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruttig"@de .
+
+:n132100930101  a       skos:Concept ;
+        skos:broader    :n13210093 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krämgen"@de .
+
+:n13210089  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Peterslahr"@de .
+
+:n14008058  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horn"@de .
+
+:n33903016  a           skos:Concept ;
+        skos:broader    :n33903 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Engelstadt"@de .
+
+:n138020240103  a       skos:Concept ;
+        skos:broader    :n13802024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhammerstein"@de .
+
+:n13809026  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hardert"@de .
+
+:n312000002102  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahnbrunnerhof"@de .
+
+:n333040390113  a       skos:Concept ;
+        skos:broader    :n33304039 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ziegelhütte"@de .
+
+:n313000000300  a       skos:Concept ;
+        skos:broader    :n31300000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Godramstein (Ortsbezirk)"@de .
+
+:n132100480102  a       skos:Concept ;
+        skos:broader    :n13210048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flögert"@de .
+
+:n312000000900  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morlautern (Ortsbezirk)"@de .
+
+:n334000070200  a       skos:Concept ;
+        skos:broader    :n33400007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sondernheim (Ortsbezirk)"@de .
+
+:n33907049  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oppenheim, Stadt"@de .
+
+:n23205040  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geichlingen"@de .
+
+:n235081180100  a       skos:Concept ;
+        skos:broader    :n23508118 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kahren (Ortsbezirk)"@de .
+
+:n33705026  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frankweiler"@de .
+
+:n14004062  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kappel"@de .
+
+:n14008037  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erbach"@de .
+
+:n13809005  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bonefeld"@de .
+
+:n337020720101  a       skos:Concept ;
+        skos:broader    :n33702072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haftelhof"@de .
+
+:n138050570400  a       skos:Concept ;
+        skos:broader    :n13805057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reichenstein"@de .
+
+:n33307  a              skos:Concept ;
+        skos:broader    :n333 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nordpfälzer Land, Verbandsgemeinde"@de .
+
+:n140005011000  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiler (Ortsbezirk)"@de .
+
+:n4108082n8  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westerwälder Seenplatte"@de .
+
+:n33207044  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tiefenthal"@de .
+
+:n141031300101  a       skos:Concept ;
+        skos:broader    :n14103130 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heckelmann-Mühle"@de .
+
+:n14304054  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedererbach"@de .
+
+:n33800019  a           skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mutterstadt"@de .
+
+:n14008101  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuerkirch"@de .
+
+:n336090640100  a       skos:Concept ;
+        skos:broader    :n33609064 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dietschweiler"@de .
+
+:n13401  a              skos:Concept ;
+        skos:broader    :n134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Baumholder, Verbandsgemeinde"@de .
+
+:n18    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saar-Nahe-Bergland"@de .
+
+:n132070630407  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederasdorf"@de .
+
+:n33907028  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hillesheim"@de .
+
+:n231081170104  a       skos:Concept ;
+        skos:broader    :n23108117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wilmshof"@de .
+
+:n132100620105  a       skos:Concept ;
+        skos:broader    :n13210062 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reisbitzen"@de .
+
+:n335020260100  a       skos:Concept ;
+        skos:broader    :n33502026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Baalborn"@de .
+
+:n13210047  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Helmenzen"@de .
+
+:n33702029  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gleiszellen-Gleishorbach"@de .
+
+:n14004041  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gemünden"@de .
+
+:n23201260  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lichtenborn"@de .
+
+:n33207023  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großkarlbach"@de .
+
+:n235071370200  a       skos:Concept ;
+        skos:broader    :n23507137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sirzenich (Ortsbezirk)"@de .
+
+:n231090570108  a       skos:Concept ;
+        skos:broader    :n23109057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wispelt (Ortsbezirk)"@de .
+
+:n23106018  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Deuselbach"@de .
+
+:n13306101  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sponheim"@de .
+
+:n14304033  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holler"@de .
+
+:n333035010300  a       skos:Concept ;
+        skos:broader    :n33303501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zell (Ortsbezirk)"@de .
+
+:n134050460103  a       skos:Concept ;
+        skos:broader    :n13405046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katzenloch"@de .
+
+:n13809042  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meinborn"@de .
+
+:n14302205  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Atzelgift"@de .
+
+:n138090070115  a       skos:Concept ;
+        skos:broader    :n13809007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stopperich"@de .
+
+:n33702008  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birkenhördt"@de .
+
+:n232050670300  a       skos:Concept ;
+        skos:broader    :n23205067 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obersgegen"@de .
+
+:n138010030105  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Germscheid (ehemals Gemeinde Elsaff)"@de .
+
+:n232062260400  a       skos:Concept ;
+        skos:broader    :n23206226 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Willwerath"@de .
+
+:n140005010208  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Industriegebiet Boppard-Hellerwald"@de .
+
+:n14309293  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stahlhofen am Wiesensee"@de .
+
+:n140091120301  a       skos:Concept ;
+        skos:broader    :n14009112 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Boppard, Weiler"@de .
+
+:n137092050107  a       skos:Concept ;
+        skos:broader    :n13709205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kröpplingen"@de .
+
+:n55    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hessen-Nassau"@de .
+
+:n138070730105  a       skos:Concept ;
+        skos:broader    :n13807073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scheuren"@de .
+
+:n135010820204  a       skos:Concept ;
+        skos:broader    :n13501082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grenzhäuserhof"@de .
+
+:n13306074  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhausen an der Nahe"@de .
+
+:n33806  a              skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lambsheim-Heßheim, Verbandsgemeinde"@de .
+
+:n33705042  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ilbesheim bei Landau in der Pfalz"@de .
+
+:n235071510203  a       skos:Concept ;
+        skos:broader    :n23507151 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönfelderhof"@de .
+
+:n339010030108  a       skos:Concept ;
+        skos:broader    :n33901003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neurath (Ortsbezirk)"@de .
+
+:n13101075  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Senscheid"@de .
+
+:n134   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birkenfeld, Landkreis"@de .
+
+:n14009201  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beulich"@de .
+
+:n13210005  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berzhausen"@de .
+
+:n340082070101  a       skos:Concept ;
+        skos:broader    :n34008207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Falkenbusch"@de .
+
+:n333020190108  a       skos:Concept ;
+        skos:broader    :n33302019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinborn (Ortsbezirk)"@de .
+
+:n14306302  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waigandshain"@de .
+
+:n336095010100  a       skos:Concept ;
+        skos:broader    :n33609501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Liebsthal"@de .
+
+:n13709504  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lehmen"@de .
+
+:n14009116  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Perscheid"@de .
+
+:n34    a               skos:Concept ;
+        skos:broader    :n3 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katholische Kirche / Erzdiözese Köln"@de .
+
+:n13702070  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mertloch"@de .
+
+:n13203019  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Derschen"@de .
+
+:n137092120303  a       skos:Concept ;
+        skos:broader    :n13709212 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Belltal"@de .
+
+:n14111089  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mudershausen"@de .
+
+:n33702045  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kapellen-Drusweiler"@de .
+
+:n33302  a              skos:Concept ;
+        skos:broader    :n333 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eisenberg (Pfalz), Verbandsgemeinde"@de .
+
+:n34004032  a           skos:Concept ;
+        skos:broader    :n34004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münchweiler an der Rodalb"@de .
+
+:n132060910105  a       skos:Concept ;
+        skos:broader    :n13206091 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wickhausen"@de .
+
+:n315000001000  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienborn (Ortsbezirk)"@de .
+
+:n334005010100  a       skos:Concept ;
+        skos:broader    :n33400501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büchelberg (Ortsbezirk)"@de .
+
+:n23506026  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Föhren"@de .
+
+:n92    a               skos:Concept ;
+        skos:broader    :n5 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Main-Gebiet"@de .
+
+:n4095361n0  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hocheifel"@de .
+
+:n4069508n6  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bitburger Land"@de .
+
+:n340092150104  a       skos:Concept ;
+        skos:broader    :n34009215 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Labach"@de .
+
+:n23306229  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nohn"@de .
+
+:n133061120103  a       skos:Concept ;
+        skos:broader    :n13306112 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scholländerhof"@de .
+
+:n23304003  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beinhausen"@de .
+
+:n23301027  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gillenfeld"@de .
+
+:n231090670103  a       skos:Concept ;
+        skos:broader    :n23109067 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hetzhof (Ortsbezirk)"@de .
+
+:n233060760100  a       skos:Concept ;
+        skos:broader    :n23306076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heyroth (Ortsbezirk)"@de .
+
+:n14009089  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maisborn"@de .
+
+:n33610088  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruthweiler"@de .
+
+:n13    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mainzer Becken"@de .
+
+:n132070630402  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brühlhof"@de .
+
+:n231010080200  a       skos:Concept ;
+        skos:broader    :n23101008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bernkastel"@de .
+
+:n137020890107  a       skos:Concept ;
+        skos:broader    :n13702089 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaan"@de .
+
+:n143040710102  a       skos:Concept ;
+        skos:broader    :n14304071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berg Moriah"@de .
+
+:n14111068  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katzenelnbogen, Stadt"@de .
+
+:n13501025  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellenz-Poltersdorf"@de .
+
+:n14008011  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Benzweiler"@de .
+
+:n13101033  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hümmel"@de .
+
+:n13311  a              skos:Concept ;
+        skos:broader    :n133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenlonsheim-Stromberg, Verbandsgemeinde"@de .
+
+:n33610009  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bosenbach"@de .
+
+:n138010440206  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eilenberg"@de .
+
+:n33101008  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bermersheim vor der Höhe"@de .
+
+:n13709  a              skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Mosel, Verbandsgemeinde"@de .
+
+:n340082110104  a       skos:Concept ;
+        skos:broader    :n34008211 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ringweilerhof"@de .
+
+:n131010440100  a       skos:Concept ;
+        skos:broader    :n13101044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gilgenbach"@de .
+
+:n132100170101  a       skos:Concept ;
+        skos:broader    :n13210017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beul"@de .
+
+:n14309230  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Härtlingen"@de .
+
+:n333075020201  a       skos:Concept ;
+        skos:broader    :n33307502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mordkammerhof (ehem.Gem.Dannenfels)"@de .
+
+:n232062960400  a       skos:Concept ;
+        skos:broader    :n23206296 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinmehlen"@de .
+
+:n23301006  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Betteldorf"@de .
+
+:n143030320103  a       skos:Concept ;
+        skos:broader    :n14303032 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grenzau"@de .
+
+:n138040680100  a       skos:Concept ;
+        skos:broader    :n13804068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hargarten"@de .
+
+:n31100000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frankenthal(Pfalz), Kreisfreie Stadt"@de .
+
+:n33610067  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederalben"@de .
+
+:n138090470102  a       skos:Concept ;
+        skos:broader    :n13809047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bürder"@de .
+
+:n133000060103  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gutleuthof"@de .
+
+:n23506063  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klüsserath"@de .
+
+:n132070760201  a       skos:Concept ;
+        skos:broader    :n13207076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberasdorf (ehem.Gem.Harbach)"@de .
+
+:n339010620100  a       skos:Concept ;
+        skos:broader    :n33901062 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Genheim (Ortsbezirk)"@de .
+
+:n231080530103  a       skos:Concept ;
+        skos:broader    :n23108053 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erlenbach"@de .
+
+:n23301064  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönbach"@de .
+
+:n137092050102  a       skos:Concept ;
+        skos:broader    :n13709205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrenburg"@de .
+
+:n14107037  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Endlichhofen"@de .
+
+:n132100900101  a       skos:Concept ;
+        skos:broader    :n13210090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pleckhausermühle"@de .
+
+:n50    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Französische Gebiete / 1792-1815"@de .
+
+:n33907060  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Undenheim"@de .
+
+:n14103062  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horhausen"@de .
+
+:n14305006  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitenau"@de .
+
+:n312000000200  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dansenberg (Ortsbezirk)"@de .
+
+:n13505037  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grenderich"@de .
+
+:n33801  a              skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dannstadt-Schauernheim, Verbandsgemeinde"@de .
+
+:n14009047  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hausbay"@de .
+
+:n133090520204  a       skos:Concept ;
+        skos:broader    :n13309052 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kyrburg"@de .
+
+:n33900030  a           skos:Concept ;
+        skos:broader    :n339 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ingelheim am Rhein, große kreisangeh. Stadt"@de .
+
+:n33610046  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horschbach"@de .
+
+:n13703006  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arft"@de .
+
+:n235081540300  a       skos:Concept ;
+        skos:broader    :n23508154 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Körrig (Ortsbezirk)"@de .
+
+:n33806015  a           skos:Concept ;
+        skos:broader    :n33806 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinniedesheim"@de .
+
+:n14306291  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Salzburg"@de .
+
+:n23301043  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meisburg"@de .
+
+:n336100030300  a       skos:Concept ;
+        skos:broader    :n33610003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Patersbach (Ortsbezirk)"@de .
+
+:n235075010300  a       skos:Concept ;
+        skos:broader    :n23507501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ittel (Ortsbezirk)"@de .
+
+:n138040370104  a       skos:Concept ;
+        skos:broader    :n13804037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krumscheid"@de .
+
+:n23504129  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sommerau"@de .
+
+:n140032020201  a       skos:Concept ;
+        skos:broader    :n14003202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Waldeck, Hsgr."@de .
+
+:n33610025  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Föckelberg"@de .
+
+:n33101024  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flomborn"@de .
+
+:n140035040101  a       skos:Concept ;
+        skos:broader    :n14003504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Petershäuserhof"@de .
+
+:n14308502  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mähren"@de .
+
+:n235071110100  a       skos:Concept ;
+        skos:broader    :n23507111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Edingen (Ortsbezirk)"@de .
+
+:n14103503  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Balduinstein"@de .
+
+:n138000450300  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Feldkirchen (Ortsbezirk)"@de .
+
+:n138020630102  a       skos:Concept ;
+        skos:broader    :n13802063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arienheller"@de .
+
+:n141000750211  a       skos:Concept ;
+        skos:broader    :n14100075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Friedrichssegen"@de .
+
+:n31900000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Worms, Kreisfreie Stadt"@de .
+
+:n13505074  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reidenhausen"@de .
+
+:n233015010700  a       skos:Concept ;
+        skos:broader    :n23301501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldkönigen (Ortsbezirk)"@de .
+
+:n14009084  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leiningen"@de .
+
+:n320000000900  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberauerbach (Ortsbezirk)"@de .
+
+:n140081250211  a       skos:Concept ;
+        skos:broader    :n14008125 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinböllerhütte"@de .
+
+:n13703043  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kehrig"@de .
+
+:n133000060602  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Huttental"@de .
+
+:n332000020300  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leistadt (Ortsbezirk)"@de .
+
+:n138040750105  a       skos:Concept ;
+        skos:broader    :n13804075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberelsaff"@de .
+
+:n33303026  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Göllheim"@de .
+
+:n138020040105  a       skos:Concept ;
+        skos:broader    :n13802004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reidenbruch"@de .
+
+:n13501020  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Cochem, Stadt"@de .
+
+:n132100870101  a       skos:Concept ;
+        skos:broader    :n13210087 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Friedenthal"@de .
+
+:n140005010702  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hübingen"@de .
+
+:n14009005  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Badenhard"@de .
+
+:n13102027  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heckenbach"@de .
+
+:n132070370169  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wippe"@de .
+
+:n14305  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ransbach-Baumbach, Verbandsgemeinde"@de .
+
+:n138010440201  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenhütte"@de .
+
+:n31800000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Speyer, Kreisfreie Stadt"@de .
+
+:n13704  a              skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mendig, Verbandsgemeinde"@de .
+
+:n14003202  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dommershausen"@de .
+
+:n232080270105  a       skos:Concept ;
+        skos:broader    :n23208027 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ordorf"@de .
+
+:n13704106  a           skos:Concept ;
+        skos:broader    :n13704 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Volkesfeld"@de .
+
+:n33706052  a           skos:Concept ;
+        skos:broader    :n33706 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maikammer"@de .
+
+:n333040100103  a       skos:Concept ;
+        skos:broader    :n33304010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klosterhof"@de .
+
+:n14009063  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Karbach"@de .
+
+:n33901045  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberheimbach"@de .
+
+:n33608062  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merzweiler"@de .
+
+:n33106  a              skos:Concept ;
+        skos:broader    :n331 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wörrstadt, Verbandsgemeinde"@de .
+
+:n333070140200  a       skos:Concept ;
+        skos:broader    :n33307014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steingruben"@de .
+
+:n336091070200  a       skos:Concept ;
+        skos:broader    :n33609107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Matzenbach"@de .
+
+:n131020030101  a       skos:Concept ;
+        skos:broader    :n13102003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenburg"@de .
+
+:n232012590103  a       skos:Concept ;
+        skos:broader    :n23201259 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lautzerath"@de .
+
+:n332050140114  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Speyerbrunn (ehem.Gem.Wilgartswiesen)"@de .
+
+:n232050010102  a       skos:Concept ;
+        skos:broader    :n23205001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kohnenhof"@de .
+
+:n138090710100  a       skos:Concept ;
+        skos:broader    :n13809071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellingen"@de .
+
+:n14305001  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alsbach"@de .
+
+:n131030060203  a       skos:Concept ;
+        skos:broader    :n13103006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mönchsheide"@de .
+
+:n13505032  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forst (Hunsrück)"@de .
+
+:n333040620102  a       skos:Concept ;
+        skos:broader    :n33304062 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steuerwaldsmühle"@de .
+
+:n235080580104  a       skos:Concept ;
+        skos:broader    :n23508058 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mühlscheid"@de .
+
+:n13209073  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nauroth"@de .
+
+:n13703001  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Acht"@de .
+
+:n34009017  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herschberg"@de .
+
+:n131045020202  a       skos:Concept ;
+        skos:broader    :n13104502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heidnerhof"@de .
+
+:n23208  a              skos:Concept ;
+        skos:broader    :n232 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bitburger Land, Verbandsgemeinde"@de .
+
+:n23306240  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stadtkyll"@de .
+
+:n143040480300  a       skos:Concept ;
+        skos:broader    :n14304048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eschelbach (Ortsbezirk)"@de .
+
+:n337020450105  a       skos:Concept ;
+        skos:broader    :n33702045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaplaneihof"@de .
+
+:n134020200102  a       skos:Concept ;
+        skos:broader    :n13402020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eborner Berg, Sdlg."@de .
+
+:n233060290300  a       skos:Concept ;
+        skos:broader    :n23306029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederbettingen (Ortsbezirk)"@de .
+
+:n14310047  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mogendorf"@de .
+
+:n33901003  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bacharach, Stadt"@de .
+
+:n23504124  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schöndorf"@de .
+
+:n23507094  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Newel"@de .
+
+:n23108107  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Platten"@de .
+
+:n140040410101  a       skos:Concept ;
+        skos:broader    :n14004041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Panzweiler"@de .
+
+:n33501011  a           skos:Concept ;
+        skos:broader    :n33501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gerhardsbrunn"@de .
+
+:n33102018  a           skos:Concept ;
+        skos:broader    :n33102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eich"@de .
+
+:n235081040400  a       skos:Concept ;
+        skos:broader    :n23508104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kreuzweiler (Ortsbezirk)"@de .
+
+:n140091120100  a       skos:Concept ;
+        skos:broader    :n14009112 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dellhofen (Ortsbezirk)"@de .
+
+:n141110890104  a       skos:Concept ;
+        skos:broader    :n14111089 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zollhaus"@de .
+
+:n235080720107  a       skos:Concept ;
+        skos:broader    :n23508072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedersehr"@de .
+
+:n134020100102  a       skos:Concept ;
+        skos:broader    :n13402010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Feckweiler"@de .
+
+:n232050080102  a       skos:Concept ;
+        skos:broader    :n23205008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuscheuerhof"@de .
+
+:n13502093  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zettingen"@de .
+
+:n33509019  a           skos:Concept ;
+        skos:broader    :n33509 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kollweiler"@de .
+
+:n231080690200  a       skos:Concept ;
+        skos:broader    :n23108069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krames"@de .
+
+:n138010800105  a       skos:Concept ;
+        skos:broader    :n13801080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sauerwiese (ehem.Gem.Elsaff)"@de .
+
+:n335020480101  a       skos:Concept ;
+        skos:broader    :n33502048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwarzsohl, Waldhaus"@de .
+
+:n235060830204  a       skos:Concept ;
+        skos:broader    :n23506083 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neu-Mehring"@de .
+
+:n231005020800  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hoxel (Ortsbezirk)"@de .
+
+:n33508020  a           skos:Concept ;
+        skos:broader    :n33508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kottweiler-Schwanden"@de .
+
+:n13301069  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neu-Bamberg"@de .
+
+:n134020720101  a       skos:Concept ;
+        skos:broader    :n13402072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nockenthal"@de .
+
+:n131000700704  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rolandsbogen"@de .
+
+:n13502014  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brieden"@de .
+
+:n23504103  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Osburg"@de .
+
+:n23507073  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langsur"@de .
+
+:n335020100105  a       skos:Concept ;
+        skos:broader    :n33502010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Diemerstein"@de .
+
+:n4006536n4  a          skos:Concept ;
+        skos:broader    :n14 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bienwald"@de .
+
+:n332070380103  a       skos:Concept ;
+        skos:broader    :n33207038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nackterhof"@de .
+
+:n13704101  a           skos:Concept ;
+        skos:broader    :n13704 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thür"@de .
+
+:n337070410100  a       skos:Concept ;
+        skos:broader    :n33707041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhochstadt"@de .
+
+:n335080380214  a       skos:Concept ;
+        skos:broader    :n33508038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Moordammühle (ehem.Gem.Landstuhl)"@de .
+
+:n232013330400  a       skos:Concept ;
+        skos:broader    :n23201333 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberüttfeld"@de .
+
+:n33307054  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obermoschel, Stadt"@de .
+
+:n23508136  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trassem"@de .
+
+:n33901040  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederheimbach"@de .
+
+:n33902039  a           skos:Concept ;
+        skos:broader    :n33902 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nackenheim"@de .
+
+:n33609056  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenbach"@de .
+
+:n33101  a              skos:Concept ;
+        skos:broader    :n331 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alzey-Land, Verbandsgemeinde"@de .
+
+:n141000750100  a       skos:Concept ;
+        skos:broader    :n14100075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederlahnstein"@de .
+
+:n317000000505  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedersimten (ehem.Gem.Simten) (Ortsbezirk)"@de .
+
+:n131000700200  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kripp (Ortsbezirk 1)"@de .
+
+:n13206034  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forst"@de .
+
+:n132070370143  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhöhe"@de .
+
+:n13805040  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Linkenbach"@de .
+
+:n14000501  a           skos:Concept ;
+        skos:broader    :n140 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Boppard, Stadt"@de .
+
+:n13402072  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rötsweiler-Nockenthal"@de .
+
+:n23306028  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gönnersdorf"@de .
+
+:n13310057  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lauschied"@de .
+
+:n233060560102  a       skos:Concept ;
+        skos:broader    :n23306056 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kasselburg"@de .
+
+:n111000000500  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrenbreitstein"@de .
+
+:n211000000306  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Quint"@de .
+
+:n339000050200  a       skos:Concept ;
+        skos:broader    :n33900005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bingerbrück"@de .
+
+:n13502051  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Landkern"@de .
+
+:n33200024  a           skos:Concept ;
+        skos:broader    :n332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grünstadt, Stadt"@de .
+
+:n33304057  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Orbis"@de .
+
+:n14109  a              skos:Concept ;
+        skos:broader    :n141 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Loreley, Verbandsgemeinde"@de .
+
+:n13309205  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwarzerden"@de .
+
+:n137002030104  a       skos:Concept ;
+        skos:broader    :n13700203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mülhofen"@de .
+
+:n23201309  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sengerich"@de .
+
+:n33502026  a           skos:Concept ;
+        skos:broader    :n33502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mehlingen"@de .
+
+:n33102034  a           skos:Concept ;
+        skos:broader    :n33102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gimbsheim"@de .
+
+:n13104206  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hohenleimbach"@de .
+
+:n13206013  a           skos:Concept ;
+        skos:broader    :n13206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitscheidt"@de .
+
+:n132070370122  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hilchenbach"@de .
+
+:n231005021900  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wolzburg (Ortsbezirk)"@de .
+
+:n141091210101  a       skos:Concept ;
+        skos:broader    :n14109121 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Block Loreley"@de .
+
+:n23101087  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Monzelfeld"@de .
+
+:n23306007  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birgel"@de .
+
+:n135010240200  a       skos:Concept ;
+        skos:broader    :n13501024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eller"@de .
+
+:n23101008  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bernkastel-Kues, Stadt"@de .
+
+:n23208017  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birtlingen"@de .
+
+:n320000000200  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bubenhausen"@de .
+
+:n131000770200  a       skos:Concept ;
+        skos:broader    :n13100077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Franken (Ortsbezirk)"@de .
+
+:n14003064  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kastellaun, Stadt"@de .
+
+:n14310042  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leuterod"@de .
+
+:n23108096  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederscheidweiler"@de .
+
+:n13405039  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herrstein"@de .
+
+:n34006015  a           skos:Concept ;
+        skos:broader    :n34006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heltersberg"@de .
+
+:n33206046  a           skos:Concept ;
+        skos:broader    :n33206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wachenheim an der Weinstraße, Stadt"@de .
+
+:n21100000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trier, Kreisfreie Stadt"@de .
+
+:n23206332  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hersdorf"@de .
+
+:n235080720102  a       skos:Concept ;
+        skos:broader    :n23508072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geisemerich"@de .
+
+:n13310094  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seesbach"@de .
+
+:n23101066  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kesten"@de .
+
+:n23208075  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Malberg"@de .
+
+:n336100970102  a       skos:Concept ;
+        skos:broader    :n33610097 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burglichtenberg"@de .
+
+:n137000680300  a       skos:Concept ;
+        skos:broader    :n13700068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kürrenberg (Ortsbezirk)"@de .
+
+:n13503087  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wagenhausen"@de .
+
+:n23508152  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zerf"@de .
+
+:n137030070107  a       skos:Concept ;
+        skos:broader    :n13703007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberbaar"@de .
+
+:n232080830102  a       skos:Concept ;
+        skos:broader    :n23208083 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tempelhof"@de .
+
+:n13701056  a           skos:Concept ;
+        skos:broader    :n13701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kretz"@de .
+
+:n333070370104  a       skos:Concept ;
+        skos:broader    :n33307037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Untermittweilerhof"@de .
+
+:n13503008  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beuren"@de .
+
+:n232000180400  a       skos:Concept ;
+        skos:broader    :n23200018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Masholder (Ortsbezirk)"@de .
+
+:n00Sn03s0395a  a       skos:Concept ;
+        skos:broader    :n15 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberer Mundatwald"@de .
+
+:n337050400100  a       skos:Concept ;
+        skos:broader    :n33705040 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heuchelheim"@de .
+
+:n111000001600  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederberg"@de .
+
+:n33202050  a           skos:Concept ;
+        skos:broader    :n33202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weisenheim am Sand"@de .
+
+:n2     a               skos:Concept ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Landschaften in Rheinland-Pfalz"@de .
+
+:n23205078  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Menningen"@de .
+
+:n23304216  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horperath"@de .
+
+:n14110139  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winden"@de .
+
+:n33707041  a           skos:Concept ;
+        skos:broader    :n33707 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochstadt (Pfalz)"@de .
+
+:n23508131  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Taben-Rodt"@de .
+
+:n23206226  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weinsheim"@de .
+
+:n33902034  a           skos:Concept ;
+        skos:broader    :n33902 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lörzweiler"@de .
+
+:n231080010101  a       skos:Concept ;
+        skos:broader    :n23108001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büscheid"@de .
+
+:n13405076  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schauren"@de .
+
+:n317000000500  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pirmasens"@de .
+
+:n14109099  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nochern"@de .
+
+:n32000000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zweibrücken, Kreisfreie Stadt"@de .
+
+:n340040320105  a       skos:Concept ;
+        skos:broader    :n34004032 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Riegelbrunnerhof"@de .
+
+:n14008139  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönborn"@de .
+
+:n23306023  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Feusdorf"@de .
+
+:n231005021205  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmausemühle"@de .
+
+:n14004164  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Woppenroth"@de .
+
+:n335110470102  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Aschbacherhof"@de .
+
+:n23206284  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberlauch"@de .
+
+:n143092490101  a       skos:Concept ;
+        skos:broader    :n14309249 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Möllingen"@de .
+
+:n33906067  a           skos:Concept ;
+        skos:broader    :n33906 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zornheim"@de .
+
+:n333070650105  a       skos:Concept ;
+        skos:broader    :n33307065 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unter-Gerbacherhof"@de .
+
+:n231010870101  a       skos:Concept ;
+        skos:broader    :n23101087 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Annenberg"@de .
+
+:n340030520103  a       skos:Concept ;
+        skos:broader    :n34003052 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Imsbacherhof"@de .
+
+:n211000000301  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auf der Bausch"@de .
+
+:n33704044  a           skos:Concept ;
+        skos:broader    :n33704 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Insheim"@de .
+
+:n13100077  a           skos:Concept ;
+        skos:broader    :n131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sinzig, Stadt"@de .
+
+:n138010030313  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krankel"@de .
+
+:n13405055  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelreidenbach"@de .
+
+:n334040130109  a       skos:Concept ;
+        skos:broader    :n33404013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Minderslachen"@de .
+
+:n23201298  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reipeldingen"@de .
+
+:n141111260102  a       skos:Concept ;
+        skos:broader    :n14111126 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bärbach"@de .
+
+:n13503  a              skos:Concept ;
+        skos:broader    :n135 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ulmen, Verbandsgemeinde"@de .
+
+:n232012010300  a       skos:Concept ;
+        skos:broader    :n23201201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hickeshausen"@de .
+
+:n33106004  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Armsheim"@de .
+
+:n23504050  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holzerath"@de .
+
+:n138010770100  a       skos:Concept ;
+        skos:broader    :n13801077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rederscheid"@de .
+
+:n13104201  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brenk"@de .
+
+:n23508025  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fisch"@de .
+
+:n14003001  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alterkülz"@de .
+
+:n33404031  a           skos:Concept ;
+        skos:broader    :n33404 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vollmersweiler"@de .
+
+:n138050140101  a       skos:Concept ;
+        skos:broader    :n13805014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daufenbach"@de .
+
+:n23208091  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederstedem"@de .
+
+:n23306002  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Basberg"@de .
+
+:n233060260300  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gees (Ortsbezirk)"@de .
+
+:n14008118  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pleizenhausen"@de .
+
+:n13301080  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pleitersheim"@de .
+
+:n231005020100  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bischofsdhron (Ortsbezirk)"@de .
+
+:n235071370302  a       skos:Concept ;
+        skos:broader    :n23507137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederweiler"@de .
+
+:n33304031  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ilbesheim"@de .
+
+:n337015010200  a       skos:Concept ;
+        skos:broader    :n33701501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bindersbach (Ortsbezirk)"@de .
+
+:n23108091  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Musweiler"@de .
+
+:n333075020308  a       skos:Concept ;
+        skos:broader    :n33307502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rußmühlerhof"@de .
+
+:n23306060  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Salm"@de .
+
+:n23208070  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kyllburg, Stadt"@de .
+
+:n235010470101  a       skos:Concept ;
+        skos:broader    :n23501047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gedenkstätte Hinzert"@de .
+
+:n23205094  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niehl"@de .
+
+:n14004122  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reckershausen"@de .
+
+:n137030070102  a       skos:Concept ;
+        skos:broader    :n13703007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Engeln"@de .
+
+:n333070230101  a       skos:Concept ;
+        skos:broader    :n33307023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gutenbacherhof"@de .
+
+:n13405092  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weitersbach"@de .
+
+:n340090510200  a       skos:Concept ;
+        skos:broader    :n34009051 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thalfröschen"@de .
+
+:n134000450500  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Idar"@de .
+
+:n235041070105  a       skos:Concept ;
+        skos:broader    :n23504107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wilzenburg"@de .
+
+:n33510  a              skos:Concept ;
+        skos:broader    :n335 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Otterbach-Otterberg, Verbandsgemeinde"@de .
+
+:n33304010  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bolanden"@de .
+
+:n23508062  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirf"@de .
+
+:n337050510103  a       skos:Concept ;
+        skos:broader    :n33705051 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Slevogthof"@de .
+
+:n14109121  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Goarshausen, Loreleystadt, Stadt"@de .
+
+:n13405013  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitenthal"@de .
+
+:n33206020  a           skos:Concept ;
+        skos:broader    :n33206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Friedelsheim"@de .
+
+:n33908  a              skos:Concept ;
+        skos:broader    :n339 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sprendlingen-Gensingen, Verbandsgemeinde"@de .
+
+:n141095010105  a       skos:Concept ;
+        skos:broader    :n14109501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Im Mühltal"@de .
+
+:n211000000800  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heiligkreuz (Ortsbezirk 18)"@de .
+
+:n13702114  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wierschem"@de .
+
+:n137092230100  a       skos:Concept ;
+        skos:broader    :n13709223 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederspay"@de .
+
+:n23101040  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gornhausen"@de .
+
+:n23205073  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leimbach"@de .
+
+:n14308232  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahn am See"@de .
+
+:n14303030  a           skos:Concept ;
+        skos:broader    :n14303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hilgert"@de .
+
+:n13702029  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gering"@de .
+
+:n231080260102  a       skos:Concept ;
+        skos:broader    :n23108026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eichelhütte"@de .
+
+:n338000050100  a       skos:Concept ;
+        skos:broader    :n33800005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Böhl"@de .
+
+:n143030300101  a       skos:Concept ;
+        skos:broader    :n14303030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Faulbach"@de .
+
+:n137031130102  a       skos:Concept ;
+        skos:broader    :n13703113 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwelschenbach"@de .
+
+:n14309289  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rothenbach"@de .
+
+:n14308290  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Salz"@de .
+
+:n332050160102  a       skos:Concept ;
+        skos:broader    :n33205016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erfenstein"@de .
+
+:n131000070300  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gimmigen (Ortsbezirk)"@de .
+
+:n231005021200  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morbach (Ortsbezirk)"@de .
+
+:n14008134  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sargenroth"@de .
+
+:n340030280107  a       skos:Concept ;
+        skos:broader    :n34003028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodalberhof"@de .
+
+:n33404  a              skos:Concept ;
+        skos:broader    :n334 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kandel, Verbandsgemeinde"@de .
+
+:n335080300200  a       skos:Concept ;
+        skos:broader    :n33508030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reuschbach"@de .
+
+:n137020410103  a       skos:Concept ;
+        skos:broader    :n13702041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Windhäuserhof"@de .
+
+:n13702087  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pillig"@de .
+
+:n131000900300  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eckendorf (Ortsbezirk)"@de .
+
+:n13309046  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochstetten-Dhaun"@de .
+
+:n14302259  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lochum"@de .
+
+:n14304008  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daubach"@de .
+
+:n131000700503  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloss Calmuth"@de .
+
+:n137030110105  a       skos:Concept ;
+        skos:broader    :n13703011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heunenhof"@de .
+
+:n319000001200  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfiffligheim (Ortsbezirk)"@de .
+
+:n334040130104  a       skos:Concept ;
+        skos:broader    :n33404013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hardtmühle"@de .
+
+:n23201293  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Plütscheid"@de .
+
+:n33103023  a           skos:Concept ;
+        skos:broader    :n33103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flörsheim-Dalsheim"@de .
+
+:n233060760202  a       skos:Concept ;
+        skos:broader    :n23306076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nollenbach"@de .
+
+:n314000000800  a       skos:Concept ;
+        skos:broader    :n31400000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruchheim (Ortsbezirk)"@de .
+
+:n336081050103  a       skos:Concept ;
+        skos:broader    :n33608105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stahlhausen"@de .
+
+:n23201214  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dasburg"@de .
+
+:n332070410401  a       skos:Concept ;
+        skos:broader    :n33207041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuoffstein"@de .
+
+:n132031130100  a       skos:Concept ;
+        skos:broader    :n13203113 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberdreisbach"@de .
+
+:n14008113  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ohlweiler"@de .
+
+:n23205031  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Emmelbaum"@de .
+
+:n23506  a              skos:Concept ;
+        skos:broader    :n235 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweich an der Röm. Weinstraße, Verbandsgemeinde"@de .
+
+:n14110086  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Miellen"@de .
+
+:n14004053  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirschfeld (Hunsrück)"@de .
+
+:n211000001900  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trier-West (T.a. Ortsbezirk 8)"@de .
+
+:n23106115  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönberg"@de .
+
+:n333075020303  a       skos:Concept ;
+        skos:broader    :n33307502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hintersteinerhof"@de .
+
+:n232051080102  a       skos:Concept ;
+        skos:broader    :n23205108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Prümer Burg, Gastst."@de .
+
+:n131000070109  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kloster Calvarienberg"@de .
+
+:n33511037  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Queidersbach"@de .
+
+:n138040680202  a       skos:Concept ;
+        skos:broader    :n13804068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brochenbach"@de .
+
+:n235062070102  a       skos:Concept ;
+        skos:broader    :n23506207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Im Dhrönchen"@de .
+
+:n14309247  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaden"@de .
+
+:n14302296  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stein-Wingert"@de .
+
+:n336090100101  a       skos:Concept ;
+        skos:broader    :n33609010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bambergerhof"@de .
+
+:n13809054  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberraden"@de .
+
+:n137082160100  a       skos:Concept ;
+        skos:broader    :n13708216 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kärlich"@de .
+
+:n143062860100  a       skos:Concept ;
+        skos:broader    :n14306286 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Emmerichenhain"@de .
+
+:n34008210  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großsteinhausen"@de .
+
+:n132080800126  a       skos:Concept ;
+        skos:broader    :n13208080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schönborn"@de .
+
+:n13804068  a           skos:Concept ;
+        skos:broader    :n13804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Katharinen (Lkr. Neuwied)"@de .
+
+:n34004007  a           skos:Concept ;
+        skos:broader    :n34004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Donsieders"@de .
+
+:n33903  a              skos:Concept ;
+        skos:broader    :n339 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gau-Algesheim, Verbandsgemeinde"@de .
+
+:n14009149  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thörlingen"@de .
+
+:n14008150  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tiefenbach"@de .
+
+:n316000000400  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geinsheim (Ortsbezirk)"@de .
+
+:n14109031  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörscheid"@de .
+
+:n14309226  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Girkenroth"@de .
+
+:n13306086  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roxheim"@de .
+
+:n231   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bernkastel-Wittlich, Landkreis"@de .
+
+:n14304024  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großholbach"@de .
+
+:n141030290101  a       skos:Concept ;
+        skos:broader    :n14103029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oranienstein"@de .
+
+:n141030640100  a       skos:Concept ;
+        skos:broader    :n14103064 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Giershausen"@de .
+
+:n13501079  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Senheim (Mosel)"@de .
+
+:n14004090  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maitzborn"@de .
+
+:n14008065  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Keidelheim"@de .
+
+:n13707226  a           skos:Concept ;
+        skos:broader    :n13707 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vallendar, Stadt"@de .
+
+:n333060090103  a       skos:Concept ;
+        skos:broader    :n33306009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahnweilerhof"@de .
+
+:n14110044  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frücht"@de .
+
+:n13210017  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Busenhausen"@de .
+
+:n133111100102  a       skos:Concept ;
+        skos:broader    :n13311110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wald Erbach"@de .
+
+:n13101008  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Barweiler"@de .
+
+:n33501203  a           skos:Concept ;
+        skos:broader    :n33501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Martinshöhe"@de .
+
+:n132100880101  a       skos:Concept ;
+        skos:broader    :n13210088 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berg"@de .
+
+:n14309284  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pottum"@de .
+
+:n46    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kurpfalz"@de .
+
+:n13309041  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heimweiler"@de .
+
+:n11100000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Koblenz, Kreisfreie Stadt"@de .
+
+:n111000002000  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rübenach (Ortsbezirk 7)"@de .
+
+:n13101066  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Quiddelbach"@de .
+
+:n4440854n7  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Voreifel"@de .
+
+:n140030090400  a       skos:Concept ;
+        skos:broader    :n14003009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leideneck (Ortsbezirk)"@de .
+
+:n23301039  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchweiler"@de .
+
+:n312000002003  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vogelweh"@de .
+
+:n33610106  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bedesbach"@de .
+
+:n25    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lahntal"@de .
+
+:n33907035  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ludwigshöhe"@de .
+
+:n138010440303  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grube Anxbach"@de .
+
+:n13306044  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hergenfeld"@de .
+
+:n23501  a              skos:Concept ;
+        skos:broader    :n235 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hermeskeil, Verbandsgemeinde"@de .
+
+:n137030740107  a       skos:Concept ;
+        skos:broader    :n13703074 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schäfereihof"@de .
+
+:n33705012  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Böchingen"@de .
+
+:n338010220200  a       skos:Concept ;
+        skos:broader    :n33801022 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rödersheim"@de .
+
+:n14008023  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Budenbach"@de .
+
+:n232050020102  a       skos:Concept ;
+        skos:broader    :n23205002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberecken"@de .
+
+:n13208054  a           skos:Concept ;
+        skos:broader    :n13208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hövels"@de .
+
+:n33900005  a           skos:Concept ;
+        skos:broader    :n339 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bingen am Rhein, große kreisangehörige Stadt"@de .
+
+:n235030680700  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedermennig (T.a.Ortsbezirk 4)"@de .
+
+:n34009225  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallhalben"@de .
+
+:n231090720101  a       skos:Concept ;
+        skos:broader    :n23109072 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kövenig (Ortsbezirk)"@de .
+
+:n33207030  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchheim an der Weinstraße"@de .
+
+:n231005021004  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hunolsteinerhof"@de .
+
+:n13203068  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mauden"@de .
+
+:n14309242  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höhn"@de .
+
+:n23301018  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dockweiler"@de .
+
+:n137000030308  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pönterhof"@de .
+
+:n133000060200  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bosenheim (Ortsbezirk)"@de .
+
+:n33800005  a           skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Böhl-Iggelheim"@de .
+
+:n33610079  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rammelsbach"@de .
+
+:n140005010300  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buchholz (Ortsbezirk)"@de .
+
+:n14302212  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Borod"@de .
+
+:n340082060109  a       skos:Concept ;
+        skos:broader    :n34008206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wahlbacherhof"@de .
+
+:n232012120107  a       skos:Concept ;
+        skos:broader    :n23201212 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wehrbüsch"@de .
+
+:n338010060100  a       skos:Concept ;
+        skos:broader    :n33801006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dannstadt"@de .
+
+:n13210033  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fluterschen"@de .
+
+:n14008002  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altweidelbach"@de .
+
+:n340010100102  a       skos:Concept ;
+        skos:broader    :n34001010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lauterschwan"@de .
+
+:n14107134  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weidenbach"@de .
+
+:n23106083  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merschbach"@de .
+
+:n34009204  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biedershausen"@de .
+
+:n235070690102  a       skos:Concept ;
+        skos:broader    :n23507069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochmark"@de .
+
+:n233060800200  a       skos:Concept ;
+        skos:broader    :n23306080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zilsdorf (Ortsbezirk)"@de .
+
+:n339010030200  a       skos:Concept ;
+        skos:broader    :n33901003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steeg (Ortsbezirk)"@de .
+
+:n33402002  a           skos:Concept ;
+        skos:broader    :n33402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berg (Pfalz)"@de .
+
+:n13703097  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Johann"@de .
+
+:n14306245  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hüblingen"@de .
+
+:n135050920304  a       skos:Concept ;
+        skos:broader    :n13505092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siedlung Althaus"@de .
+
+:n340040380112  a       skos:Concept ;
+        skos:broader    :n34004038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhof"@de .
+
+:n13101082  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wershofen"@de .
+
+:n333020190200  a       skos:Concept ;
+        skos:broader    :n33302019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stauf (Ortsbezirk)"@de .
+
+:n13306002  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Allenfeld"@de .
+
+:n33608058  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lauterecken, Stadt"@de .
+
+:n141   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Lahn-Kreis"@de .
+
+:n340092170102  a       skos:Concept ;
+        skos:broader    :n34009217 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hitscherhof"@de .
+
+:n314000000100  a       skos:Concept ;
+        skos:broader    :n31400000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Edigheim"@de .
+
+:n132080110124  a       skos:Concept ;
+        skos:broader    :n13208011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Voßwinkel"@de .
+
+:n13401074  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rückweiler"@de .
+
+:n23301055  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberstadtfeld"@de .
+
+:n332000240100  a       skos:Concept ;
+        skos:broader    :n33200024 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Asselheim (Ortsbezirk)"@de .
+
+:n313000000700  a       skos:Concept ;
+        skos:broader    :n31300000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Queichheim (Ortsbezirk)"@de .
+
+:n41    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erzstift Trier"@de .
+
+:n232062260301  a       skos:Concept ;
+        skos:broader    :n23206226 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brühlborn"@de .
+
+:n14103053  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heistenbach"@de .
+
+:n13203026  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Emmerzhausen"@de .
+
+:n14309200  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ailertchen"@de .
+
+:n13210070  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Michelbach (Westerwald)"@de .
+
+:n14111102  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberneisen"@de .
+
+:n140091120202  a       skos:Concept ;
+        skos:broader    :n14009112 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reschscheider Hof"@de .
+
+:n14111096  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedertiefenbach"@de .
+
+:n13501053  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lieg"@de .
+
+:n134020630101  a       skos:Concept ;
+        skos:broader    :n13402063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sauerbrunnen"@de .
+
+:n33302060  a           skos:Concept ;
+        skos:broader    :n33302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ramsen"@de .
+
+:n233060190101  a       skos:Concept ;
+        skos:broader    :n23306019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dohm"@de .
+
+:n233060540100  a       skos:Concept ;
+        skos:broader    :n23306054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberehe"@de .
+
+:n141090160101  a       skos:Concept ;
+        skos:broader    :n14109016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gemeindemühle"@de .
+
+:n211000001200  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mariahof (Ortsbezirk 19)"@de .
+
+:n137000680407  a       skos:Concept ;
+        skos:broader    :n13700068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geisbüschhof"@de .
+
+:n33707  a              skos:Concept ;
+        skos:broader    :n337 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Offenbach an der Queich, Verbandsgemeinde"@de .
+
+:n132100050101  a       skos:Concept ;
+        skos:broader    :n13210005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Strickhausen"@de .
+
+:n23208331  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zendscheid"@de .
+
+:n23207104  a           skos:Concept ;
+        skos:broader    :n23207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Philippsheim"@de .
+
+:n14306282  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberrod"@de .
+
+:n143022940100  a       skos:Concept ;
+        skos:broader    :n14302294 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmidthahn"@de .
+
+:n235040460101  a       skos:Concept ;
+        skos:broader    :n23504046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinzenburgermühle"@de .
+
+:n23304010  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Boxberg"@de .
+
+:n23301034  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Immerath"@de .
+
+:n14009102  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ney"@de .
+
+:n33908029  a           skos:Concept ;
+        skos:broader    :n33908 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horrweiler"@de .
+
+:n20    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eifel"@de .
+
+:n13703055  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kottenheim"@de .
+
+:n33608095  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Julian"@de .
+
+:n13801  a              skos:Concept ;
+        skos:broader    :n138 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Asbach, Verbandsgemeinde"@de .
+
+:n137030740102  a       skos:Concept ;
+        skos:broader    :n13703074 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siedlung Cond"@de .
+
+:n13102039  a           skos:Concept ;
+        skos:broader    :n13102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kesseling"@de .
+
+:n23506091  a           skos:Concept ;
+        skos:broader    :n23506 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Naurath (Eifel)"@de .
+
+:n335095010300  a       skos:Concept ;
+        skos:broader    :n33509501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reichenbach"@de .
+
+:n138010440213  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hombach"@de .
+
+:n143092540300  a       skos:Concept ;
+        skos:broader    :n14309254 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hölzenhausen"@de .
+
+:n34009220  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reifenberg"@de .
+
+:n232050950202  a       skos:Concept ;
+        skos:broader    :n23205095 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rohrbach"@de .
+
+:n13805078  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Woldert"@de .
+
+:n33205048  a           skos:Concept ;
+        skos:broader    :n33205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weidenthal"@de .
+
+:n232063180107  a       skos:Concept ;
+        skos:broader    :n23206318 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wickenseifen"@de .
+
+:n137000030303  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geishügelhof"@de .
+
+:n13501090  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wirfus"@de .
+
+:n14009075  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kratzenburg"@de .
+
+:n13703034  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hausten"@de .
+
+:n33508016  a           skos:Concept ;
+        skos:broader    :n33508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hütschenhausen"@de .
+
+:n315000000300  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Drais (Ortsbezirk)"@de .
+
+:n33608074  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Odenbach"@de .
+
+:n14111054  a           skos:Concept ;
+        skos:broader    :n14111 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herold"@de .
+
+:n13311085  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roth"@de .
+
+:n33303017  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreisen"@de .
+
+:n23507069  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kordel"@de .
+
+:n337050070300  a       skos:Concept ;
+        skos:broader    :n33705007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ingenheim"@de .
+
+:n131030060300  a       skos:Concept ;
+        skos:broader    :n13103006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheineck"@de .
+
+:n111000000602  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bisholder"@de .
+
+:n13805057  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Puderbach"@de .
+
+:n34001021  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirschthal"@de .
+
+:n332070410200  a       skos:Concept ;
+        skos:broader    :n33207041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Colgenstein-Heidesheim"@de .
+
+:n23301071  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Strotzbüsch"@de .
+
+:n332050480103  a       skos:Concept ;
+        skos:broader    :n33205048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morschbacherhof, Forsthaus"@de .
+
+:n331000030200  a       skos:Concept ;
+        skos:broader    :n33100003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dautenheim (Ortsbezirk)"@de .
+
+:n13703092  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reudelsterz"@de .
+
+:n133000060651  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ebernburg"@de .
+
+:n13801003  a           skos:Concept ;
+        skos:broader    :n13801 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Asbach"@de .
+
+:n33901036  a           skos:Concept ;
+        skos:broader    :n33901 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Manubach"@de .
+
+:n33608053  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kreimbach-Kaulbach"@de .
+
+:n33101052  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ober-Flörsheim"@de .
+
+:n13209006  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Betzdorf, Stadt"@de .
+
+:n235081520109  a       skos:Concept ;
+        skos:broader    :n23508152 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberzerf"@de .
+
+:n232080980100  a       skos:Concept ;
+        skos:broader    :n23208098 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beifels"@de .
+
+:n23507048  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hockweiler"@de .
+
+:n132070370139  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Möhren"@de .
+
+:n131020020300  a       skos:Concept ;
+        skos:broader    :n13102002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pützfeld"@de .
+
+:n4322679n6  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalkeifel"@de .
+
+:n23208119  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seffern"@de .
+
+:n132060340101  a       skos:Concept ;
+        skos:broader    :n13206034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dellingen"@de .
+
+:n332050140105  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Harzofen"@de .
+
+:n33306030  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höringen"@de .
+
+:n332070010102  a       skos:Concept ;
+        skos:broader    :n33207001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Drahtzug"@de .
+
+:n135010820100  a       skos:Concept ;
+        skos:broader    :n13501082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Karden"@de .
+
+:n231001340400  a       skos:Concept ;
+        skos:broader    :n23100134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuerburg (Ortsbezirk)"@de .
+
+:n34002057  a           skos:Concept ;
+        skos:broader    :n34002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wilgartswiesen"@de .
+
+:n33101031  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gau-Heppenheim"@de .
+
+:n33702  a              skos:Concept ;
+        skos:broader    :n337 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Bergzabern, Verbandsgemeinde"@de .
+
+:n23507027  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Franzenheim"@de .
+
+:n132070370118  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hammer"@de .
+
+:n315000001400  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neustadt (Ortsbezirk)"@de .
+
+:n34003205  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bottenbach"@de .
+
+:n333060480102  a       skos:Concept ;
+        skos:broader    :n33306048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neumühle"@de .
+
+:n14305050  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nauort"@de .
+
+:n13505081  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tellig"@de .
+
+:n141030300104  a       skos:Concept ;
+        skos:broader    :n14103030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalkofen"@de .
+
+:n33608090  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rutsweiler an der Lauter"@de .
+
+:n232062710104  a       skos:Concept ;
+        skos:broader    :n23206271 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweiler"@de .
+
+:n33703025  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Flemlingen"@de .
+
+:n13502026  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eppenberg"@de .
+
+:n33307008  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bisterschied"@de .
+
+:n335020040102  a       skos:Concept ;
+        skos:broader    :n33502004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hetschmühle"@de .
+
+:n143012060400  a       skos:Concept ;
+        skos:broader    :n14301206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zinhain"@de .
+
+:n336100030201  a       skos:Concept ;
+        skos:broader    :n33610003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreikönigszug"@de .
+
+:n33101010  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biebelnheim"@de .
+
+:n135050710100  a       skos:Concept ;
+        skos:broader    :n13505071 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Löffelscheid"@de .
+
+:n23206328  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winterscheid"@de .
+
+:n132081170406  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hagdorn"@de .
+
+:n332020500101  a       skos:Concept ;
+        skos:broader    :n33202050 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eyersheimerhof"@de .
+
+:n33403012  a           skos:Concept ;
+        skos:broader    :n33403 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jockgrim"@de .
+
+:n14107060  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holzhausen an der Haide"@de .
+
+:n132030500300  a       skos:Concept ;
+        skos:broader    :n13203050 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sassenroth (Ortsbezirk)"@de .
+
+:n13502084  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Urmersbach"@de .
+
+:n33307066  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Alban"@de .
+
+:n131042020300  a       skos:Concept ;
+        skos:broader    :n13104202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiler"@de .
+
+:n13807062  a           skos:Concept ;
+        skos:broader    :n13807 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinbreitbach"@de .
+
+:n331070550103  a       skos:Concept ;
+        skos:broader    :n33107055 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mühlheim"@de .
+
+:n233062040103  a       skos:Concept ;
+        skos:broader    :n23306204 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rom"@de .
+
+:n33303012  a           skos:Concept ;
+        skos:broader    :n33303 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bubenheim"@de .
+
+:n143093080100  a       skos:Concept ;
+        skos:broader    :n14309308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gershasen"@de .
+
+:n23101126  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Veldenz"@de .
+
+:n23208135  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wilsecker"@de .
+
+:n336100550200  a       skos:Concept ;
+        skos:broader    :n33610055 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Diedelkopf (Ortsbezirk)"@de .
+
+:n232063080102  a       skos:Concept ;
+        skos:broader    :n23206308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hontheim"@de .
+
+:n13805052  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberdreis"@de .
+
+:n13402084  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siesbach"@de .
+
+:n335110470119  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unterhammer"@de .
+
+:n23206307  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seiwerath"@de .
+
+:n138010440102  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrenberg"@de .
+
+:n131040550103  a       skos:Concept ;
+        skos:broader    :n13104055 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodder (ehem.Gem.Niederdürenbach)"@de .
+
+:n336080750200  a       skos:Concept ;
+        skos:broader    :n33608075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Offenbach"@de .
+
+:n138010770202  a       skos:Concept ;
+        skos:broader    :n13801077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birken"@de .
+
+:n13301039  a           skos:Concept ;
+        skos:broader    :n13301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hallgarten"@de .
+
+:n33609047  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hüffler"@de .
+
+:n34009024  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höhfröschen"@de .
+
+:n14003018  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Braunshorn"@de .
+
+:n23101105  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Piesport"@de .
+
+:n340092280100  a       skos:Concept ;
+        skos:broader    :n34009228 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhausen"@de .
+
+:n235081540700  a       skos:Concept ;
+        skos:broader    :n23508154 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Südlingen (Ortsbezirk)"@de .
+
+:n23306019  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dohm-Lammersdorf"@de .
+
+:n143062560300  a       skos:Concept ;
+        skos:broader    :n14306256 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weißenberg"@de .
+
+:n13402063  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhambach"@de .
+
+:n140090840100  a       skos:Concept ;
+        skos:broader    :n14009084 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lamscheid"@de .
+
+:n132030180100  a       skos:Concept ;
+        skos:broader    :n13203018 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biersdorf"@de .
+
+:n131010330301  a       skos:Concept ;
+        skos:broader    :n13101033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heistert"@de .
+
+:n23208029  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Echtershausen"@de .
+
+:n133010300102  a       skos:Concept ;
+        skos:broader    :n13301030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Feil"@de .
+
+:n13502042  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Illerich"@de .
+
+:n33307024  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gehrweiler"@de .
+
+:n23108114  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schladt"@de .
+
+:n13101  a              skos:Concept ;
+        skos:broader    :n131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Adenau, Verbandsgemeinde"@de .
+
+:n333060200101  a       skos:Concept ;
+        skos:broader    :n33306020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bornshof"@de .
+
+:n138010030309  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinterplag"@de .
+
+:n133090520100  a       skos:Concept ;
+        skos:broader    :n13309052 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kallenfels (Ortsbezirk)"@de .
+
+:n23504046  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hinzenburg"@de .
+
+:n23205117  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scheuern"@de .
+
+:n23208087  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neidenbach"@de .
+
+:n13402042  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hoppstädten-Weiersbach"@de .
+
+:n233010750100  a       skos:Concept ;
+        skos:broader    :n23301075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tettscheid (Ortsbezirk)"@de .
+
+:n23109  a              skos:Concept ;
+        skos:broader    :n231 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Traben-Trarbach, Verbandsgemeinde"@de .
+
+:n335100170104  a       skos:Concept ;
+        skos:broader    :n33510017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kühbörncheshof"@de .
+
+:n138000450700  a       skos:Concept ;
+        skos:broader    :n13800045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuwied"@de .
+
+:n232051020102  a       skos:Concept ;
+        skos:broader    :n23205102 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Glashütte"@de .
+
+:n131042080101  a       skos:Concept ;
+        skos:broader    :n13104208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hannebach"@de .
+
+:n33106058  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saulheim"@de .
+
+:n33703020  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Edenkoben,Stadt"@de .
+
+:n334020020101  a       skos:Concept ;
+        skos:broader    :n33402002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neulauterburg"@de .
+
+:n132100400102  a       skos:Concept ;
+        skos:broader    :n13210040 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herpteroth"@de .
+
+:n131040730104  a       skos:Concept ;
+        skos:broader    :n13104073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Untervinxt"@de .
+
+:n14003055  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hollnich"@de .
+
+:n33307003  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alsenz"@de .
+
+:n14109138  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weyer"@de .
+
+:n338   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rhein-Pfalz-Kreis"@de .
+
+:n23306056  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pelm"@de .
+
+:n132081170401  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alserberg"@de .
+
+:n23507001  a           skos:Concept ;
+        skos:broader    :n23507 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Aach"@de .
+
+:n312000001700  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Betzenberg (Ortsbezirk)"@de .
+
+:n232062260100  a       skos:Concept ;
+        skos:broader    :n23206226 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gondelsheim"@de .
+
+:n23304228  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nitz"@de .
+
+:n133105010305  a       skos:Concept ;
+        skos:broader    :n13310501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinhardt"@de .
+
+:n13503078  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmitt"@de .
+
+:n33307061  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ransweiler"@de .
+
+:n235075010111  a       skos:Concept ;
+        skos:broader    :n23507501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Träg (Ortsbezirk)"@de .
+
+:n23206238  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heisdorf"@de .
+
+:n131000070402  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehlingen"@de .
+
+:n33509005  a           skos:Concept ;
+        skos:broader    :n33509 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erzenhausen"@de .
+
+:n13405088  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sulzbach"@de .
+
+:n131000901003  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bölingen"@de .
+
+:n133110350200  a       skos:Concept ;
+        skos:broader    :n13311035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldhilbersheim"@de .
+
+:n4108577n2  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vorderwesterwald"@de .
+
+:n134020570101  a       skos:Concept ;
+        skos:broader    :n13402057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fischerhof"@de .
+
+:n23508058  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kell am See"@de .
+
+:n231080690101  a       skos:Concept ;
+        skos:broader    :n23108069 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pohlbacher Mühle"@de .
+
+:n14310012  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ebernhahn"@de .
+
+:n13405009  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berschweiler bei Kirn"@de .
+
+:n335080440300  a       skos:Concept ;
+        skos:broader    :n33508044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weltersbach"@de .
+
+:n339060570100  a       skos:Concept ;
+        skos:broader    :n33906057 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elsheim"@de .
+
+:n23306035  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jünkerath"@de .
+
+:n135050130106  a       skos:Concept ;
+        skos:broader    :n13505013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maiermund"@de .
+
+:n23206302  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roth bei Prüm"@de .
+
+:n339010400102  a       skos:Concept ;
+        skos:broader    :n33901040 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Sooneck"@de .
+
+:n13310064  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meddersheim"@de .
+
+:n23206296  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Prüm, Stadt"@de .
+
+:n23208045  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Halsdorf"@de .
+
+:n335080380200  a       skos:Concept ;
+        skos:broader    :n33508038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ramstein"@de .
+
+:n23205069  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kruchten"@de .
+
+:n14301277  a           skos:Concept ;
+        skos:broader    :n14301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nisterau"@de .
+
+:n23304207  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Borler"@de .
+
+:n23508122  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schoden"@de .
+
+:n13709204  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brey"@de .
+
+:n13503057  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lutzerath"@de .
+
+:n132070630606  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Junkernthal, Schloß und Forsthaus"@de .
+
+:n133060680103  a       skos:Concept ;
+        skos:broader    :n13306068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Struthof"@de .
+
+:n335010030400  a       skos:Concept ;
+        skos:broader    :n33501003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Miesau"@de .
+
+:n231010080404  a       skos:Concept ;
+        skos:broader    :n23101008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Machern"@de .
+
+:n14310070  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siershahn"@de .
+
+:n13405067  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwörresbach"@de .
+
+:n232063320100  a       skos:Concept ;
+        skos:broader    :n23206332 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhersdorf"@de .
+
+:n33807011  a           skos:Concept ;
+        skos:broader    :n33807 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Harthausen"@de .
+
+:n338070230200  a       skos:Concept ;
+        skos:broader    :n33807023 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heiligenstein"@de .
+
+:n134050170102  a       skos:Concept ;
+        skos:broader    :n13405017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reinhardtsmühle"@de .
+
+:n137000030102  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gut zur Nette"@de .
+
+:n143040480700  a       skos:Concept ;
+        skos:broader    :n14304048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reckenthal (Ortsbezirk)"@de .
+
+:n23208024  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dahlem"@de .
+
+:n33307502  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rockenhausen, Stadt"@de .
+
+:n340010390103  a       skos:Concept ;
+        skos:broader    :n34001039 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Falkenmühle"@de .
+
+:n333070250104  a       skos:Concept ;
+        skos:broader    :n33307025 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schneebergerhof"@de .
+
+:n133100010102  a       skos:Concept ;
+        skos:broader    :n13310001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "St.Antoniushof"@de .
+
+:n13405046  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kempfeld"@de .
+
+:n34006022  a           skos:Concept ;
+        skos:broader    :n34006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höheinöd"@de .
+
+:n339000050101  a       skos:Concept ;
+        skos:broader    :n33900005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auf dem Rochusberg"@de .
+
+:n138010030304  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Diefenau"@de .
+
+:n14109069  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kaub, Stadt"@de .
+
+:n23205112  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roth an der Our"@de .
+
+:n23108024  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreis"@de .
+
+:n336090920300  a       skos:Concept ;
+        skos:broader    :n33609092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmittweiler"@de .
+
+:n23304244  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welcherath"@de .
+
+:n335110450102  a       skos:Concept ;
+        skos:broader    :n33511045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitenau"@de .
+
+:n13310022  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daubach"@de .
+
+:n312000000404  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stockborn"@de .
+
+:n232062960100  a       skos:Concept ;
+        skos:broader    :n23206296 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dausfeld"@de .
+
+:n14004049  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heinzenbach"@de .
+
+:n33304022  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gauersheim"@de .
+
+:n335110210104  a       skos:Concept ;
+        skos:broader    :n33511021 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweinstal"@de .
+
+:n23108082  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Meerfeld"@de .
+
+:n34008227  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wiesbach"@de .
+
+:n333   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Donnersberg-Kreis"@de .
+
+:n13405025  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fischbach"@de .
+
+:n235070010103  a       skos:Concept ;
+        skos:broader    :n23507001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haus Wehrborn"@de .
+
+:n232012580101  a       skos:Concept ;
+        skos:broader    :n23201258 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berscheiderhof"@de .
+
+:n320000000101  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bombacherhof"@de .
+
+:n33510034  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Otterbach"@de .
+
+:n138090060115  a       skos:Concept ;
+        skos:broader    :n13809006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Verscheid"@de .
+
+:n23208061  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Idesheim"@de .
+
+:n335100410102  a       skos:Concept ;
+        skos:broader    :n33510041 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wickelhof"@de .
+
+:n13306109  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallhausen"@de .
+
+:n340060540200  a       skos:Concept ;
+        skos:broader    :n34006054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldfischbach"@de .
+
+:n23108003  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arenrath"@de .
+
+:n23205085  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nasingen"@de .
+
+:n132060140103  a       skos:Concept ;
+        skos:broader    :n13206014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenbach"@de .
+
+:n141090660103  a       skos:Concept ;
+        skos:broader    :n14109066 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg Sterrenberg"@de .
+
+:n13210119  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ziegenhain"@de .
+
+:n13709220  a           skos:Concept ;
+        skos:broader    :n13709 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberfell"@de .
+
+:n13103081  a           skos:Concept ;
+        skos:broader    :n13103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldorf"@de .
+
+:n132100550103  a       skos:Concept ;
+        skos:broader    :n13210055 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Luchert"@de .
+
+:n13310001  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Abtweiler"@de .
+
+:n132060280101  a       skos:Concept ;
+        skos:broader    :n13206028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heckenhof"@de .
+
+:n13405083  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sienhachenbach"@de .
+
+:n33701017  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dernbach"@de .
+
+:n33808026  a           skos:Concept ;
+        skos:broader    :n33808 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldsee"@de .
+
+:n14004028  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dickenschied"@de .
+
+:n33501  a              skos:Concept ;
+        skos:broader    :n335 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bruchmühlbach-Miesau, Verbandsgemeinde"@de .
+
+:n14109112  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Prath"@de .
+
+:n235060830100  a       skos:Concept ;
+        skos:broader    :n23506083 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lörsch"@de .
+
+:n14309307  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weltersburg"@de .
+
+:n34008206  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Contwig"@de .
+
+:n23201247  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kesfeld"@de .
+
+:n13405004  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Asbach"@de .
+
+:n131000700600  a       skos:Concept ;
+        skos:broader    :n13100070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rolandseck (T.a.Ortsbezirk 3)"@de .
+
+:n14307075  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinen"@de .
+
+:n135050130101  a       skos:Concept ;
+        skos:broader    :n13505013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Briedeler Heck"@de .
+
+:n33510013  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heiligenmoschel"@de .
+
+:n111000002102  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Königsbach"@de .
+
+:n143092890100  a       skos:Concept ;
+        skos:broader    :n14309289 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obersayn"@de .
+
+:n235010450101  a       skos:Concept ;
+        skos:broader    :n23501045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Abtei"@de .
+
+:n23205064  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Karlshausen"@de .
+
+:n23304202  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bereborn"@de .
+
+:n337010640101  a       skos:Concept ;
+        skos:broader    :n33701064 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Modenbacherhof"@de .
+
+:n4054837n5  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siebengebirge"@de .
+
+:n33903019  a           skos:Concept ;
+        skos:broader    :n33903 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gau-Algesheim, Stadt"@de .
+
+:n14004086  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lindenschied"@de .
+
+:n132070630601  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Äpfelbach"@de .
+
+:n13104059  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberdürenbach"@de .
+
+:n33902020  a           skos:Concept ;
+        skos:broader    :n33902 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gau-Bischofsheim"@de .
+
+:n111000000900  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Karthause"@de .
+
+:n23109124  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Traben-Trarbach, Stadt"@de .
+
+:n14111  a              skos:Concept ;
+        skos:broader    :n141 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Aar-Einrich, Verbandsgemeinde"@de .
+
+:n339000050600  a       skos:Concept ;
+        skos:broader    :n33900005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gaulsheim"@de .
+
+:n340092250100  a       skos:Concept ;
+        skos:broader    :n34009225 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhausen"@de .
+
+:n4039705n1  a          skos:Concept ;
+        skos:broader    :n22 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelrhein"@de .
+
+:n134020420200  a       skos:Concept ;
+        skos:broader    :n13402042 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiersbach"@de .
+
+:n14004007  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Belg"@de .
+
+:n14308281  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberahr"@de .
+
+:n141110500106  a       skos:Concept ;
+        skos:broader    :n14111050 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rupbach"@de .
+
+:n14008125  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinböllen, Stadt"@de .
+
+:n231011360102  a       skos:Concept ;
+        skos:broader    :n23101136 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rachtig (Ortsbezirk)"@de .
+
+:n132080540107  a       skos:Concept ;
+        skos:broader    :n13208054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberhövels"@de .
+
+:n14110098  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nievern"@de .
+
+:n33701054  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münchweiler am Klingbach"@de .
+
+:n33907201  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dorn-Dürkheim"@de .
+
+:n13207072  a           skos:Concept ;
+        skos:broader    :n13207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mudersbach"@de .
+
+:n233015010400  a       skos:Concept ;
+        skos:broader    :n23301501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pützborn (Ortsbezirk)"@de .
+
+:n320000000600  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelbach (Ortsbezirk)"@de .
+
+:n131000770600  a       skos:Concept ;
+        skos:broader    :n13100077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westum (Ortsbezirk)"@de .
+
+:n13405041  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hintertiefenbach"@de .
+
+:n339000300213  a       skos:Concept ;
+        skos:broader    :n33900030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sporkenheim"@de .
+
+:n33207047  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wattenheim"@de .
+
+:n140005010402  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Windhausen"@de .
+
+:n337040380100  a       skos:Concept ;
+        skos:broader    :n33704038 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hayna (Ortsbezirk)"@de .
+
+:n13803023  a           skos:Concept ;
+        skos:broader    :n13803 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Großmaischeid"@de .
+
+:n14304057  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberelbert"@de .
+
+:n312000001000  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Siegelbach (Ortsbezirk)"@de .
+
+:n131042050101  a       skos:Concept ;
+        skos:broader    :n13104205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maria Laach"@de .
+
+:n33906032  a           skos:Concept ;
+        skos:broader    :n33906 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klein-Winternheim"@de .
+
+:n13809066  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rüscheid"@de .
+
+:n23205022  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burg"@de .
+
+:n13309016  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brauweiler"@de .
+
+:n14302229  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hachenburg, Stadt"@de .
+
+:n33701033  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gossersweiler-Stein"@de .
+
+:n14004044  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hahn"@de .
+
+:n340010040104  a       skos:Concept ;
+        skos:broader    :n34001004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reichenbach"@de .
+
+:n23201263  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lützkampen"@de .
+
+:n333070040103  a       skos:Concept ;
+        skos:broader    :n33307004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schmalfelderhof"@de .
+
+:n14309238  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hergenroth"@de .
+
+:n133061050101  a       skos:Concept ;
+        skos:broader    :n13306105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Auf dem Rotenfels"@de .
+
+:n137025010300  a       skos:Concept ;
+        skos:broader    :n13702501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lasserg (Ortsbezirk)"@de .
+
+:n23205080  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mettendorf"@de .
+
+:n13306098  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sommerloch"@de .
+
+:n14302287  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roßbach"@de .
+
+:n14304036  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hübingen"@de .
+
+:n14110141  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zimmerschied"@de .
+
+:n13210114  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Werkhausen"@de .
+
+:n233010170101  a       skos:Concept ;
+        skos:broader    :n23301017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Desserath"@de .
+
+:n14008077  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kümbdchen"@de .
+
+:n231010700200  a       skos:Concept ;
+        skos:broader    :n23101070 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fronhofen (Ortsbezirk)"@de .
+
+:n13306019  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burgsponheim"@de .
+
+:n23205001  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Affler"@de .
+
+:n138090360102  a       skos:Concept ;
+        skos:broader    :n13809036 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Escherwiese"@de .
+
+:n140032020400  a       skos:Concept ;
+        skos:broader    :n14003202 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sabershausen (Ortsbezirk)"@de .
+
+:n33808021  a           skos:Concept ;
+        skos:broader    :n33808 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Otterstadt"@de .
+
+:n33302019  a           skos:Concept ;
+        skos:broader    :n33302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eisenberg (Pfalz), Stadt"@de .
+
+:n138010030108  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Limberg (ehemals Gemeinde Elsaff)"@de .
+
+:n23106079  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Malborn"@de .
+
+:n34008201  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Althornbach"@de .
+
+:n140091120304  a       skos:Concept ;
+        skos:broader    :n14009112 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederbachtal"@de .
+
+:n23304048  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neichen"@de .
+
+:n235040370101  a       skos:Concept ;
+        skos:broader    :n23504037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Romika"@de .
+
+:n58    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bayerische Pfalz"@de .
+
+:n133090460100  a       skos:Concept ;
+        skos:broader    :n13309046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochstädten (Ortsbezirk)"@de .
+
+:n13210087  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ölsen"@de .
+
+:n14004081  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laufersweiler"@de .
+
+:n14008056  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Holzbach"@de .
+
+:n13104054  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederdürenbach"@de .
+
+:n137   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mayen-Koblenz, Landkreis"@de .
+
+:n312000002100  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Erzhütten/Wiesenthalerhof (Ortsbezirk)"@de .
+
+:n13208008  a           skos:Concept ;
+        skos:broader    :n13208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Birken-Honigsessen"@de .
+
+:n33405032  a           skos:Concept ;
+        skos:broader    :n33405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weingarten (Pfalz)"@de .
+
+:n132081170200  a       skos:Concept ;
+        skos:broader    :n13208117 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Köttingerhöhe"@de .
+
+:n333040390111  a       skos:Concept ;
+        skos:broader    :n33304039 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rothenkircherhof"@de .
+
+:n23106058  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Horath"@de .
+
+:n231011330107  a       skos:Concept ;
+        skos:broader    :n23101133 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kasholz"@de .
+
+:n134010050102  a       skos:Concept ;
+        skos:broader    :n13401005 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eschelbacherhof"@de .
+
+:n235081040100  a       skos:Concept ;
+        skos:broader    :n23508104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dilmar (Ortsbezirk)"@de .
+
+:n37    a               skos:Concept ;
+        skos:broader    :n3 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katholische Kirche / Diözese Speyer"@de .
+
+:n14103049  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gückingen"@de .
+
+:n233060260700  a       skos:Concept ;
+        skos:broader    :n23306026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Michelbach (Ortsbezirk)"@de .
+
+:n13501049  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klotten"@de .
+
+:n231005021101  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dörrwiese"@de .
+
+:n14008035  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellern (Hunsrück)"@de .
+
+:n333060420102  a       skos:Concept ;
+        skos:broader    :n33306042 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pulvermühle"@de .
+
+:n23106122  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Talling"@de .
+
+:n333075020310  a       skos:Concept ;
+        skos:broader    :n33307502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Scharfeeck"@de .
+
+:n231005020500  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haag (Ortsbezirk)"@de .
+
+:n33207042  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Quirnheim"@de .
+
+:n4102956n2  a          skos:Concept ;
+        skos:broader    :n22 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pellenz"@de .
+
+:n95    a               skos:Concept ;
+        skos:broader    :n07 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Südpfalz"@de .
+
+:n14309254  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenhahn"@de .
+
+:n14306278  a           skos:Concept ;
+        skos:broader    :n14306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nister-Möhrendorf"@de .
+
+:n14304052  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhäusel"@de .
+
+:n33705082  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Walsheim"@de .
+
+:n231085030101  a       skos:Concept ;
+        skos:broader    :n23108503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenhof"@de .
+
+:n319000000500  a       skos:Concept ;
+        skos:broader    :n31900000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochheim (Ortsbezirk)"@de .
+
+:n33800017  a           skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Limburgerhof"@de .
+
+:n16    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westrich"@de .
+
+:n132070630405  a       skos:Concept ;
+        skos:broader    :n13207063 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jungenthal"@de .
+
+:n33903051  a           skos:Concept ;
+        skos:broader    :n33903 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwabenheim an der Selz"@de .
+
+:n13809061  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rengsdorf"@de .
+
+:n337010330100  a       skos:Concept ;
+        skos:broader    :n33701033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gossersweiler"@de .
+
+:n232013330100  a       skos:Concept ;
+        skos:broader    :n23201333 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Binscheid"@de .
+
+:n13311108  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldlaubersheim"@de .
+
+:n340040310103  a       skos:Concept ;
+        skos:broader    :n34004031 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wieslauterhof"@de .
+
+:n134000450900  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberstein"@de .
+
+:n34009216  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krähenberg"@de .
+
+:n13804075  a           skos:Concept ;
+        skos:broader    :n13804 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vettelschoß"@de .
+
+:n33207021  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gerolsheim"@de .
+
+:n14009156  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Utzenhain"@de .
+
+:n33511023  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Linden"@de .
+
+:n23208306  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seinsfeld"@de .
+
+:n14309233  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Halbs"@de .
+
+:n13501086  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Valwig"@de .
+
+:n13209108  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steineroth"@de .
+
+:n13306014  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Boos"@de .
+
+:n131020270107  a       skos:Concept ;
+        skos:broader    :n13102027 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederheckenbach"@de .
+
+:n333040130101  a       skos:Concept ;
+        skos:broader    :n33304013 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bastenhaus"@de .
+
+:n33702006  a           skos:Concept ;
+        skos:broader    :n33702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Barbelroth"@de .
+
+:n111000000200  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arzheim (Ortsbezirk 2)"@de .
+
+:n13501007  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beilstein"@de .
+
+:n13700203  a           skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bendorf, Stadt"@de .
+
+:n13101015  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dankerath"@de .
+
+:n333065030100  a       skos:Concept ;
+        skos:broader    :n33306503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Alsenbrück-Langmeil (Ortsbezirk)"@de .
+
+:n138010030103  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büsch"@de .
+
+:n143022960103  a       skos:Concept ;
+        skos:broader    :n14302296 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehrlich"@de .
+
+:n23301067  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steineberg"@de .
+
+:n33804  a              skos:Concept ;
+        skos:broader    :n338 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maxdorf, Verbandsgemeinde"@de .
+
+:n14305009  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Deesen"@de .
+
+:n33511002  a           skos:Concept ;
+        skos:broader    :n33511 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bann"@de .
+
+:n13208  a              skos:Concept ;
+        skos:broader    :n132 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wissen, Verbandsgemeinde"@de .
+
+:n131000070700  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ramersbach (Ortsbezirk)"@de .
+
+:n53    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hessen-Darmstadt"@de .
+
+:n138070730103  a       skos:Concept ;
+        skos:broader    :n13807073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heister"@de .
+
+:n135010820202  a       skos:Concept ;
+        skos:broader    :n13501082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beurenhof"@de .
+
+:n231001340502  a       skos:Concept ;
+        skos:broader    :n23100134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wahlholz"@de .
+
+:n231005021600  a       skos:Concept ;
+        skos:broader    :n23100502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wederath (Ortsbezirk)"@de .
+
+:n14302261  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marzhausen"@de .
+
+:n13210082  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberirsen"@de .
+
+:n33705040  a           skos:Concept ;
+        skos:broader    :n33705 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heuchelheim-Klingen"@de .
+
+:n13501065  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Moselkern"@de .
+
+:n13401007  a           skos:Concept ;
+        skos:broader    :n13401 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berglangenbach"@de .
+
+:n138010800304  a       skos:Concept ;
+        skos:broader    :n13801080 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jungeroth"@de .
+
+:n131000900700  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lantershofen (Ortsbezirk)"@de .
+
+:n340092220100  a       skos:Concept ;
+        skos:broader    :n34009222 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höhmühlbach"@de .
+
+:n235070730202  a       skos:Concept ;
+        skos:broader    :n23507073 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wasserbilligerbrück"@de .
+
+:n33608049  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kappeln"@de .
+
+:n132   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenkirchen(Ww), Landkreis"@de .
+
+:n14107104  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obertiefenbach"@de .
+
+:n133010030101  a       skos:Concept ;
+        skos:broader    :n13301003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altenbaumburg"@de .
+
+:n138090150101  a       skos:Concept ;
+        skos:broader    :n13809015 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forsthaus Gommerscheid"@de .
+
+:n23301046  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mückeln"@de .
+
+:n231062040101  a       skos:Concept ;
+        skos:broader    :n23106204 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heidenburgerhof"@de .
+
+:n32    a               skos:Concept ;
+        skos:broader    :n3 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Evangelische Kirche der Pfalz (Protestantische Landeskirche)"@de .
+
+:n14107019  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buch"@de .
+
+:n138010440310  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weißenfels"@de .
+
+:n14302240  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heuzert"@de .
+
+:n13210061  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kettenhausen"@de .
+
+:n235075010303  a       skos:Concept ;
+        skos:broader    :n23507501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wellkyll"@de .
+
+:n13505019  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bullay"@de .
+
+:n23503133  a           skos:Concept ;
+        skos:broader    :n23503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Temmels"@de .
+
+:n13101052  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Müsch"@de .
+
+:n138010440225  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rotterheide (ehem.Gem.Elsaffthal)"@de .
+
+:n318000000104  a       skos:Concept ;
+        skos:broader    :n31800000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleine Lann"@de .
+
+:n137000030400  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Miesenheim (Ortsbezirk)"@de .
+
+:n340010450200  a       skos:Concept ;
+        skos:broader    :n34001045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gebüg (Ortsbezirk)"@de .
+
+:n140030210200  a       skos:Concept ;
+        skos:broader    :n14003021 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörz (Ortsbezirk)"@de .
+
+:n131000070111  a       skos:Concept ;
+        skos:broader    :n13100007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Walporzheim (Ortsbezirk)"@de .
+
+:n132060910103  a       skos:Concept ;
+        skos:broader    :n13206091 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hohegrete"@de .
+
+:n33101027  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freimersheim"@de .
+
+:n90    a               skos:Concept ;
+        skos:broader    :n07 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Westpfalz"@de .
+
+:n13203075  a           skos:Concept ;
+        skos:broader    :n13203 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederdreisbach"@de .
+
+:n23106032  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Etgert"@de .
+
+:n337060470103  a       skos:Concept ;
+        skos:broader    :n33706047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Breitenstein, Forsthaus"@de .
+
+:n23306227  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mürlenbach"@de .
+
+:n111000001300  a       skos:Concept ;
+        skos:broader    :n11100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Metternich"@de .
+
+:n23301025  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gefell"@de .
+
+:n13505077  a           skos:Concept ;
+        skos:broader    :n13505 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schauren"@de .
+
+:n14009087  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lingerhahn"@de .
+
+:n11    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Taunus"@de .
+
+:n138040750108  a       skos:Concept ;
+        skos:broader    :n13804075 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Willscheid"@de .
+
+:n33608086  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Relsberg"@de .
+
+:n233010840106  a       skos:Concept ;
+        skos:broader    :n23301084 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberwinkel"@de .
+
+:n13210040  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gieleroth"@de .
+
+:n13311103  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stromberg, Stadt"@de .
+
+:n137030340101  a       skos:Concept ;
+        skos:broader    :n13703034 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morswiesen"@de .
+
+:n13209039  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gebhardshain"@de .
+
+:n14308  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallmerod, Verbandsgemeinde"@de .
+
+:n4393885n1  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kroppacher Schweiz"@de .
+
+:n34001033  a           skos:Concept ;
+        skos:broader    :n34001 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederschlettenbach"@de .
+
+:n14308080  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weroth"@de .
+
+:n13707  a              skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vallendar, Verbandsgemeinde"@de .
+
+:n13311018  a           skos:Concept ;
+        skos:broader    :n13311 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bretzenheim"@de .
+
+:n13703110  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weiler"@de .
+
+:n317000000200  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fehrbach (Ortsbezirk)"@de .
+
+:n235030680601  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obermennig (T.a.Ortsbezirk 4)"@de .
+
+:n316000000800  a       skos:Concept ;
+        skos:broader    :n31600000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Königsbach (Ortsbezirk)"@de .
+
+:n320000001000  a       skos:Concept ;
+        skos:broader    :n32000000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rimschweiler (Ortsbezirk)"@de .
+
+:n131020470200  a       skos:Concept ;
+        skos:broader    :n13102047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obliers"@de .
+
+:n13703025  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ettringen"@de .
+
+:n14103002  a           skos:Concept ;
+        skos:broader    :n14103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Altendiez"@de .
+
+:n131020270102  a       skos:Concept ;
+        skos:broader    :n13102027 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Blasweiler"@de .
+
+:n33608065  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nerzweiler"@de .
+
+:n137025010603  a       skos:Concept ;
+        skos:broader    :n13702501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sevenich"@de .
+
+:n14107120  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruppertshofen"@de .
+
+:n138040090101  a       skos:Concept ;
+        skos:broader    :n13804009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arnsau"@de .
+
+:n13805048  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederhofen"@de .
+
+:n23301062  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saxler"@de .
+
+:n33201043  a           skos:Concept ;
+        skos:broader    :n33201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruppertsberg"@de .
+
+:n33205018  a           skos:Concept ;
+        skos:broader    :n33205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frankeneck"@de .
+
+:n13203  a              skos:Concept ;
+        skos:broader    :n132 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Daaden-Herdorf, Verbandsgemeinde"@de .
+
+:n14107035  a           skos:Concept ;
+        skos:broader    :n14107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehr"@de .
+
+:n131020170102  a       skos:Concept ;
+        skos:broader    :n13102017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Marienthal"@de .
+
+:n333070430102  a       skos:Concept ;
+        skos:broader    :n33307043 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weidelbacherhof"@de .
+
+:n13501060  a           skos:Concept ;
+        skos:broader    :n13501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mesenich"@de .
+
+:n232012630300  a       skos:Concept ;
+        skos:broader    :n23201263 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welchenhausen"@de .
+
+:n14009045  a           skos:Concept ;
+        skos:broader    :n14009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Halsenbach"@de .
+
+:n33306042  a           skos:Concept ;
+        skos:broader    :n33306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lohnsfeld"@de .
+
+:n143092420300  a       skos:Concept ;
+        skos:broader    :n14309242 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oellingen"@de .
+
+:n231010120201  a       skos:Concept ;
+        skos:broader    :n23101012 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirzlei (Ortsbezirk)"@de .
+
+:n13703004  a           skos:Concept ;
+        skos:broader    :n13703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Anschau"@de .
+
+:n131010370100  a       skos:Concept ;
+        skos:broader    :n13101037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Jammelshofen"@de .
+
+:n33608044  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Homberg"@de .
+
+:n33101043  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lonsheim"@de .
+
+:n33806013  a           skos:Concept ;
+        skos:broader    :n33806 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heuchelheim bei Frankenthal"@de .
+
+:n134020580101  a       skos:Concept ;
+        skos:broader    :n13402058 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Böschweiler"@de .
+
+:n13805027  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Harschbach"@de .
+
+:n235081260106  a       skos:Concept ;
+        skos:broader    :n23508126 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloss Saarstein"@de .
+
+:n14305062  a           skos:Concept ;
+        skos:broader    :n14305 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ransbach-Baumbach, Stadt"@de .
+
+:n138045010100  a       skos:Concept ;
+        skos:broader    :n13804501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kasbach"@de .
+
+:n33508044  a           skos:Concept ;
+        skos:broader    :n33508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinwenden"@de .
+
+:n33609107  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Matzenbach"@de .
+
+:n340082080102  a       skos:Concept ;
+        skos:broader    :n34008208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirschbacherhof"@de .
+
+:n13502038  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hambuch"@de .
+
+:n33608023  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eßweiler"@de .
+
+:n33101022  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Esselborn"@de .
+
+:n141030140101  a       skos:Concept ;
+        skos:broader    :n14103014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fachingen"@de .
+
+:n134000450200  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Georg-Weierbach"@de .
+
+:n33403024  a           skos:Concept ;
+        skos:broader    :n33403 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinzabern"@de .
+
+:n143022650102  a       skos:Concept ;
+        skos:broader    :n14302265 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Burbach"@de .
+
+:n23301020  a           skos:Concept ;
+        skos:broader    :n23301 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreis-Brück"@de .
+
+:n211000001101  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Domäne Avelsbach"@de .
+
+:n33307078  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unkenbach"@de .
+
+:n33608  a              skos:Concept ;
+        skos:broader    :n336 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lauterecken-Wolfstein, Verbandsgemeinde"@de .
+
+:n33801006  a           skos:Concept ;
+        skos:broader    :n33801 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dannstadt-Schauernheim"@de .
+
+:n33610081  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rathsweiler"@de .
+
+:n133000060600  a       skos:Concept ;
+        skos:broader    :n13300006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Münster am Stein-Ebernburg (Ortsbezirk)"@de .
+
+:n140030100500  a       skos:Concept ;
+        skos:broader    :n14003010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schnellbach (Ortsbezirk)"@de .
+
+:n211000000500  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Euren (Ortsbezirk 9)"@de .
+
+:n141110540101  a       skos:Concept ;
+        skos:broader    :n14111054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dillenbergermühle"@de .
+
+:n138020040103  a       skos:Concept ;
+        skos:broader    :n13802004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Girgenrath"@de .
+
+:n140005010700  a       skos:Concept ;
+        skos:broader    :n14000501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oppenhausen (Ortsbezirk)"@de .
+
+:n14303  a              skos:Concept ;
+        skos:broader    :n143 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Höhr-Grenzhausen, Verbandsgemeinde"@de .
+
+:n33610002  a           skos:Concept ;
+        skos:broader    :n33610 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Albessen"@de .
+
+:n13805064  a           skos:Concept ;
+        skos:broader    :n13805 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rodenbach bei Puderbach"@de .
+
+:n33101001  a           skos:Concept ;
+        skos:broader    :n33101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Albig"@de .
+
+:n33205034  a           skos:Concept ;
+        skos:broader    :n33205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lindenberg"@de .
+
+:n13702  a              skos:Concept ;
+        skos:broader    :n137 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maifeld, Verbandsgemeinde"@de .
+
+:n235030950200  a       skos:Concept ;
+        skos:broader    :n23503095 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Köllig (Ortsbezirk)"@de .
+
+:n333040100101  a       skos:Concept ;
+        skos:broader    :n33304010 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bolanderhof"@de .
+
+:n13502075  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roes"@de .
+
+:n13708222  a           skos:Concept ;
+        skos:broader    :n13708 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sankt Sebastian"@de .
+
+:n143040210200  a       skos:Concept ;
+        skos:broader    :n14304021 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinholbach"@de .
+
+:n33608060  a           skos:Concept ;
+        skos:broader    :n33608 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lohnweiler"@de .
+
+:n232080170103  a       skos:Concept ;
+        skos:broader    :n23208017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hungerburg"@de .
+
+:n132070370146  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obersolbach"@de .
+
+:n235070940200  a       skos:Concept ;
+        skos:broader    :n23507094 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Butzweiler (Ortsbezirk)"@de .
+
+:n23208126  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trimport"@de .
+
+:n34002006  a           skos:Concept ;
+        skos:broader    :n34002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dimbach"@de .
+
+:n135010250101  a       skos:Concept ;
+        skos:broader    :n13501025 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ellenz"@de .
+
+:n314000000500  a       skos:Concept ;
+        skos:broader    :n31400000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oggersheim (Ortsbezirk)"@de .
+
+:n332050140112  a       skos:Concept ;
+        skos:broader    :n33205014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwabenbach"@de .
+
+:n233060560105  a       skos:Concept ;
+        skos:broader    :n23306056 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloßbrunnen Gerolstein"@de .
+
+:n332000020107  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grethen (Ortsbezirk)"@de .
+
+:n235081360101  a       skos:Concept ;
+        skos:broader    :n23508136 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Perdenbach"@de .
+
+:n13209071  a           skos:Concept ;
+        skos:broader    :n13209 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Molzhain"@de .
+
+:n33307036  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kalkofen"@de .
+
+:n23508118  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saarburg, Stadt"@de .
+
+:n4288874n8  a          skos:Concept ;
+        skos:broader    :n50 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Département Donnersberg"@de .
+
+:n135050920200  a       skos:Concept ;
+        skos:broader    :n13505092 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Merl"@de .
+
+:n4119314n3  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Unterwesterwald"@de .
+
+:n4109995n3  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kannenbäckerland"@de .
+
+:n13104209  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wassenach"@de .
+
+:n23206  a              skos:Concept ;
+        skos:broader    :n232 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Prüm, Verbandsgemeinde"@de .
+
+:n33807007  a           skos:Concept ;
+        skos:broader    :n33807 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dudenhofen"@de .
+
+:n14003009  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bell (Hunsrück)"@de .
+
+:n23208105  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pickließem"@de .
+
+:n23208099  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberweis"@de .
+
+:n211000001600  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pfalzel (Ortsbezirk 5)"@de .
+
+:n4012733n3  a          skos:Concept ;
+        skos:broader    :n17 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Donnersberg"@de .
+
+:n231061230102  a       skos:Concept ;
+        skos:broader    :n23106123 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Forsthaus Deuselbach"@de .
+
+:n335100460100  a       skos:Concept ;
+        skos:broader    :n33510046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obersulzbach"@de .
+
+:n33801022  a           skos:Concept ;
+        skos:broader    :n33801 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rödersheim-Gronau"@de .
+
+:n33609102  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldmohr, Stadt"@de .
+
+:n33609096  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinbach am Glan"@de .
+
+:n4049779n3  a          skos:Concept ;
+        skos:broader    :n03 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rheinisches Schiefergebirge"@de .
+
+:n33703032  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gommersheim"@de .
+
+:n13502033  a           skos:Concept ;
+        skos:broader    :n13502 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gamlen"@de .
+
+:n231091240209  a       skos:Concept ;
+        skos:broader    :n23109124 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Litzig"@de .
+
+:n33304039  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchheimbolanden, Stadt"@de .
+
+:n232063290202  a       skos:Concept ;
+        skos:broader    :n23206329 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinebrück"@de .
+
+:n33609017  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dunzweiler"@de .
+
+:n338010140200  a       skos:Concept ;
+        skos:broader    :n33801014 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hochdorf"@de .
+
+:n141110890102  a       skos:Concept ;
+        skos:broader    :n14111089 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hohlenfels"@de .
+
+:n23504037  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gusterath"@de .
+
+:n232050190108  a       skos:Concept ;
+        skos:broader    :n23205019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weilerbach"@de .
+
+:n143050620100  a       skos:Concept ;
+        skos:broader    :n14305062 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Baumbach"@de .
+
+:n23205108  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Prümzurlay"@de .
+
+:n131000901100  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vettelhoven (Ortsbezirk)"@de .
+
+:n335090490104  a       skos:Concept ;
+        skos:broader    :n33509049 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Samuelshof"@de .
+
+:n137020860105  a       skos:Concept ;
+        skos:broader    :n13702086 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fressenhof"@de .
+
+:n14003131  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Roth"@de .
+
+:n33307073  a           skos:Concept ;
+        skos:broader    :n33307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stahlberg"@de .
+
+:n33703011  a           skos:Concept ;
+        skos:broader    :n33703 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Böbingen"@de .
+
+:n138090540100  a       skos:Concept ;
+        skos:broader    :n13809054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederraden"@de .
+
+:n14003046  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hasselbach"@de .
+
+:n315000000700  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hechtsheim (Ortsbezirk)"@de .
+
+:n333040450102  a       skos:Concept ;
+        skos:broader    :n33304045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Elbisheimerhof"@de .
+
+:n23101133  a           skos:Concept ;
+        skos:broader    :n23101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wintrich"@de .
+
+:n4064074n7  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vulkaneifel"@de .
+
+:n340010020102  a       skos:Concept ;
+        skos:broader    :n34001002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bärenbrunnermühle"@de .
+
+:n5     a               skos:Concept ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Angrenzende Gebiete und länderübergreifende Regionen"@de .
+
+:n13310076  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Odernheim am Glan"@de .
+
+:n13704093  a           skos:Concept ;
+        skos:broader    :n13704 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rieden"@de .
+
+:n338000040100  a       skos:Concept ;
+        skos:broader    :n33800004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bobenheim"@de .
+
+:n23208057  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hütterscheid"@de .
+
+:n137092120100  a       skos:Concept ;
+        skos:broader    :n13709212 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dreckenach"@de .
+
+:n13802004  a           skos:Concept ;
+        skos:broader    :n13802 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bad Hönningen, Stadt"@de .
+
+:n332000020123  a       skos:Concept ;
+        skos:broader    :n33200002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Seebach (Ortsbezirk)"@de .
+
+:n33704068  a           skos:Concept ;
+        skos:broader    :n33704 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rohrbach"@de .
+
+:n14004109  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederweiler"@de .
+
+:n33304076  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stetten"@de .
+
+:n235075010102  a       skos:Concept ;
+        skos:broader    :n23507501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Helenenberg"@de .
+
+:n13405079  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwerbach"@de .
+
+:n335100290102  a       skos:Concept ;
+        skos:broader    :n33510029 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Karlshöhe"@de .
+
+:n33609054  a           skos:Concept ;
+        skos:broader    :n33609 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krottelbach"@de .
+
+:n340092190102  a       skos:Concept ;
+        skos:broader    :n34009219 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neumühle"@de .
+
+:n33807023  a           skos:Concept ;
+        skos:broader    :n33807 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Römerberg"@de .
+
+:n14310003  a           skos:Concept ;
+        skos:broader    :n14310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bannberscheid"@de .
+
+:n14109108  a           skos:Concept ;
+        skos:broader    :n14109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Osterspai"@de .
+
+:n143100600200  a       skos:Concept ;
+        skos:broader    :n14310060 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sainerholz"@de .
+
+:n339000300400  a       skos:Concept ;
+        skos:broader    :n33900030 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wackernheim"@de .
+
+:n14308304  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wallmerod"@de .
+
+:n132090660100  a       skos:Concept ;
+        skos:broader    :n13209066 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hommelsberg"@de .
+
+:n23306026  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gerolstein, Stadt"@de .
+
+:n13402070  a           skos:Concept ;
+        skos:broader    :n13402 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rimsberg"@de .
+
+:n336080850101  a       skos:Concept ;
+        skos:broader    :n33608085 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ausbacherhof"@de .
+
+:n33510009  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Frankelbach"@de .
+
+:n13310055  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Langenthal"@de .
+
+:n13701096  a           skos:Concept ;
+        skos:broader    :n13701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Saffig"@de .
+
+:n339080500103  a       skos:Concept ;
+        skos:broader    :n33908050 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wißberg"@de .
+
+:n232012600300  a       skos:Concept ;
+        skos:broader    :n23201260 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Stalbach"@de .
+
+:n23208036  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Feilsdorf"@de .
+
+:n33707023  a           skos:Concept ;
+        skos:broader    :n33707 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Essingen"@de .
+
+:n13503048  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kliding"@de .
+
+:n23206208  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Buchet"@de .
+
+:n13309203  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Königsau"@de .
+
+:n143062180200  a       skos:Concept ;
+        skos:broader    :n14306218 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mittelhofen"@de .
+
+:n14107  a              skos:Concept ;
+        skos:broader    :n141 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nastätten, Verbandsgemeinde"@de .
+
+:n138010030316  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedermühlen"@de .
+
+:n143040650100  a       skos:Concept ;
+        skos:broader    :n14304065 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Goldhausen"@de .
+
+:n23508028  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freudenburg"@de .
+
+:n138010770103  a       skos:Concept ;
+        skos:broader    :n13801077 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Günterscheid"@de .
+
+:n13104204  a           skos:Concept ;
+        skos:broader    :n13104 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Galenberg"@de .
+
+:n23201  a              skos:Concept ;
+        skos:broader    :n232 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arzfeld, Verbandsgemeinde"@de .
+
+:n233062270104  a       skos:Concept ;
+        skos:broader    :n23306227 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hardt"@de .
+
+:n33404034  a           skos:Concept ;
+        skos:broader    :n33404 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winden"@de .
+
+:n132070370120  a       skos:Concept ;
+        skos:broader    :n13207037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heiligenborn"@de .
+
+:n23208100  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Olsdorf"@de .
+
+:n23108036  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gipperath"@de .
+
+:n235030680400  a       skos:Concept ;
+        skos:broader    :n23503068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kommlingen (Ortsbezirk 3)"@de .
+
+:n335020260205  a       skos:Concept ;
+        skos:broader    :n33502026 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neukirchen"@de .
+
+:n23306005  a           skos:Concept ;
+        skos:broader    :n23306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Berndorf"@de .
+
+:n14004146  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sohrschied"@de .
+
+:n23208015  a           skos:Concept ;
+        skos:broader    :n23208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biersdorf am See"@de .
+
+:n33106065  a           skos:Concept ;
+        skos:broader    :n33106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vendersheim"@de .
+
+:n137092300101  a       skos:Concept ;
+        skos:broader    :n13709230 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Distelbergerhof"@de .
+
+:n23108100  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberöfflingen"@de .
+
+:n13405037  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hellertshausen"@de .
+
+:n33510046  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sulzbachtal"@de .
+
+:n33404013  a           skos:Concept ;
+        skos:broader    :n33404 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kandel, Stadt"@de .
+
+:n13310092  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schweinschied"@de .
+
+:n23205103  a           skos:Concept ;
+        skos:broader    :n23205 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Peffingen"@de .
+
+:n340015010101  a       skos:Concept ;
+        skos:broader    :n34001501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reinigshof"@de .
+
+:n14307029  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Herschbach"@de .
+
+:n13503085  a           skos:Concept ;
+        skos:broader    :n13503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Urschmitt"@de .
+
+:n137030070105  a       skos:Concept ;
+        skos:broader    :n13703007 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederbaar"@de .
+
+:n339030190104  a       skos:Concept ;
+        skos:broader    :n33903019 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laurenziberg"@de .
+
+:n13405095  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wirschweiler"@de .
+
+:n333070370102  a       skos:Concept ;
+        skos:broader    :n33307037 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Obermittweilerhof"@de .
+
+:n133090460202  a       skos:Concept ;
+        skos:broader    :n13309046 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "St.Johannisberg"@de .
+
+:n134000450503  a       skos:Concept ;
+        skos:broader    :n13400045 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Tiefenstein"@de .
+
+:n335080160200  a       skos:Concept ;
+        skos:broader    :n33508016 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Katzenbach"@de .
+
+:n33304013  a           skos:Concept ;
+        skos:broader    :n33304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dannenfels"@de .
+
+:n23504090  a           skos:Concept ;
+        skos:broader    :n23504 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Morscheid"@de .
+
+:n235080620100  a       skos:Concept ;
+        skos:broader    :n23508062 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Beuren/Saargau (Ortsbezirk)"@de .
+
+:n13103014  a           skos:Concept ;
+        skos:broader    :n13103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Brohl-Lützing"@de .
+
+:n132101030101  a       skos:Concept ;
+        skos:broader    :n13210103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bettgenhausen"@de .
+
+:n34008218  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mauschbach"@de .
+
+:n23201259  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leidenborn"@de .
+
+:n211000001404  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Trimmelterhof"@de .
+
+:n135010170200  a       skos:Concept ;
+        skos:broader    :n13501017 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fankel"@de .
+
+:n33510025  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mehlbach"@de .
+
+:n14008158  a           skos:Concept ;
+        skos:broader    :n14008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wahlbach"@de .
+
+:n335110470121  a       skos:Concept ;
+        skos:broader    :n33511047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wilensteinerhof"@de .
+
+:n23501035  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Grimburg"@de .
+
+:n131020490103  a       skos:Concept ;
+        skos:broader    :n13102049 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laach"@de .
+
+:n23206224  a           skos:Concept ;
+        skos:broader    :n23206 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Giesdorf"@de .
+
+:n312000001601  a       skos:Concept ;
+        skos:broader    :n31200000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Entersweilerhof"@de .
+
+:n340090350103  a       skos:Concept ;
+        skos:broader    :n34009035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dusenbrücken"@de .
+
+:n313000000400  a       skos:Concept ;
+        skos:broader    :n31300000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörlheim (Ortsbezirk)"@de .
+
+:n14003503  a           skos:Concept ;
+        skos:broader    :n14003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörsdorf"@de .
+
+:n34006050  a           skos:Concept ;
+        skos:broader    :n34006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinalben"@de .
+
+:n33103047  a           skos:Concept ;
+        skos:broader    :n33103 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mörstadt"@de .
+
+:n232050470104  a       skos:Concept ;
+        skos:broader    :n23205047 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Windhausen"@de .
+
+:n131020110107  a       skos:Concept ;
+        skos:broader    :n13102011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vischel"@de .
+
+:n23501093  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuhütten"@de .
+
+:n231090040201  a       skos:Concept ;
+        skos:broader    :n23109004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heinzerathermühle"@de .
+
+:n235081180200  a       skos:Concept ;
+        skos:broader    :n23508118 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Krutweiler (Ortsbezirk)"@de .
+
+:n34008  a              skos:Concept ;
+        skos:broader    :n340 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zweibrücken-Land, Verbandsgemeinde"@de .
+
+:n132060960106  a       skos:Concept ;
+        skos:broader    :n13206096 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Thal"@de .
+
+:n14110201  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Arzbach"@de .
+
+:n14307066  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schenkelberg"@de .
+
+:n131020390103  a       skos:Concept ;
+        skos:broader    :n13102039 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weidenbach"@de .
+
+:n13310050  a           skos:Concept ;
+        skos:broader    :n13310 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ippenschied"@de .
+
+:n23501014  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Damflos"@de .
+
+:n333070650103  a       skos:Concept ;
+        skos:broader    :n33307065 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwarzengraben"@de .
+
+:n31700000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pirmasens, Kreisfreie Stadt"@de .
+
+:n235041240101  a       skos:Concept ;
+        skos:broader    :n23504124 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lonzenburg"@de .
+
+:n340030520101  a       skos:Concept ;
+        skos:broader    :n34003052 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Felsenbrunnerhof (Ortsbezirk)"@de .
+
+:n132100530103  a       skos:Concept ;
+        skos:broader    :n13210053 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hirzbach"@de .
+
+:n132100670101  a       skos:Concept ;
+        skos:broader    :n13210067 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hüttenhofen"@de .
+
+:n34003053  a           skos:Concept ;
+        skos:broader    :n34003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vinningen"@de .
+
+:n143012790100  a       skos:Concept ;
+        skos:broader    :n14301279 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büdingen"@de .
+
+:n13501  a              skos:Concept ;
+        skos:broader    :n135 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Cochem, Verbandsgemeinde"@de .
+
+:n23108031  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Esch"@de .
+
+:n33405028  a           skos:Concept ;
+        skos:broader    :n33405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwegenheim"@de .
+
+:n333040390107  a       skos:Concept ;
+        skos:broader    :n33304039 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Haide"@de .
+
+:n31600000  a           skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neustadt an der Weinstraße, Kreisfreie Stadt"@de .
+
+:n13309113  a           skos:Concept ;
+        skos:broader    :n13309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weitersborn"@de .
+
+:n14307045  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maroth"@de .
+
+:n4827033n7  a          skos:Concept ;
+        skos:broader    :n10 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Wildenburgisches Land"@de .
+
+:n14004141  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schwarzen"@de .
+
+:n134020420106  a       skos:Concept ;
+        skos:broader    :n13402042 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neubrücke"@de .
+
+:n23106203  a           skos:Concept ;
+        skos:broader    :n23106 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Büdlich"@de .
+
+:n13207063  a           skos:Concept ;
+        skos:broader    :n13207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kirchen (Sieg), Stadt"@de .
+
+:n211000001903  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Markusberg"@de .
+
+:n23508081  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mandern"@de .
+
+:n340   a               skos:Concept ;
+        skos:broader    :n6 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Südwestpfalz, Landkreis"@de .
+
+:n132090060200  a       skos:Concept ;
+        skos:broader    :n13209006 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dauersberg (Dauersberg)"@de .
+
+:n13405032  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Griebelschied"@de .
+
+:n33207038  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Neuleiningen"@de .
+
+:n33510041  a           skos:Concept ;
+        skos:broader    :n33510 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schallodenbach"@de .
+
+:n131040540101  a       skos:Concept ;
+        skos:broader    :n13104054 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hain"@de .
+
+:n23508002  a           skos:Concept ;
+        skos:broader    :n23508 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ayl"@de .
+
+:n23108010  a           skos:Concept ;
+        skos:broader    :n23108 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Binsfeld"@de .
+
+:n14308251  a           skos:Concept ;
+        skos:broader    :n14308 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kuhnhöfen"@de .
+
+:n14302299  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Streithausen"@de .
+
+:n23304230  a           skos:Concept ;
+        skos:broader    :n23304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Oberelz"@de .
+
+:n14304048  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Montabaur, Stadt"@de .
+
+:n14004120  a           skos:Concept ;
+        skos:broader    :n14004 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Raversbeuren"@de .
+
+:n333065030202  a       skos:Concept ;
+        skos:broader    :n33306503 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kahlheckerhof"@de .
+
+:n138010030205  a       skos:Concept ;
+        skos:broader    :n13801003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Löhe"@de .
+
+:n13702048  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kerben"@de .
+
+:n13405090  a           skos:Concept ;
+        skos:broader    :n13405 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Vollmersbach"@de .
+
+:n138090760106  a       skos:Concept ;
+        skos:broader    :n13809076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Over"@de .
+
+:n235041070103  a       skos:Concept ;
+        skos:broader    :n23504107 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pluwigerhammer"@de .
+
+:n211000002000  a       skos:Concept ;
+        skos:broader    :n21100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Zewen (T.a. Ortsbezirk 10)"@de .
+
+:n33701024  a           skos:Concept ;
+        skos:broader    :n33701 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eußerthal"@de .
+
+:n141100820102  a       skos:Concept ;
+        skos:broader    :n14110082 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Waldschmidtmühle"@de .
+
+:n143040200101  a       skos:Concept ;
+        skos:broader    :n14304020 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dies"@de .
+
+:n14309314  a           skos:Concept ;
+        skos:broader    :n14309 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winnen"@de .
+
+:n23201254  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lambertsberg"@de .
+
+:n23109067  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kinderbeuern"@de .
+
+:n34008213  a           skos:Concept ;
+        skos:broader    :n34008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinbundenbach"@de .
+
+:n337020490103  a       skos:Concept ;
+        skos:broader    :n33702049 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Klingbachhof"@de .
+
+:n33906  a              skos:Concept ;
+        skos:broader    :n339 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Nieder-Olm, Verbandsgemeinde"@de .
+
+:n131000900802  a       skos:Concept ;
+        skos:broader    :n13100090 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niederich"@de .
+
+:n23501030  a           skos:Concept ;
+        skos:broader    :n23501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Geisfeld"@de .
+
+:n13702112  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Welling"@de .
+
+:n13306089  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schloßböckelheim"@de .
+
+:n235080280104  a       skos:Concept ;
+        skos:broader    :n23508028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kollesleuken"@de .
+
+:n14304027  a           skos:Concept ;
+        skos:broader    :n14304 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heiligenroth"@de .
+
+:n14110132  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Sulzbach"@de .
+
+:n13210099  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Schöneberg"@de .
+
+:n13208105  a           skos:Concept ;
+        skos:broader    :n13208 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Selbach (Sieg)"@de .
+
+:n13707229  a           skos:Concept ;
+        skos:broader    :n13707 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weitersburg"@de .
+
+:n13702027  a           skos:Concept ;
+        skos:broader    :n13702 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Gappenach"@de .
+
+:n232050330101  a       skos:Concept ;
+        skos:broader    :n23205033 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ernzerhof"@de .
+
+:n13809036  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kurtscheid"@de .
+
+:n231090680101  a       skos:Concept ;
+        skos:broader    :n23109068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kindel"@de .
+
+:n131020110102  a       skos:Concept ;
+        skos:broader    :n13102011 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Freisheim"@de .
+
+:n23201233  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hargarten"@de .
+
+:n133010320102  a       skos:Concept ;
+        skos:broader    :n13301032 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hof Iben"@de .
+
+:n132060960101  a       skos:Concept ;
+        skos:broader    :n13206096 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hämmerholz"@de .
+
+:n137030350101  a       skos:Concept ;
+        skos:broader    :n13703035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Döttingen"@de .
+
+:n34003  a              skos:Concept ;
+        skos:broader    :n340 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pirmasens-Land, Verbandsgemeinde"@de .
+
+:n14307061  a           skos:Concept ;
+        skos:broader    :n14307 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Quirnbach"@de .
+
+:n231001340100  a       skos:Concept ;
+        skos:broader    :n23100134 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bombogen (Ortsbezirk)"@de .
+
+:n340030280105  a       skos:Concept ;
+        skos:broader    :n34003028 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kettrichhof (Ortsbezirk)"@de .
+
+:n33402  a              skos:Concept ;
+        skos:broader    :n334 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Hagenbach, Verbandsgemeinde"@de .
+
+:n14302257  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Limbach"@de .
+
+:n49    a               skos:Concept ;
+        skos:broader    :n4 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kleinere Territorien und Teile auswärtiger Territorien -1800"@de .
+
+:n33907059  a           skos:Concept ;
+        skos:broader    :n33907 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Uelversheim"@de .
+
+:n14110111  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pohl"@de .
+
+:n335100350119  a       skos:Concept ;
+        skos:broader    :n33510035 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weinbrunnerhof"@de .
+
+:n13306068  a           skos:Concept ;
+        skos:broader    :n13306 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Münchwald"@de .
+
+:n315000001100  a       skos:Concept ;
+        skos:broader    :n31500000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Mombach (Ortsbezirk)"@de .
+
+:n137000030502  a       skos:Concept ;
+        skos:broader    :n13700003 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Fornich"@de .
+
+:n311000000401  a       skos:Concept ;
+        skos:broader    :n31100000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Petersau"@de .
+
+:n235080020200  a       skos:Concept ;
+        skos:broader    :n23508002 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Biebelhausen"@de .
+
+:n13100070  a           skos:Concept ;
+        skos:broader    :n131 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Remagen, Stadt"@de .
+
+:n13210078  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Niedersteinebach"@de .
+
+:n334005010200  a       skos:Concept ;
+        skos:broader    :n33400501 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Maximiliansau (Ortsbezirk)"@de .
+
+:n335112040101  a       skos:Concept ;
+        skos:broader    :n33511204 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Finsterbrunnertal"@de .
+
+:n13101069  a           skos:Concept ;
+        skos:broader    :n13101 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reifferscheid"@de .
+
+:n23109110  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Reil"@de .
+
+:n13809015  a           skos:Concept ;
+        skos:broader    :n13809 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ehlscheid"@de .
+
+:n23201291  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Pintesfeld"@de .
+
+:n14110026  a           skos:Concept ;
+        skos:broader    :n14110 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dessighofen"@de .
+
+:n233060760200  a       skos:Concept ;
+        skos:broader    :n23306076 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Leudersdorf (Ortsbezirk)"@de .
+
+:n231010080300  a       skos:Concept ;
+        skos:broader    :n23101008 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kues"@de .
+
+:n336081050101  a       skos:Concept ;
+        skos:broader    :n33608105 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Immetshausen"@de .
+
+:n23201212  a           skos:Concept ;
+        skos:broader    :n23201 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Dahnen"@de .
+
+:n28    a               skos:Concept ;
+        skos:broader    :n2 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ahrtal"@de .
+
+:n138010440306  a       skos:Concept ;
+        skos:broader    :n13801044 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Panau"@de .
+
+:n14302236  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Heimborn"@de .
+
+:n13809  a              skos:Concept ;
+        skos:broader    :n138 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Rengsdorf-Waldbreitbach, Verbandsgemeinde"@de .
+
+:n23504  a              skos:Concept ;
+        skos:broader    :n235 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ruwer, Verbandsgemeinde"@de .
+
+:n13210057  a           skos:Concept ;
+        skos:broader    :n13210 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Ingelbach"@de .
+
+:n4439822n0  a          skos:Concept ;
+        skos:broader    :n20 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Kondelwald"@de .
+
+:n317000000302  a       skos:Concept ;
+        skos:broader    :n31700000 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Eichelsbachermühle"@de .
+
+:n34009228  a           skos:Concept ;
+        skos:broader    :n34009 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Winterbach (Pfalz)"@de .
+
+:n232062960500  a       skos:Concept ;
+        skos:broader    :n23206296 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Weinsfeld"@de .
+
+:n33207033  a           skos:Concept ;
+        skos:broader    :n33207 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Laumersheim"@de .
+
+:n138040680200  a       skos:Concept ;
+        skos:broader    :n13804068 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Lorscheid"@de .
+
+:n137020480101  a       skos:Concept ;
+        skos:broader    :n13702048 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Minkelfeld"@de .
+
+:n23109004  a           skos:Concept ;
+        skos:broader    :n23109 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Bausendorf"@de .
+
+:n14302294  a           skos:Concept ;
+        skos:broader    :n14302 ;
+        skos:inScheme   <https://rpb.lobid.org/spatial> ;
+        skos:prefLabel  "Steinebach an der Wied"@de .

--- a/etl/maps/test/rpb.ttl
+++ b/etl/maps/test/rpb.ttl
@@ -1,0 +1,6820 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+
+<http://purl.org/lobid/rpb>
+    a skos:ConceptScheme ;
+    dct:title "Systematik der Rheinland-Pfälzischen Bibliographie"@de , "Classification scheme for the bibliography of Rhineland-Palatinate"@en ;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    dct:description "This classification was created for use in the bibliography of . The transformation to SKOS was carried out by Felix Ostrowski for the hbz." ;
+    dct:issued "2014-01-28" ;
+    dct:publisher <http://lobid.org/organisation/DE-605> ;
+    vann:preferredNamespaceUri "http://purl.org/lobid/rpb#" ;
+    vann:preferredNamespacePrefix "rpb" ;
+    skos:hasTopConcept <http://purl.org/lobid/rpb#n100000>, <http://purl.org/lobid/rpb#n120000>, <http://purl.org/lobid/rpb#n140000>, <http://purl.org/lobid/rpb#n160000>, <http://purl.org/lobid/rpb#n200000>, <http://purl.org/lobid/rpb#n210000>, <http://purl.org/lobid/rpb#n220000>, <http://purl.org/lobid/rpb#n240000>, <http://purl.org/lobid/rpb#n260000>, <http://purl.org/lobid/rpb#n400000>, <http://purl.org/lobid/rpb#n420000>, <http://purl.org/lobid/rpb#n440000>, <http://purl.org/lobid/rpb#n500000>, <http://purl.org/lobid/rpb#n520000>, <http://purl.org/lobid/rpb#n530000>, <http://purl.org/lobid/rpb#n540000>, <http://purl.org/lobid/rpb#n550000>, <http://purl.org/lobid/rpb#n560000>, <http://purl.org/lobid/rpb#n570000>, <http://purl.org/lobid/rpb#n580000>, <http://purl.org/lobid/rpb#n610000>, <http://purl.org/lobid/rpb#n630000>, <http://purl.org/lobid/rpb#n650000>, <http://purl.org/lobid/rpb#n700000>, <http://purl.org/lobid/rpb#n720000>, <http://purl.org/lobid/rpb#n730000>, <http://purl.org/lobid/rpb#n740000>, <http://purl.org/lobid/rpb#n760000>, <http://purl.org/lobid/rpb#n780000>, <http://purl.org/lobid/rpb#n790000>, <http://purl.org/lobid/rpb#n800000>, <http://purl.org/lobid/rpb#n820000>, <http://purl.org/lobid/rpb#n840000>, <http://purl.org/lobid/rpb#n860000>, <http://purl.org/lobid/rpb#n880000> .
+
+<http://purl.org/lobid/rpb#n100000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n100100>, <http://purl.org/lobid/rpb#n101000>, <http://purl.org/lobid/rpb#n102000>, <http://purl.org/lobid/rpb#n105000>, <http://purl.org/lobid/rpb#n106000>, <http://purl.org/lobid/rpb#n109000> ;
+    skos:notation "rpb100000" ;
+    skos:prefLabel "Landeskunde"@de .
+
+<http://purl.org/lobid/rpb#n100100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n100000> ;
+    skos:notation "rpb100100" ;
+    skos:prefLabel "Landeskunde allgemein"@de .
+
+<http://purl.org/lobid/rpb#n101000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n100000> ;
+    skos:notation "rpb101000" ;
+    skos:prefLabel "Bibliografie"@de .
+
+<http://purl.org/lobid/rpb#n102000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n100000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n102040>, <http://purl.org/lobid/rpb#n102042>, <http://purl.org/lobid/rpb#n102045>, <http://purl.org/lobid/rpb#n102050>, <http://purl.org/lobid/rpb#n102060>, <http://purl.org/lobid/rpb#n102070> ;
+    skos:notation "rpb102000" ;
+    skos:prefLabel "Landesbeschreibung"@de .
+
+<http://purl.org/lobid/rpb#n102040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n102000> ;
+    skos:notation "rpb102040" ;
+    skos:prefLabel "Kreisbeschreibung"@de .
+
+<http://purl.org/lobid/rpb#n102042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n102000> ;
+    skos:notation "rpb102042" ;
+    skos:prefLabel "Verbandsgemeindebeschreibung"@de .
+
+<http://purl.org/lobid/rpb#n102045>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n102000> ;
+    skos:notation "rpb102045" ;
+    skos:prefLabel "Regionenbeschreibung"@de .
+
+<http://purl.org/lobid/rpb#n102050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n102000> ;
+    skos:notation "rpb102050" ;
+    skos:prefLabel "Ortsbeschreibung"@de .
+
+<http://purl.org/lobid/rpb#n102060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n102000> ;
+    skos:notation "rpb102060" ;
+    skos:prefLabel "Reisebericht"@de .
+
+<http://purl.org/lobid/rpb#n102070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n102000> ;
+    skos:notation "rpb102070" ;
+    skos:prefLabel "Wandern / Führer"@de .
+
+<http://purl.org/lobid/rpb#n105000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n100000> ;
+    skos:notation "rpb105000" ;
+    skos:prefLabel "Heimatpflege"@de .
+
+<http://purl.org/lobid/rpb#n106000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n100000> ;
+    skos:notation "rpb106000" ;
+    skos:prefLabel "Heimatverein"@de .
+
+<http://purl.org/lobid/rpb#n109000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n100000> ;
+    skos:notation "rpb109000" ;
+    skos:prefLabel "Biografie"@de .
+
+<http://purl.org/lobid/rpb#n120000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n120100>, <http://purl.org/lobid/rpb#n122000>, <http://purl.org/lobid/rpb#n124000>, <http://purl.org/lobid/rpb#n126000> ;
+    skos:notation "rpb120000" ;
+    skos:prefLabel "Kartografie. Geodäsie"@de .
+
+<http://purl.org/lobid/rpb#n120100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n120000> ;
+    skos:notation "rpb120100" ;
+    skos:prefLabel "Kartografie. Geodäsie allgemein"@de .
+
+<http://purl.org/lobid/rpb#n122000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n120000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n122030>, <http://purl.org/lobid/rpb#n122050>, <http://purl.org/lobid/rpb#n122070> ;
+    skos:notation "rpb122000" ;
+    skos:prefLabel "Kartografie"@de .
+
+<http://purl.org/lobid/rpb#n122030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n122000> ;
+    skos:notation "rpb122030" ;
+    skos:prefLabel "Kartenauswertung"@de .
+
+<http://purl.org/lobid/rpb#n122050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n122000> ;
+    skos:notation "rpb122050" ;
+    skos:prefLabel "Computerkartografie"@de .
+
+<http://purl.org/lobid/rpb#n122070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n122000> ;
+    skos:notation "rpb122070" ;
+    skos:prefLabel "Luftbildauswertung"@de .
+
+<http://purl.org/lobid/rpb#n124000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n120000> ;
+    skos:notation "rpb124000" ;
+    skos:prefLabel "Geodäsie"@de .
+
+<http://purl.org/lobid/rpb#n126000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n120000> ;
+    skos:notation "rpb126000" ;
+    skos:prefLabel "Karte"@de .
+
+<http://purl.org/lobid/rpb#n140000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n140100>, <http://purl.org/lobid/rpb#n141000>, <http://purl.org/lobid/rpb#n141200>, <http://purl.org/lobid/rpb#n141400>, <http://purl.org/lobid/rpb#n141600>, <http://purl.org/lobid/rpb#n142000>, <http://purl.org/lobid/rpb#n142100>, <http://purl.org/lobid/rpb#n142300>, <http://purl.org/lobid/rpb#n142500>, <http://purl.org/lobid/rpb#n146000> ;
+    skos:notation "rpb140000" ;
+    skos:prefLabel "Geowissenschaften"@de .
+
+<http://purl.org/lobid/rpb#n140100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:notation "rpb140100" ;
+    skos:prefLabel "Geowissenschaften allgemein"@de .
+
+<http://purl.org/lobid/rpb#n141000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n141020>, <http://purl.org/lobid/rpb#n141030>, <http://purl.org/lobid/rpb#n141040> ;
+    skos:notation "rpb141000" ;
+    skos:prefLabel "Geophysik"@de .
+
+<http://purl.org/lobid/rpb#n141020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141000> ;
+    skos:notation "rpb141020" ;
+    skos:prefLabel "Erdmagnetismus"@de .
+
+<http://purl.org/lobid/rpb#n141030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141000> ;
+    skos:notation "rpb141030" ;
+    skos:prefLabel "Schwere"@de .
+
+<http://purl.org/lobid/rpb#n141040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141000> ;
+    skos:notation "rpb141040" ;
+    skos:prefLabel "Erdbeben"@de .
+
+<http://purl.org/lobid/rpb#n141200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n141220>, <http://purl.org/lobid/rpb#n141230>, <http://purl.org/lobid/rpb#n141240> ;
+    skos:notation "rpb141200" ;
+    skos:prefLabel "Geologie"@de .
+
+<http://purl.org/lobid/rpb#n141220>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141200> ;
+    skos:notation "rpb141220" ;
+    skos:prefLabel "Tektonik"@de .
+
+<http://purl.org/lobid/rpb#n141230>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141200> ;
+    skos:notation "rpb141230" ;
+    skos:prefLabel "Ingenieurgeologie"@de .
+
+<http://purl.org/lobid/rpb#n141240>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141200> ;
+    skos:notation "rpb141240" ;
+    skos:prefLabel "Stratigraphie"@de .
+
+<http://purl.org/lobid/rpb#n141400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n141420>, <http://purl.org/lobid/rpb#n141430>, <http://purl.org/lobid/rpb#n141440>, <http://purl.org/lobid/rpb#n141450>, <http://purl.org/lobid/rpb#n141460> ;
+    skos:notation "rpb141400" ;
+    skos:prefLabel "Mineralogie. Gesteinskunde"@de .
+
+<http://purl.org/lobid/rpb#n141420>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141400> ;
+    skos:notation "rpb141420" ;
+    skos:prefLabel "Mineralogie"@de .
+
+<http://purl.org/lobid/rpb#n141430>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141400> ;
+    skos:notation "rpb141430" ;
+    skos:prefLabel "Gesteinskunde"@de .
+
+<http://purl.org/lobid/rpb#n141440>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141400> ;
+    skos:notation "rpb141440" ;
+    skos:prefLabel "Geochemie"@de .
+
+<http://purl.org/lobid/rpb#n141450>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141400> ;
+    skos:notation "rpb141450" ;
+    skos:prefLabel "Lagerstättenkunde"@de .
+
+<http://purl.org/lobid/rpb#n141460>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141400> ;
+    skos:notation "rpb141460" ;
+    skos:prefLabel "Mineralquelle. Thermalquelle"@de .
+
+<http://purl.org/lobid/rpb#n141600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n141620>, <http://purl.org/lobid/rpb#n141630>, <http://purl.org/lobid/rpb#n141640> ;
+    skos:notation "rpb141600" ;
+    skos:prefLabel "Paläontologie"@de .
+
+<http://purl.org/lobid/rpb#n141620>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141600> ;
+    skos:narrower <http://purl.org/lobid/rpb#n141622>, <http://purl.org/lobid/rpb#n141624> ;
+    skos:notation "rpb141620" ;
+    skos:prefLabel "Paläobotanik"@de .
+
+<http://purl.org/lobid/rpb#n141622>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141620> ;
+    skos:notation "rpb141622" ;
+    skos:prefLabel "Fossile Sporenpflanzen"@de .
+
+<http://purl.org/lobid/rpb#n141624>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141620> ;
+    skos:notation "rpb141624" ;
+    skos:prefLabel "Fossile Samenpflanzen"@de .
+
+<http://purl.org/lobid/rpb#n141630>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141600> ;
+    skos:narrower <http://purl.org/lobid/rpb#n141632>, <http://purl.org/lobid/rpb#n141634> ;
+    skos:notation "rpb141630" ;
+    skos:prefLabel "Paläozoologie"@de .
+
+<http://purl.org/lobid/rpb#n141632>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141630> ;
+    skos:notation "rpb141632" ;
+    skos:prefLabel "Fossile Wirbellose"@de .
+
+<http://purl.org/lobid/rpb#n141634>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141630> ;
+    skos:notation "rpb141634" ;
+    skos:prefLabel "Fossile Wirbeltiere"@de .
+
+<http://purl.org/lobid/rpb#n141640>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n141600> ;
+    skos:notation "rpb141640" ;
+    skos:prefLabel "Mikropaläontologie"@de .
+
+<http://purl.org/lobid/rpb#n142000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n142020>, <http://purl.org/lobid/rpb#n142030>, <http://purl.org/lobid/rpb#n142040>, <http://purl.org/lobid/rpb#n142050>, <http://purl.org/lobid/rpb#n142060> ;
+    skos:notation "rpb142000" ;
+    skos:prefLabel "Bodenkunde"@de .
+
+<http://purl.org/lobid/rpb#n142020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142000> ;
+    skos:notation "rpb142020" ;
+    skos:prefLabel "Bodenentwicklung"@de .
+
+<http://purl.org/lobid/rpb#n142030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142000> ;
+    skos:notation "rpb142030" ;
+    skos:prefLabel "Bodenphysik"@de .
+
+<http://purl.org/lobid/rpb#n142040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142000> ;
+    skos:notation "rpb142040" ;
+    skos:prefLabel "Bodenbiologie"@de .
+
+<http://purl.org/lobid/rpb#n142050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142000> ;
+    skos:notation "rpb142050" ;
+    skos:prefLabel "Bodenmechanik"@de .
+
+<http://purl.org/lobid/rpb#n142060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142000> ;
+    skos:notation "rpb142060" ;
+    skos:prefLabel "Bodenchemie"@de .
+
+<http://purl.org/lobid/rpb#n142100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n142110>, <http://purl.org/lobid/rpb#n142120>, <http://purl.org/lobid/rpb#n142130>, <http://purl.org/lobid/rpb#n142140>, <http://purl.org/lobid/rpb#n142150>, <http://purl.org/lobid/rpb#n142170>, <http://purl.org/lobid/rpb#n142180>, <http://purl.org/lobid/rpb#n142190> ;
+    skos:notation "rpb142100" ;
+    skos:prefLabel "Geomorphologie"@de .
+
+<http://purl.org/lobid/rpb#n142110>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142100> ;
+    skos:notation "rpb142110" ;
+    skos:prefLabel "Relief / Geografie"@de .
+
+<http://purl.org/lobid/rpb#n142120>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142100> ;
+    skos:notation "rpb142120" ;
+    skos:prefLabel "Abtragung"@de .
+
+<http://purl.org/lobid/rpb#n142130>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142100> ;
+    skos:notation "rpb142130" ;
+    skos:prefLabel "Klimamorphologie"@de .
+
+<http://purl.org/lobid/rpb#n142140>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142100> ;
+    skos:notation "rpb142140" ;
+    skos:prefLabel "Glazialmorphologie. Periglazialgeomorphologie"@de .
+
+<http://purl.org/lobid/rpb#n142150>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142100> ;
+    skos:notation "rpb142150" ;
+    skos:prefLabel "Vulkanismus"@de .
+
+<http://purl.org/lobid/rpb#n142170>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142100> ;
+    skos:notation "rpb142170" ;
+    skos:prefLabel "Karst"@de .
+
+<http://purl.org/lobid/rpb#n142180>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142100> ;
+    skos:notation "rpb142180" ;
+    skos:prefLabel "Höhle"@de .
+
+<http://purl.org/lobid/rpb#n142190>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142100> ;
+    skos:notation "rpb142190" ;
+    skos:prefLabel "Angewandte Geomorphologie"@de .
+
+<http://purl.org/lobid/rpb#n142300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n142310>, <http://purl.org/lobid/rpb#n142320>, <http://purl.org/lobid/rpb#n142330>, <http://purl.org/lobid/rpb#n142340>, <http://purl.org/lobid/rpb#n142350>, <http://purl.org/lobid/rpb#n142360>, <http://purl.org/lobid/rpb#n142370>, <http://purl.org/lobid/rpb#n142380>, <http://purl.org/lobid/rpb#n142390> ;
+    skos:notation "rpb142300" ;
+    skos:prefLabel "Wasser"@de .
+
+<http://purl.org/lobid/rpb#n142310>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142300> ;
+    skos:notation "rpb142310" ;
+    skos:prefLabel "Wasserrecht"@de .
+
+<http://purl.org/lobid/rpb#n142320>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142300> ;
+    skos:narrower <http://purl.org/lobid/rpb#n142323>, <http://purl.org/lobid/rpb#n142325> ;
+    skos:notation "rpb142320" ;
+    skos:prefLabel "Fließgewässer"@de .
+
+<http://purl.org/lobid/rpb#n142323>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142320> ;
+    skos:notation "rpb142323" ;
+    skos:prefLabel "Hochwasser"@de .
+
+<http://purl.org/lobid/rpb#n142325>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142320> ;
+    skos:notation "rpb142325" ;
+    skos:prefLabel "Niedrigwasser"@de .
+
+<http://purl.org/lobid/rpb#n142330>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142300> ;
+    skos:notation "rpb142330" ;
+    skos:prefLabel "See"@de .
+
+<http://purl.org/lobid/rpb#n142340>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142300> ;
+    skos:notation "rpb142340" ;
+    skos:prefLabel "Moor"@de .
+
+<http://purl.org/lobid/rpb#n142350>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142300> ;
+    skos:narrower <http://purl.org/lobid/rpb#n142352> ;
+    skos:notation "rpb142350" ;
+    skos:prefLabel "Hydrogeologie"@de .
+
+<http://purl.org/lobid/rpb#n142352>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142350> ;
+    skos:notation "rpb142352" ;
+    skos:prefLabel "Bodenwasser"@de .
+
+<http://purl.org/lobid/rpb#n142360>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142300> ;
+    skos:notation "rpb142360" ;
+    skos:prefLabel "Wasserhaushalt"@de .
+
+<http://purl.org/lobid/rpb#n142370>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142300> ;
+    skos:narrower <http://purl.org/lobid/rpb#n142372>, <http://purl.org/lobid/rpb#n142375> ;
+    skos:notation "rpb142370" ;
+    skos:prefLabel "Wasserwirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n142372>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142370> ;
+    skos:notation "rpb142372" ;
+    skos:prefLabel "Trinkwasserversorgung"@de .
+
+<http://purl.org/lobid/rpb#n142375>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142370> ;
+    skos:notation "rpb142375" ;
+    skos:prefLabel "Brauchwasser"@de .
+
+<http://purl.org/lobid/rpb#n142380>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142300> ;
+    skos:narrower <http://purl.org/lobid/rpb#n142382> ;
+    skos:notation "rpb142380" ;
+    skos:prefLabel "Hydroökologie"@de .
+
+<http://purl.org/lobid/rpb#n142382>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142380> ;
+    skos:notation "rpb142382" ;
+    skos:prefLabel "Wasseranalyse"@de .
+
+<http://purl.org/lobid/rpb#n142390>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142300> ;
+    skos:notation "rpb142390" ;
+    skos:prefLabel "Wasserstatistik"@de .
+
+<http://purl.org/lobid/rpb#n142500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n142520>, <http://purl.org/lobid/rpb#n142530>, <http://purl.org/lobid/rpb#n142540>, <http://purl.org/lobid/rpb#n142541>, <http://purl.org/lobid/rpb#n142550>, <http://purl.org/lobid/rpb#n142560>, <http://purl.org/lobid/rpb#n142570> ;
+    skos:notation "rpb142500" ;
+    skos:prefLabel "Klima"@de .
+
+<http://purl.org/lobid/rpb#n142520>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142500> ;
+    skos:narrower <http://purl.org/lobid/rpb#n142522>, <http://purl.org/lobid/rpb#n142523>, <http://purl.org/lobid/rpb#n142524>, <http://purl.org/lobid/rpb#n142525>, <http://purl.org/lobid/rpb#n142526>, <http://purl.org/lobid/rpb#n142527> ;
+    skos:notation "rpb142520" ;
+    skos:prefLabel "Klimaelement"@de .
+
+<http://purl.org/lobid/rpb#n142522>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142520> ;
+    skos:notation "rpb142522" ;
+    skos:prefLabel "Sonnenstrahlung"@de .
+
+<http://purl.org/lobid/rpb#n142523>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142520> ;
+    skos:notation "rpb142523" ;
+    skos:prefLabel "Lufttemperatur"@de .
+
+<http://purl.org/lobid/rpb#n142524>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142520> ;
+    skos:notation "rpb142524" ;
+    skos:prefLabel "Luftfeuchtigkeit"@de .
+
+<http://purl.org/lobid/rpb#n142525>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142520> ;
+    skos:notation "rpb142525" ;
+    skos:prefLabel "Luftdruck"@de .
+
+<http://purl.org/lobid/rpb#n142526>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142520> ;
+    skos:notation "rpb142526" ;
+    skos:prefLabel "Luftbewegung"@de .
+
+<http://purl.org/lobid/rpb#n142527>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142520> ;
+    skos:notation "rpb142527" ;
+    skos:prefLabel "Luftelektrizität"@de .
+
+<http://purl.org/lobid/rpb#n142530>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142500> ;
+    skos:notation "rpb142530" ;
+    skos:prefLabel "Klimatologie"@de .
+
+<http://purl.org/lobid/rpb#n142540>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142500> ;
+    skos:notation "rpb142540" ;
+    skos:prefLabel "Wetterdienst"@de .
+
+<http://purl.org/lobid/rpb#n142541>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142500> ;
+    skos:notation "rpb142541" ;
+    skos:prefLabel "Wetterlage"@de .
+
+<http://purl.org/lobid/rpb#n142550>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142500> ;
+    skos:notation "rpb142550" ;
+    skos:prefLabel "Klimafaktor"@de .
+
+<http://purl.org/lobid/rpb#n142560>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142500> ;
+    skos:notation "rpb142560" ;
+    skos:prefLabel "Klimaschwankung"@de .
+
+<http://purl.org/lobid/rpb#n142570>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n142500> ;
+    skos:notation "rpb142570" ;
+    skos:prefLabel "Paläoklimatologie"@de .
+
+<http://purl.org/lobid/rpb#n146000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n140000> ;
+    skos:notation "rpb146000" ;
+    skos:prefLabel "Geoökologie"@de .
+
+<http://purl.org/lobid/rpb#n160000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n160100>, <http://purl.org/lobid/rpb#n161000>, <http://purl.org/lobid/rpb#n162000>, <http://purl.org/lobid/rpb#n163000>, <http://purl.org/lobid/rpb#n164000> ;
+    skos:notation "rpb160000" ;
+    skos:prefLabel "Biowissenschaften"@de .
+
+<http://purl.org/lobid/rpb#n160100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n160000> ;
+    skos:notation "rpb160100" ;
+    skos:prefLabel "Biowissenschaften allgemein"@de .
+
+<http://purl.org/lobid/rpb#n161000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n160000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n161030>, <http://purl.org/lobid/rpb#n161040>, <http://purl.org/lobid/rpb#n161050> ;
+    skos:notation "rpb161000" ;
+    skos:prefLabel "Biologie"@de .
+
+<http://purl.org/lobid/rpb#n161030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n161000> ;
+    skos:notation "rpb161030" ;
+    skos:prefLabel "Ökologie"@de .
+
+<http://purl.org/lobid/rpb#n161040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n161000> ;
+    skos:notation "rpb161040" ;
+    skos:prefLabel "Biozönose"@de .
+
+<http://purl.org/lobid/rpb#n161050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n161000> ;
+    skos:notation "rpb161050" ;
+    skos:prefLabel "Mikrobiologie"@de .
+
+<http://purl.org/lobid/rpb#n162000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n160000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n162030>, <http://purl.org/lobid/rpb#n162040> ;
+    skos:notation "rpb162000" ;
+    skos:prefLabel "Pflanzen"@de .
+
+<http://purl.org/lobid/rpb#n162030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n162000> ;
+    skos:notation "rpb162030" ;
+    skos:prefLabel "Kryptogamen"@de .
+
+<http://purl.org/lobid/rpb#n162040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n162000> ;
+    skos:notation "rpb162040" ;
+    skos:prefLabel "Samenpflanzen"@de .
+
+<http://purl.org/lobid/rpb#n163000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n160000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n163020>, <http://purl.org/lobid/rpb#n163030>, <http://purl.org/lobid/rpb#n163040>, <http://purl.org/lobid/rpb#n163050>, <http://purl.org/lobid/rpb#n163060>, <http://purl.org/lobid/rpb#n163070>, <http://purl.org/lobid/rpb#n163080>, <http://purl.org/lobid/rpb#n163090> ;
+    skos:notation "rpb163000" ;
+    skos:prefLabel "Tiere"@de .
+
+<http://purl.org/lobid/rpb#n163020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n163000> ;
+    skos:notation "rpb163020" ;
+    skos:prefLabel "Wirbellose"@de .
+
+<http://purl.org/lobid/rpb#n163030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n163000> ;
+    skos:notation "rpb163030" ;
+    skos:prefLabel "Insekten"@de .
+
+<http://purl.org/lobid/rpb#n163040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n163000> ;
+    skos:notation "rpb163040" ;
+    skos:prefLabel "Wirbeltiere"@de .
+
+<http://purl.org/lobid/rpb#n163050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n163000> ;
+    skos:notation "rpb163050" ;
+    skos:prefLabel "Fische"@de .
+
+<http://purl.org/lobid/rpb#n163060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n163000> ;
+    skos:notation "rpb163060" ;
+    skos:prefLabel "Lurche"@de .
+
+<http://purl.org/lobid/rpb#n163070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n163000> ;
+    skos:notation "rpb163070" ;
+    skos:prefLabel "Reptilien"@de .
+
+<http://purl.org/lobid/rpb#n163080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n163000> ;
+    skos:notation "rpb163080" ;
+    skos:prefLabel "Vögel"@de .
+
+<http://purl.org/lobid/rpb#n163090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n163000> ;
+    skos:notation "rpb163090" ;
+    skos:prefLabel "Säugetiere"@de .
+
+<http://purl.org/lobid/rpb#n164000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n160000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n164020>, <http://purl.org/lobid/rpb#n164030>, <http://purl.org/lobid/rpb#n164040> ;
+    skos:notation "rpb164000" ;
+    skos:prefLabel "Humanbiologie"@de .
+
+<http://purl.org/lobid/rpb#n164020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n164000> ;
+    skos:notation "rpb164020" ;
+    skos:prefLabel "Menschenrasse"@de .
+
+<http://purl.org/lobid/rpb#n164030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n164000> ;
+    skos:notation "rpb164030" ;
+    skos:prefLabel "Skelettfund"@de .
+
+<http://purl.org/lobid/rpb#n164040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n164000> ;
+    skos:notation "rpb164040" ;
+    skos:prefLabel "Paläoanthropologie"@de .
+
+<http://purl.org/lobid/rpb#n200000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n200100>, <http://purl.org/lobid/rpb#n202000>, <http://purl.org/lobid/rpb#n202500>, <http://purl.org/lobid/rpb#n203000>, <http://purl.org/lobid/rpb#n203500>, <http://purl.org/lobid/rpb#n204000>, <http://purl.org/lobid/rpb#n205000>, <http://purl.org/lobid/rpb#n206000>, <http://purl.org/lobid/rpb#n207000>, <http://purl.org/lobid/rpb#n208000>, <http://purl.org/lobid/rpb#n209000> ;
+    skos:notation "rpb200000" ;
+    skos:prefLabel "Historische Hilfswissenschaften"@de .
+
+<http://purl.org/lobid/rpb#n200100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:notation "rpb200100" ;
+    skos:prefLabel "Historische Hilfswissenschaften allgemein"@de .
+
+<http://purl.org/lobid/rpb#n202000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:notation "rpb202000" ;
+    skos:prefLabel "Chronologie"@de .
+
+<http://purl.org/lobid/rpb#n202500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:notation "rpb202500" ;
+    skos:prefLabel "Metrologie"@de .
+
+<http://purl.org/lobid/rpb#n203000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:notation "rpb203000" ;
+    skos:prefLabel "Urkundenlehre"@de .
+
+<http://purl.org/lobid/rpb#n203500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:notation "rpb203500" ;
+    skos:prefLabel "Paläografie"@de .
+
+<http://purl.org/lobid/rpb#n204000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:notation "rpb204000" ;
+    skos:prefLabel "Siegelkunde"@de .
+
+<http://purl.org/lobid/rpb#n205000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n205020>, <http://purl.org/lobid/rpb#n205030> ;
+    skos:notation "rpb205000" ;
+    skos:prefLabel "Numismatik"@de .
+
+<http://purl.org/lobid/rpb#n205020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n205000> ;
+    skos:notation "rpb205020" ;
+    skos:prefLabel "Münze"@de .
+
+<http://purl.org/lobid/rpb#n205030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n205000> ;
+    skos:notation "rpb205030" ;
+    skos:prefLabel "Papiergeld"@de .
+
+<http://purl.org/lobid/rpb#n206000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:notation "rpb206000" ;
+    skos:prefLabel "Epigraphik"@de .
+
+<http://purl.org/lobid/rpb#n207000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n207020> ;
+    skos:notation "rpb207000" ;
+    skos:prefLabel "Genealogie"@de .
+
+<http://purl.org/lobid/rpb#n207020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n207000> ;
+    skos:notation "rpb207020" ;
+    skos:prefLabel "Familie"@de .
+
+<http://purl.org/lobid/rpb#n208000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n208500> ;
+    skos:notation "rpb208000" ;
+    skos:prefLabel "Heraldik"@de .
+
+<http://purl.org/lobid/rpb#n208500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n208000> ;
+    skos:notation "rpb208500" ;
+    skos:prefLabel "Flagge"@de .
+
+<http://purl.org/lobid/rpb#n209000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n200000> ;
+    skos:notation "rpb209000" ;
+    skos:prefLabel "Orden / Ehrenzeichen"@de .
+
+<http://purl.org/lobid/rpb#n210000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n210100>, <http://purl.org/lobid/rpb#n213000>, <http://purl.org/lobid/rpb#n217000> ;
+    skos:notation "rpb210000" ;
+    skos:prefLabel "Archiv. Museum"@de .
+
+<http://purl.org/lobid/rpb#n210100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n210000> ;
+    skos:notation "rpb210100" ;
+    skos:prefLabel "Archiv. Museum allgemein"@de .
+
+<http://purl.org/lobid/rpb#n213000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n210000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n213010>, <http://purl.org/lobid/rpb#n213020>, <http://purl.org/lobid/rpb#n213030>, <http://purl.org/lobid/rpb#n213040>, <http://purl.org/lobid/rpb#n213050>, <http://purl.org/lobid/rpb#n213060>, <http://purl.org/lobid/rpb#n213070>, <http://purl.org/lobid/rpb#n213080>, <http://purl.org/lobid/rpb#n213090>, <http://purl.org/lobid/rpb#n213092> ;
+    skos:notation "rpb213000" ;
+    skos:prefLabel "Archiv"@de .
+
+<http://purl.org/lobid/rpb#n213010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:notation "rpb213010" ;
+    skos:prefLabel "Bundesarchiv Koblenz"@de .
+
+<http://purl.org/lobid/rpb#n213020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:notation "rpb213020" ;
+    skos:prefLabel "Staatsarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n213031>, <http://purl.org/lobid/rpb#n213033> ;
+    skos:notation "rpb213030" ;
+    skos:prefLabel "Kreisarchiv. Gemeindearchiv"@de .
+
+<http://purl.org/lobid/rpb#n213031>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213030> ;
+    skos:notation "rpb213031" ;
+    skos:prefLabel "Kreisarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213033>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213030> ;
+    skos:notation "rpb213033" ;
+    skos:prefLabel "Gemeindearchiv"@de .
+
+<http://purl.org/lobid/rpb#n213040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:notation "rpb213040" ;
+    skos:prefLabel "Kirchenarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n213052>, <http://purl.org/lobid/rpb#n213053>, <http://purl.org/lobid/rpb#n213054> ;
+    skos:notation "rpb213050" ;
+    skos:prefLabel "Archiv für Literatur, Kunst und Wissenschaft"@de .
+
+<http://purl.org/lobid/rpb#n213052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213050> ;
+    skos:notation "rpb213052" ;
+    skos:prefLabel "Literaturarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213053>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213050> ;
+    skos:notation "rpb213053" ;
+    skos:prefLabel "Kunstarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213054>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213050> ;
+    skos:notation "rpb213054" ;
+    skos:prefLabel "Wissenschaftsarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:notation "rpb213060" ;
+    skos:prefLabel "Parteiarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n213072>, <http://purl.org/lobid/rpb#n213073>, <http://purl.org/lobid/rpb#n213074> ;
+    skos:notation "rpb213070" ;
+    skos:prefLabel "Medienarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213072>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213070> ;
+    skos:notation "rpb213072" ;
+    skos:prefLabel "Rundfunkarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213073>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213070> ;
+    skos:notation "rpb213073" ;
+    skos:prefLabel "Pressearchiv"@de .
+
+<http://purl.org/lobid/rpb#n213074>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213070> ;
+    skos:notation "rpb213074" ;
+    skos:prefLabel "Filmarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n213082> ;
+    skos:notation "rpb213080" ;
+    skos:prefLabel "Wirtschaftsarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213082>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213080> ;
+    skos:notation "rpb213082" ;
+    skos:prefLabel "Firmenarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:notation "rpb213090" ;
+    skos:prefLabel "Familienarchiv"@de .
+
+<http://purl.org/lobid/rpb#n213092>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n213000> ;
+    skos:notation "rpb213092" ;
+    skos:prefLabel "Sonstige Archive"@de .
+
+<http://purl.org/lobid/rpb#n217000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n210000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n217010>, <http://purl.org/lobid/rpb#n217020>, <http://purl.org/lobid/rpb#n217030>, <http://purl.org/lobid/rpb#n217040>, <http://purl.org/lobid/rpb#n217050>, <http://purl.org/lobid/rpb#n217090> ;
+    skos:notation "rpb217000" ;
+    skos:prefLabel "Museum"@de .
+
+<http://purl.org/lobid/rpb#n217010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n217000> ;
+    skos:notation "rpb217010" ;
+    skos:prefLabel "Museumspädagogik"@de .
+
+<http://purl.org/lobid/rpb#n217020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n217000> ;
+    skos:notation "rpb217020" ;
+    skos:prefLabel "Naturkundemuseum"@de .
+
+<http://purl.org/lobid/rpb#n217030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n217000> ;
+    skos:notation "rpb217030" ;
+    skos:prefLabel "Technisches Museum"@de .
+
+<http://purl.org/lobid/rpb#n217040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n217000> ;
+    skos:notation "rpb217040" ;
+    skos:prefLabel "Historisches Museum. Heimatmuseum"@de .
+
+<http://purl.org/lobid/rpb#n217050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n217000> ;
+    skos:notation "rpb217050" ;
+    skos:prefLabel "Volkskundemuseum"@de .
+
+<http://purl.org/lobid/rpb#n217090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n217000> ;
+    skos:notation "rpb217090" ;
+    skos:prefLabel "Sonstige Museen"@de .
+
+<http://purl.org/lobid/rpb#n220000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n220100>, <http://purl.org/lobid/rpb#n220500>, <http://purl.org/lobid/rpb#n221000>, <http://purl.org/lobid/rpb#n222000>, <http://purl.org/lobid/rpb#n223000>, <http://purl.org/lobid/rpb#n224000>, <http://purl.org/lobid/rpb#n225000>, <http://purl.org/lobid/rpb#n226000>, <http://purl.org/lobid/rpb#n227000>, <http://purl.org/lobid/rpb#n228000> ;
+    skos:notation "rpb220000" ;
+    skos:prefLabel "Vor- und Frühgeschichte. Archäologie"@de .
+
+<http://purl.org/lobid/rpb#n220100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:notation "rpb220100" ;
+    skos:prefLabel "Vor- und Frühgeschichte. Archäologie allgemein"@de .
+
+<http://purl.org/lobid/rpb#n220500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:notation "rpb220500" ;
+    skos:prefLabel "Archäologie"@de .
+
+<http://purl.org/lobid/rpb#n221000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:notation "rpb221000" ;
+    skos:prefLabel "Vor- und Frühgeschichte"@de .
+
+<http://purl.org/lobid/rpb#n222000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:notation "rpb222000" ;
+    skos:prefLabel "Paläolithikum. Mesolithikum"@de .
+
+<http://purl.org/lobid/rpb#n223000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n223020>, <http://purl.org/lobid/rpb#n223030>, <http://purl.org/lobid/rpb#n223040>, <http://purl.org/lobid/rpb#n223050>, <http://purl.org/lobid/rpb#n223060>, <http://purl.org/lobid/rpb#n223070> ;
+    skos:notation "rpb223000" ;
+    skos:prefLabel "Neolithikum"@de .
+
+<http://purl.org/lobid/rpb#n223020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n223000> ;
+    skos:notation "rpb223020" ;
+    skos:prefLabel "Bandkeramik"@de .
+
+<http://purl.org/lobid/rpb#n223030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n223000> ;
+    skos:notation "rpb223030" ;
+    skos:prefLabel "Rössener Kultur"@de .
+
+<http://purl.org/lobid/rpb#n223040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n223000> ;
+    skos:notation "rpb223040" ;
+    skos:prefLabel "Michelsberger Kultur"@de .
+
+<http://purl.org/lobid/rpb#n223050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n223000> ;
+    skos:notation "rpb223050" ;
+    skos:prefLabel "Megalithkultur"@de .
+
+<http://purl.org/lobid/rpb#n223060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n223000> ;
+    skos:notation "rpb223060" ;
+    skos:prefLabel "Schnurkeramik"@de .
+
+<http://purl.org/lobid/rpb#n223070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n223000> ;
+    skos:notation "rpb223070" ;
+    skos:prefLabel "Glockenbecherkultur"@de .
+
+<http://purl.org/lobid/rpb#n224000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n224050>, <http://purl.org/lobid/rpb#n224060> ;
+    skos:notation "rpb224000" ;
+    skos:prefLabel "Bronzezeit"@de .
+
+<http://purl.org/lobid/rpb#n224050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n224000> ;
+    skos:notation "rpb224050" ;
+    skos:prefLabel "Hügelgräberkultur"@de .
+
+<http://purl.org/lobid/rpb#n224060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n224000> ;
+    skos:notation "rpb224060" ;
+    skos:prefLabel "Urnenfelderkultur"@de .
+
+<http://purl.org/lobid/rpb#n225000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n225020>, <http://purl.org/lobid/rpb#n225025>, <http://purl.org/lobid/rpb#n225030>, <http://purl.org/lobid/rpb#n225040>, <http://purl.org/lobid/rpb#n225050> ;
+    skos:notation "rpb225000" ;
+    skos:prefLabel "Vorrömische Eisenzeit"@de .
+
+<http://purl.org/lobid/rpb#n225020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n225000> ;
+    skos:notation "rpb225020" ;
+    skos:prefLabel "Hallstattkultur"@de .
+
+<http://purl.org/lobid/rpb#n225025>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n225000> ;
+    skos:notation "rpb225025" ;
+    skos:prefLabel "Hunsrück-Eifel-Kultur"@de .
+
+<http://purl.org/lobid/rpb#n225030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n225000> ;
+    skos:notation "rpb225030" ;
+    skos:prefLabel "Latène-Zeit"@de .
+
+<http://purl.org/lobid/rpb#n225040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n225000> ;
+    skos:notation "rpb225040" ;
+    skos:prefLabel "Kelten"@de .
+
+<http://purl.org/lobid/rpb#n225050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n225000> ;
+    skos:notation "rpb225050" ;
+    skos:prefLabel "Germanen"@de .
+
+<http://purl.org/lobid/rpb#n226000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n226020>, <http://purl.org/lobid/rpb#n226030>, <http://purl.org/lobid/rpb#n226040>, <http://purl.org/lobid/rpb#n226050> ;
+    skos:notation "rpb226000" ;
+    skos:prefLabel "Römerzeit"@de .
+
+<http://purl.org/lobid/rpb#n226020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n226000> ;
+    skos:notation "rpb226020" ;
+    skos:prefLabel "Kelten"@de .
+
+<http://purl.org/lobid/rpb#n226030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n226000> ;
+    skos:notation "rpb226030" ;
+    skos:prefLabel "Römer"@de .
+
+<http://purl.org/lobid/rpb#n226040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n226000> ;
+    skos:notation "rpb226040" ;
+    skos:prefLabel "Germanen"@de .
+
+<http://purl.org/lobid/rpb#n226050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n226000> ;
+    skos:notation "rpb226050" ;
+    skos:prefLabel "Franken <Volk>"@de .
+
+<http://purl.org/lobid/rpb#n227000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n227020>, <http://purl.org/lobid/rpb#n227030>, <http://purl.org/lobid/rpb#n227040> ;
+    skos:notation "rpb227000" ;
+    skos:prefLabel "Völkerwanderung"@de .
+
+<http://purl.org/lobid/rpb#n227020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n227000> ;
+    skos:notation "rpb227020" ;
+    skos:prefLabel "Römer"@de .
+
+<http://purl.org/lobid/rpb#n227030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n227000> ;
+    skos:notation "rpb227030" ;
+    skos:prefLabel "Germanen"@de .
+
+<http://purl.org/lobid/rpb#n227040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n227000> ;
+    skos:notation "rpb227040" ;
+    skos:prefLabel "Franken <Volk>"@de .
+
+<http://purl.org/lobid/rpb#n228000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n220000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n228020>, <http://purl.org/lobid/rpb#n228030>, <http://purl.org/lobid/rpb#n228080> ;
+    skos:notation "rpb228000" ;
+    skos:prefLabel "Mittelalterliche Archäologie. Neuzeitliche Archäologie"@de .
+
+<http://purl.org/lobid/rpb#n228020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n228000> ;
+    skos:notation "rpb228020" ;
+    skos:prefLabel "Bestattung"@de .
+
+<http://purl.org/lobid/rpb#n228030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n228000> ;
+    skos:notation "rpb228030" ;
+    skos:prefLabel "Funde"@de .
+
+<http://purl.org/lobid/rpb#n228080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n228000> ;
+    skos:notation "rpb228080" ;
+    skos:prefLabel "Industriearchäologie"@de .
+
+<http://purl.org/lobid/rpb#n240000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n240100>, <http://purl.org/lobid/rpb#n240200>, <http://purl.org/lobid/rpb#n240300>, <http://purl.org/lobid/rpb#n240350>, <http://purl.org/lobid/rpb#n240400>, <http://purl.org/lobid/rpb#n240500>, <http://purl.org/lobid/rpb#n240600>, <http://purl.org/lobid/rpb#n241050>, <http://purl.org/lobid/rpb#n241100>, <http://purl.org/lobid/rpb#n241200>, <http://purl.org/lobid/rpb#n241400>, <http://purl.org/lobid/rpb#n242100>, <http://purl.org/lobid/rpb#n242200>, <http://purl.org/lobid/rpb#n242300>, <http://purl.org/lobid/rpb#n242500>, <http://purl.org/lobid/rpb#n242600>, <http://purl.org/lobid/rpb#n242700>, <http://purl.org/lobid/rpb#n242800>, <http://purl.org/lobid/rpb#n243100>, <http://purl.org/lobid/rpb#n243400>, <http://purl.org/lobid/rpb#n245100>, <http://purl.org/lobid/rpb#n245300>, <http://purl.org/lobid/rpb#n246100>, <http://purl.org/lobid/rpb#n246200>, <http://purl.org/lobid/rpb#n246300>, <http://purl.org/lobid/rpb#n246500>, <http://purl.org/lobid/rpb#n246700>, <http://purl.org/lobid/rpb#n248000>, <http://purl.org/lobid/rpb#n248100>, <http://purl.org/lobid/rpb#n248300>, <http://purl.org/lobid/rpb#n248500>, <http://purl.org/lobid/rpb#n249100> ;
+    skos:notation "rpb240000" ;
+    skos:prefLabel "Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n240100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb240100" ;
+    skos:prefLabel "Quelle"@de .
+
+<http://purl.org/lobid/rpb#n240200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb240200" ;
+    skos:prefLabel "Geschichtsschreibung"@de .
+
+<http://purl.org/lobid/rpb#n240300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb240300" ;
+    skos:prefLabel "Regionalgeschichte"@de .
+
+<http://purl.org/lobid/rpb#n240350>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb240350" ;
+    skos:prefLabel "Verbandsgemeindegeschichte"@de .
+
+<http://purl.org/lobid/rpb#n240400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb240400" ;
+    skos:prefLabel "Ortsgeschichte"@de .
+
+<http://purl.org/lobid/rpb#n240500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb240500" ;
+    skos:prefLabel "Historische Ausstellung"@de .
+
+<http://purl.org/lobid/rpb#n240600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb240600" ;
+    skos:prefLabel "Gedenkstätte"@de .
+
+<http://purl.org/lobid/rpb#n241050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb241050" ;
+    skos:prefLabel "Rheinland-Pfalz (gesamt) / Geschichte Anfänge-1945"@de .
+
+<http://purl.org/lobid/rpb#n241100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb241100" ;
+    skos:prefLabel "Rheinland / Geschichte Anfänge-1945"@de .
+
+<http://purl.org/lobid/rpb#n241200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb241200" ;
+    skos:prefLabel "Pfalz / Geschichte Anfänge-1945"@de .
+
+<http://purl.org/lobid/rpb#n241400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb241400" ;
+    skos:prefLabel "Rheinhessen / Geschichte Anfänge-1945"@de .
+
+<http://purl.org/lobid/rpb#n242100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb242100" ;
+    skos:prefLabel "Kurpfalz"@de .
+
+<http://purl.org/lobid/rpb#n242200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb242200" ;
+    skos:prefLabel "Hochstift Trier"@de .
+
+<http://purl.org/lobid/rpb#n242300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb242300" ;
+    skos:prefLabel "Hochstift Mainz"@de .
+
+<http://purl.org/lobid/rpb#n242500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb242500" ;
+    skos:prefLabel "Hochstift Speyer"@de .
+
+<http://purl.org/lobid/rpb#n242600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb242600" ;
+    skos:prefLabel "Hochstift Worms"@de .
+
+<http://purl.org/lobid/rpb#n242700>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n242720>, <http://purl.org/lobid/rpb#n242730>, <http://purl.org/lobid/rpb#n242740>, <http://purl.org/lobid/rpb#n242760> ;
+    skos:notation "rpb242700" ;
+    skos:prefLabel "Reichsterritorium. Reichsbeziehung"@de .
+
+<http://purl.org/lobid/rpb#n242720>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242700> ;
+    skos:notation "rpb242720" ;
+    skos:prefLabel "Reichstag"@de .
+
+<http://purl.org/lobid/rpb#n242730>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242700> ;
+    skos:notation "rpb242730" ;
+    skos:prefLabel "Reichsrecht"@de .
+
+<http://purl.org/lobid/rpb#n242740>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242700> ;
+    skos:narrower <http://purl.org/lobid/rpb#n242743>, <http://purl.org/lobid/rpb#n242744>, <http://purl.org/lobid/rpb#n242746>, <http://purl.org/lobid/rpb#n242747> ;
+    skos:notation "rpb242740" ;
+    skos:prefLabel "Reichsgut"@de .
+
+<http://purl.org/lobid/rpb#n242743>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242740> ;
+    skos:notation "rpb242743" ;
+    skos:prefLabel "Königshof"@de .
+
+<http://purl.org/lobid/rpb#n242744>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242740> ;
+    skos:notation "rpb242744" ;
+    skos:prefLabel "Königspfalz"@de .
+
+<http://purl.org/lobid/rpb#n242746>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242740> ;
+    skos:notation "rpb242746" ;
+    skos:prefLabel "Reichsabtei"@de .
+
+<http://purl.org/lobid/rpb#n242747>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242740> ;
+    skos:notation "rpb242747" ;
+    skos:prefLabel "Reichsstadt"@de .
+
+<http://purl.org/lobid/rpb#n242760>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242700> ;
+    skos:notation "rpb242760" ;
+    skos:prefLabel "Reichsritterschaft"@de .
+
+<http://purl.org/lobid/rpb#n242800>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n242810>, <http://purl.org/lobid/rpb#n242812>, <http://purl.org/lobid/rpb#n242814>, <http://purl.org/lobid/rpb#n242816>, <http://purl.org/lobid/rpb#n242818>, <http://purl.org/lobid/rpb#n242830>, <http://purl.org/lobid/rpb#n242832>, <http://purl.org/lobid/rpb#n242834>, <http://purl.org/lobid/rpb#n242836>, <http://purl.org/lobid/rpb#n242850>, <http://purl.org/lobid/rpb#n242852>, <http://purl.org/lobid/rpb#n242854>, <http://purl.org/lobid/rpb#n242856>, <http://purl.org/lobid/rpb#n242870>, <http://purl.org/lobid/rpb#n242872>, <http://purl.org/lobid/rpb#n242874>, <http://purl.org/lobid/rpb#n242876>, <http://purl.org/lobid/rpb#n242878> ;
+    skos:notation "rpb242800" ;
+    skos:prefLabel "Kleinere Territorien und Teile auswärtiger Territorien"@de .
+
+<http://purl.org/lobid/rpb#n242810>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242810" ;
+    skos:prefLabel "Luxemburg"@de .
+
+<http://purl.org/lobid/rpb#n242812>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242812" ;
+    skos:prefLabel "Hochstift Köln"@de .
+
+<http://purl.org/lobid/rpb#n242814>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242814" ;
+    skos:prefLabel "Grafschaft Homburg, Saar"@de .
+
+<http://purl.org/lobid/rpb#n242816>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242816" ;
+    skos:prefLabel "Grafschaft Saarbrücken"@de .
+
+<http://purl.org/lobid/rpb#n242818>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242818" ;
+    skos:prefLabel "Staat Leiningen"@de .
+
+<http://purl.org/lobid/rpb#n242830>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242830" ;
+    skos:prefLabel "Grafschaft Virneburg"@de .
+
+<http://purl.org/lobid/rpb#n242832>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242832" ;
+    skos:prefLabel "Grafschaft Manderscheid"@de .
+
+<http://purl.org/lobid/rpb#n242834>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242834" ;
+    skos:prefLabel "Herzogtum Arenberg"@de .
+
+<http://purl.org/lobid/rpb#n242836>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242836" ;
+    skos:prefLabel "Fürstentum Löwenstein-Wertheim"@de .
+
+<http://purl.org/lobid/rpb#n242850>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242850" ;
+    skos:prefLabel "Grafschaft Wied"@de .
+
+<http://purl.org/lobid/rpb#n242852>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242852" ;
+    skos:prefLabel "Fürstentum Isenburg. Grafschaft Isenburg"@de .
+
+<http://purl.org/lobid/rpb#n242854>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242854" ;
+    skos:prefLabel "Grafschaft Sayn"@de .
+
+<http://purl.org/lobid/rpb#n242856>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242856" ;
+    skos:prefLabel "Grafschaft Katzenelnbogen"@de .
+
+<http://purl.org/lobid/rpb#n242870>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242870" ;
+    skos:prefLabel "Grafschaft Veldenz"@de .
+
+<http://purl.org/lobid/rpb#n242872>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242872" ;
+    skos:prefLabel "Grafschaft Sponheim"@de .
+
+<http://purl.org/lobid/rpb#n242874>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242874" ;
+    skos:prefLabel "Wild- und Rheingrafen"@de .
+
+<http://purl.org/lobid/rpb#n242876>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242876" ;
+    skos:prefLabel "Pfalz-Simmern"@de .
+
+<http://purl.org/lobid/rpb#n242878>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n242800> ;
+    skos:notation "rpb242878" ;
+    skos:prefLabel "Hanau-Lichtenberg"@de .
+
+<http://purl.org/lobid/rpb#n243100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb243100" ;
+    skos:prefLabel "Pfalz-Zweibrücken"@de .
+
+<http://purl.org/lobid/rpb#n243400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb243400" ;
+    skos:prefLabel "Staat Nassau"@de .
+
+<http://purl.org/lobid/rpb#n245100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n245120>, <http://purl.org/lobid/rpb#n245130>, <http://purl.org/lobid/rpb#n245140>, <http://purl.org/lobid/rpb#n245160>, <http://purl.org/lobid/rpb#n245180> ;
+    skos:notation "rpb245100" ;
+    skos:prefLabel "Französische Besetzung / 1792-1815"@de .
+
+<http://purl.org/lobid/rpb#n245120>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n245100> ;
+    skos:notation "rpb245120" ;
+    skos:prefLabel "Mainzer Republik"@de .
+
+<http://purl.org/lobid/rpb#n245130>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n245100> ;
+    skos:notation "rpb245130" ;
+    skos:prefLabel "Wälderdepartement"@de .
+
+<http://purl.org/lobid/rpb#n245140>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n245100> ;
+    skos:notation "rpb245140" ;
+    skos:prefLabel "Rhein-Mosel-Département"@de .
+
+<http://purl.org/lobid/rpb#n245160>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n245100> ;
+    skos:notation "rpb245160" ;
+    skos:prefLabel "Département Donnersberg"@de .
+
+<http://purl.org/lobid/rpb#n245180>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n245100> ;
+    skos:notation "rpb245180" ;
+    skos:prefLabel "Saardepartement"@de .
+
+<http://purl.org/lobid/rpb#n245300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb245300" ;
+    skos:prefLabel "Rheinbund / 1806-1813"@de .
+
+<http://purl.org/lobid/rpb#n246100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb246100" ;
+    skos:prefLabel "Rheinprovinz"@de .
+
+<http://purl.org/lobid/rpb#n246200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb246200" ;
+    skos:prefLabel "Hessen-Darmstadt"@de .
+
+<http://purl.org/lobid/rpb#n246300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb246300" ;
+    skos:prefLabel "Hessen-Nassau"@de .
+
+<http://purl.org/lobid/rpb#n246500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb246500" ;
+    skos:prefLabel "Bayerische Pfalz"@de .
+
+<http://purl.org/lobid/rpb#n246700>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n246720>, <http://purl.org/lobid/rpb#n246740>, <http://purl.org/lobid/rpb#n246760> ;
+    skos:notation "rpb246700" ;
+    skos:prefLabel "Kleinere Territorien des 19. Jahrhunderts"@de .
+
+<http://purl.org/lobid/rpb#n246720>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n246700> ;
+    skos:notation "rpb246720" ;
+    skos:prefLabel "Fürstentum Birkenfeld"@de .
+
+<http://purl.org/lobid/rpb#n246740>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n246700> ;
+    skos:notation "rpb246740" ;
+    skos:prefLabel "Fürstentum Lichtenberg"@de .
+
+<http://purl.org/lobid/rpb#n246760>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n246700> ;
+    skos:notation "rpb246760" ;
+    skos:prefLabel "Oberamt Meisenheim"@de .
+
+<http://purl.org/lobid/rpb#n248000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb248000" ;
+    skos:prefLabel "Rheinland-Pfalz / Geschichte 1945-1947"@de .
+
+<http://purl.org/lobid/rpb#n248100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb248100" ;
+    skos:prefLabel "Rheinland / Geschichte 1945-"@de .
+
+<http://purl.org/lobid/rpb#n248300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb248300" ;
+    skos:prefLabel "Rheinhessen / Geschichte 1945-"@de .
+
+<http://purl.org/lobid/rpb#n248500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb248500" ;
+    skos:prefLabel "Pfalz / Geschichte 1945-"@de .
+
+<http://purl.org/lobid/rpb#n249100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n240000> ;
+    skos:notation "rpb249100" ;
+    skos:prefLabel "Rheinland-Pfalz / Geschichte 1947-"@de .
+
+<http://purl.org/lobid/rpb#n260000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n260100>, <http://purl.org/lobid/rpb#n262000>, <http://purl.org/lobid/rpb#n263000> ;
+    skos:notation "rpb260000" ;
+    skos:prefLabel "Militär- und Wehrwesen"@de .
+
+<http://purl.org/lobid/rpb#n260100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n260000> ;
+    skos:notation "rpb260100" ;
+    skos:prefLabel "Militär- und Wehrwesen allgemein"@de .
+
+<http://purl.org/lobid/rpb#n262000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n260000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n262010>, <http://purl.org/lobid/rpb#n262020> ;
+    skos:notation "rpb262000" ;
+    skos:prefLabel "Militär"@de .
+
+<http://purl.org/lobid/rpb#n262010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n262011>, <http://purl.org/lobid/rpb#n262012>, <http://purl.org/lobid/rpb#n262014>, <http://purl.org/lobid/rpb#n262016> ;
+    skos:notation "rpb262010" ;
+    skos:prefLabel "Militärbau"@de .
+
+<http://purl.org/lobid/rpb#n262011>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262010> ;
+    skos:notation "rpb262011" ;
+    skos:prefLabel "Burg"@de .
+
+<http://purl.org/lobid/rpb#n262012>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262010> ;
+    skos:notation "rpb262012" ;
+    skos:prefLabel "Festung"@de .
+
+<http://purl.org/lobid/rpb#n262014>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262010> ;
+    skos:notation "rpb262014" ;
+    skos:prefLabel "Schanze"@de .
+
+<http://purl.org/lobid/rpb#n262016>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262010> ;
+    skos:notation "rpb262016" ;
+    skos:prefLabel "Standort"@de .
+
+<http://purl.org/lobid/rpb#n262020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n262022>, <http://purl.org/lobid/rpb#n262023>, <http://purl.org/lobid/rpb#n262024>, <http://purl.org/lobid/rpb#n262025>, <http://purl.org/lobid/rpb#n262026> ;
+    skos:notation "rpb262020" ;
+    skos:prefLabel "Militär / Ausrüstung"@de .
+
+<http://purl.org/lobid/rpb#n262022>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262020> ;
+    skos:notation "rpb262022" ;
+    skos:prefLabel "Kriegswaffe"@de .
+
+<http://purl.org/lobid/rpb#n262023>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262020> ;
+    skos:notation "rpb262023" ;
+    skos:prefLabel "Rüstung"@de .
+
+<http://purl.org/lobid/rpb#n262024>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262020> ;
+    skos:notation "rpb262024" ;
+    skos:prefLabel "Uniform"@de .
+
+<http://purl.org/lobid/rpb#n262025>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262020> ;
+    skos:notation "rpb262025" ;
+    skos:prefLabel "Feldzeichen"@de .
+
+<http://purl.org/lobid/rpb#n262026>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n262020> ;
+    skos:notation "rpb262026" ;
+    skos:prefLabel "Orden / Ehrenzeichen"@de .
+
+<http://purl.org/lobid/rpb#n263000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n260000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n263010>, <http://purl.org/lobid/rpb#n263020>, <http://purl.org/lobid/rpb#n263030>, <http://purl.org/lobid/rpb#n263040>, <http://purl.org/lobid/rpb#n263050>, <http://purl.org/lobid/rpb#n263060>, <http://purl.org/lobid/rpb#n263090> ;
+    skos:notation "rpb263000" ;
+    skos:prefLabel "Wehrwesen"@de .
+
+<http://purl.org/lobid/rpb#n263010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n263000> ;
+    skos:notation "rpb263010" ;
+    skos:prefLabel "Bürgerwehr"@de .
+
+<http://purl.org/lobid/rpb#n263020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n263000> ;
+    skos:notation "rpb263020" ;
+    skos:prefLabel "Militär / Geschichte Anfänge-1918"@de .
+
+<http://purl.org/lobid/rpb#n263030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n263000> ;
+    skos:notation "rpb263030" ;
+    skos:prefLabel "Deutschland / Reichswehr"@de .
+
+<http://purl.org/lobid/rpb#n263040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n263000> ;
+    skos:notation "rpb263040" ;
+    skos:prefLabel "Deutschland / Wehrmacht"@de .
+
+<http://purl.org/lobid/rpb#n263050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n263000> ;
+    skos:notation "rpb263050" ;
+    skos:prefLabel "Ausländisches Militär"@de .
+
+<http://purl.org/lobid/rpb#n263060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n263000> ;
+    skos:notation "rpb263060" ;
+    skos:prefLabel "Deutschland / Bundeswehr"@de .
+
+<http://purl.org/lobid/rpb#n263090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n263000> ;
+    skos:notation "rpb263090" ;
+    skos:prefLabel "Soldat"@de .
+
+<http://purl.org/lobid/rpb#n400000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n400100>, <http://purl.org/lobid/rpb#n402000>, <http://purl.org/lobid/rpb#n402300>, <http://purl.org/lobid/rpb#n404000>, <http://purl.org/lobid/rpb#n404300>, <http://purl.org/lobid/rpb#n406000> ;
+    skos:notation "rpb400000" ;
+    skos:prefLabel "Staat. Politik"@de .
+
+<http://purl.org/lobid/rpb#n400100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n400000> ;
+    skos:notation "rpb400100" ;
+    skos:prefLabel "Staat. Politik allgemein"@de .
+
+<http://purl.org/lobid/rpb#n402000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n400000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n402020>, <http://purl.org/lobid/rpb#n402030>, <http://purl.org/lobid/rpb#n402040>, <http://purl.org/lobid/rpb#n402050>, <http://purl.org/lobid/rpb#n402060>, <http://purl.org/lobid/rpb#n402070> ;
+    skos:notation "rpb402000" ;
+    skos:prefLabel "Staatsgrundlage"@de .
+
+<http://purl.org/lobid/rpb#n402020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402000> ;
+    skos:notation "rpb402020" ;
+    skos:prefLabel "Staatsrecht"@de .
+
+<http://purl.org/lobid/rpb#n402030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402000> ;
+    skos:notation "rpb402030" ;
+    skos:prefLabel "Staatsangehörigkeit"@de .
+
+<http://purl.org/lobid/rpb#n402040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402000> ;
+    skos:notation "rpb402040" ;
+    skos:prefLabel "Staatsgebiet"@de .
+
+<http://purl.org/lobid/rpb#n402050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402000> ;
+    skos:notation "rpb402050" ;
+    skos:prefLabel "Hoheitsrecht"@de .
+
+<http://purl.org/lobid/rpb#n402060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402000> ;
+    skos:notation "rpb402060" ;
+    skos:prefLabel "Staatsform"@de .
+
+<http://purl.org/lobid/rpb#n402070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402000> ;
+    skos:notation "rpb402070" ;
+    skos:prefLabel "Föderalismus"@de .
+
+<http://purl.org/lobid/rpb#n402300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n400000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n402330>, <http://purl.org/lobid/rpb#n402340>, <http://purl.org/lobid/rpb#n402350> ;
+    skos:notation "rpb402300" ;
+    skos:prefLabel "Verfassung"@de .
+
+<http://purl.org/lobid/rpb#n402330>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402300> ;
+    skos:notation "rpb402330" ;
+    skos:prefLabel "Verfassung / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n402340>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402300> ;
+    skos:narrower <http://purl.org/lobid/rpb#n402344> ;
+    skos:notation "rpb402340" ;
+    skos:prefLabel "Grundrecht"@de .
+
+<http://purl.org/lobid/rpb#n402344>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402340> ;
+    skos:notation "rpb402344" ;
+    skos:prefLabel "Datenschutz"@de .
+
+<http://purl.org/lobid/rpb#n402350>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n402300> ;
+    skos:notation "rpb402350" ;
+    skos:prefLabel "Gewaltenteilung"@de .
+
+<http://purl.org/lobid/rpb#n404000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n400000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n404030>, <http://purl.org/lobid/rpb#n404040>, <http://purl.org/lobid/rpb#n404050>, <http://purl.org/lobid/rpb#n404060>, <http://purl.org/lobid/rpb#n404070>, <http://purl.org/lobid/rpb#n404090> ;
+    skos:notation "rpb404000" ;
+    skos:prefLabel "Politisches System"@de .
+
+<http://purl.org/lobid/rpb#n404030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404000> ;
+    skos:notation "rpb404030" ;
+    skos:prefLabel "Regierungsbildung"@de .
+
+<http://purl.org/lobid/rpb#n404040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404000> ;
+    skos:notation "rpb404040" ;
+    skos:prefLabel "Regierungschef"@de .
+
+<http://purl.org/lobid/rpb#n404050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404000> ;
+    skos:notation "rpb404050" ;
+    skos:prefLabel "Regierung"@de .
+
+<http://purl.org/lobid/rpb#n404060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404000> ;
+    skos:notation "rpb404060" ;
+    skos:prefLabel "Ministerium"@de .
+
+<http://purl.org/lobid/rpb#n404070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404000> ;
+    skos:notation "rpb404070" ;
+    skos:prefLabel "Regierungspolitik"@de .
+
+<http://purl.org/lobid/rpb#n404090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404000> ;
+    skos:notation "rpb404090" ;
+    skos:prefLabel "Landespartnerschaft"@de .
+
+<http://purl.org/lobid/rpb#n404300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n400000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n404320>, <http://purl.org/lobid/rpb#n404340>, <http://purl.org/lobid/rpb#n404350>, <http://purl.org/lobid/rpb#n404360>, <http://purl.org/lobid/rpb#n404380> ;
+    skos:notation "rpb404300" ;
+    skos:prefLabel "Parlament"@de .
+
+<http://purl.org/lobid/rpb#n404320>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404300> ;
+    skos:notation "rpb404320" ;
+    skos:prefLabel "Parlament / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n404340>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404300> ;
+    skos:notation "rpb404340" ;
+    skos:prefLabel "Regierungspartei"@de .
+
+<http://purl.org/lobid/rpb#n404350>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404300> ;
+    skos:notation "rpb404350" ;
+    skos:prefLabel "Opposition"@de .
+
+<http://purl.org/lobid/rpb#n404360>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404300> ;
+    skos:narrower <http://purl.org/lobid/rpb#n404361>, <http://purl.org/lobid/rpb#n404365> ;
+    skos:notation "rpb404360" ;
+    skos:prefLabel "Parlamentsorganisation"@de .
+
+<http://purl.org/lobid/rpb#n404361>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404360> ;
+    skos:notation "rpb404361" ;
+    skos:prefLabel "Parlamentsausschuss"@de .
+
+<http://purl.org/lobid/rpb#n404365>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404360> ;
+    skos:notation "rpb404365" ;
+    skos:prefLabel "Ombudsmann"@de .
+
+<http://purl.org/lobid/rpb#n404380>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n404300> ;
+    skos:notation "rpb404380" ;
+    skos:prefLabel "Abgeordneter"@de .
+
+<http://purl.org/lobid/rpb#n406000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n400000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n406020>, <http://purl.org/lobid/rpb#n406030>, <http://purl.org/lobid/rpb#n406040>, <http://purl.org/lobid/rpb#n406060>, <http://purl.org/lobid/rpb#n406080>, <http://purl.org/lobid/rpb#n406100>, <http://purl.org/lobid/rpb#n406200>, <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406000" ;
+    skos:prefLabel "Politische Willensbildung"@de .
+
+<http://purl.org/lobid/rpb#n406020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406000> ;
+    skos:notation "rpb406020" ;
+    skos:prefLabel "Öffentlichkeitsarbeit"@de .
+
+<http://purl.org/lobid/rpb#n406030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406000> ;
+    skos:notation "rpb406030" ;
+    skos:prefLabel "Politische Bildung"@de .
+
+<http://purl.org/lobid/rpb#n406040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406000> ;
+    skos:notation "rpb406040" ;
+    skos:prefLabel "Öffentliche Meinung"@de .
+
+<http://purl.org/lobid/rpb#n406060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406000> ;
+    skos:notation "rpb406060" ;
+    skos:prefLabel "Politische Bewegung"@de .
+
+<http://purl.org/lobid/rpb#n406080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406000> ;
+    skos:notation "rpb406080" ;
+    skos:prefLabel "Parteistiftung"@de .
+
+<http://purl.org/lobid/rpb#n406100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n406120>, <http://purl.org/lobid/rpb#n406130> ;
+    skos:notation "rpb406100" ;
+    skos:prefLabel "Partei. Politikerin. Politiker"@de .
+
+<http://purl.org/lobid/rpb#n406120>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406100> ;
+    skos:notation "rpb406120" ;
+    skos:prefLabel "Partei"@de .
+
+<http://purl.org/lobid/rpb#n406130>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406100> ;
+    skos:notation "rpb406130" ;
+    skos:prefLabel "Politikerin. Politiker"@de .
+
+<http://purl.org/lobid/rpb#n406200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n406230>, <http://purl.org/lobid/rpb#n406250>, <http://purl.org/lobid/rpb#n406270> ;
+    skos:notation "rpb406200" ;
+    skos:prefLabel "Politische Gruppe"@de .
+
+<http://purl.org/lobid/rpb#n406230>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406200> ;
+    skos:notation "rpb406230" ;
+    skos:prefLabel "Politischer Verein"@de .
+
+<http://purl.org/lobid/rpb#n406250>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406200> ;
+    skos:notation "rpb406250" ;
+    skos:prefLabel "Bürgerinitiative"@de .
+
+<http://purl.org/lobid/rpb#n406270>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406200> ;
+    skos:notation "rpb406270" ;
+    skos:prefLabel "Projektgruppe"@de .
+
+<http://purl.org/lobid/rpb#n406300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n406310>, <http://purl.org/lobid/rpb#n406320>, <http://purl.org/lobid/rpb#n406330>, <http://purl.org/lobid/rpb#n406340>, <http://purl.org/lobid/rpb#n406350>, <http://purl.org/lobid/rpb#n406360>, <http://purl.org/lobid/rpb#n406370>, <http://purl.org/lobid/rpb#n406380>, <http://purl.org/lobid/rpb#n406390> ;
+    skos:notation "rpb406300" ;
+    skos:prefLabel "Wahl"@de .
+
+<http://purl.org/lobid/rpb#n406310>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406310" ;
+    skos:prefLabel "Wahlrecht"@de .
+
+<http://purl.org/lobid/rpb#n406320>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406320" ;
+    skos:prefLabel "Wahlkreiseinteilung"@de .
+
+<http://purl.org/lobid/rpb#n406330>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406330" ;
+    skos:prefLabel "Volksabstimmung"@de .
+
+<http://purl.org/lobid/rpb#n406340>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406340" ;
+    skos:prefLabel "Europawahl"@de .
+
+<http://purl.org/lobid/rpb#n406350>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406350" ;
+    skos:prefLabel "Bundestagswahl"@de .
+
+<http://purl.org/lobid/rpb#n406360>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406360" ;
+    skos:prefLabel "Landtagswahl"@de .
+
+<http://purl.org/lobid/rpb#n406370>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406370" ;
+    skos:prefLabel "Kreistag / Wahl"@de .
+
+<http://purl.org/lobid/rpb#n406380>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406380" ;
+    skos:prefLabel "Bezirkstag / Wahl"@de .
+
+<http://purl.org/lobid/rpb#n406390>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n406300> ;
+    skos:notation "rpb406390" ;
+    skos:prefLabel "Kommunalwahl"@de .
+
+<http://purl.org/lobid/rpb#n420000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n420100>, <http://purl.org/lobid/rpb#n421000>, <http://purl.org/lobid/rpb#n421400>, <http://purl.org/lobid/rpb#n422000>, <http://purl.org/lobid/rpb#n423000>, <http://purl.org/lobid/rpb#n424000>, <http://purl.org/lobid/rpb#n425000>, <http://purl.org/lobid/rpb#n426000>, <http://purl.org/lobid/rpb#n427000>, <http://purl.org/lobid/rpb#n428000> ;
+    skos:notation "rpb420000" ;
+    skos:prefLabel "Verwaltung"@de .
+
+<http://purl.org/lobid/rpb#n420100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:notation "rpb420100" ;
+    skos:prefLabel "Verwaltung allgemein"@de .
+
+<http://purl.org/lobid/rpb#n421000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:notation "rpb421000" ;
+    skos:prefLabel "Verwaltungsrecht"@de .
+
+<http://purl.org/lobid/rpb#n421400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:notation "rpb421400" ;
+    skos:prefLabel "Verwaltungskontrolle"@de .
+
+<http://purl.org/lobid/rpb#n422000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:notation "rpb422000" ;
+    skos:prefLabel "Verwaltung / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n423000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n423020>, <http://purl.org/lobid/rpb#n423030>, <http://purl.org/lobid/rpb#n423050>, <http://purl.org/lobid/rpb#n423400>, <http://purl.org/lobid/rpb#n423600> ;
+    skos:notation "rpb423000" ;
+    skos:prefLabel "Allgemeine Verwaltung"@de .
+
+<http://purl.org/lobid/rpb#n423020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423000> ;
+    skos:notation "rpb423020" ;
+    skos:prefLabel "Verwaltung / Struktur"@de .
+
+<http://purl.org/lobid/rpb#n423030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423000> ;
+    skos:notation "rpb423030" ;
+    skos:prefLabel "Behörde / Organisation"@de .
+
+<http://purl.org/lobid/rpb#n423050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423000> ;
+    skos:notation "rpb423050" ;
+    skos:prefLabel "Behörde / Datenverarbeitung"@de .
+
+<http://purl.org/lobid/rpb#n423400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n423420>, <http://purl.org/lobid/rpb#n423430>, <http://purl.org/lobid/rpb#n423440> ;
+    skos:notation "rpb423400" ;
+    skos:prefLabel "Verwaltungsreform"@de .
+
+<http://purl.org/lobid/rpb#n423420>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423400> ;
+    skos:notation "rpb423420" ;
+    skos:prefLabel "Länderneugliederung"@de .
+
+<http://purl.org/lobid/rpb#n423430>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423400> ;
+    skos:notation "rpb423430" ;
+    skos:prefLabel "Gebietsreform"@de .
+
+<http://purl.org/lobid/rpb#n423440>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423400> ;
+    skos:notation "rpb423440" ;
+    skos:prefLabel "Funktionalreform"@de .
+
+<http://purl.org/lobid/rpb#n423600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n423610>, <http://purl.org/lobid/rpb#n423620>, <http://purl.org/lobid/rpb#n423640> ;
+    skos:notation "rpb423600" ;
+    skos:prefLabel "Öffentlicher Dienst"@de .
+
+<http://purl.org/lobid/rpb#n423610>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423600> ;
+    skos:notation "rpb423610" ;
+    skos:prefLabel "Dienstrecht"@de .
+
+<http://purl.org/lobid/rpb#n423620>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423600> ;
+    skos:notation "rpb423620" ;
+    skos:prefLabel "Personalwesen"@de .
+
+<http://purl.org/lobid/rpb#n423640>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n423600> ;
+    skos:notation "rpb423640" ;
+    skos:prefLabel "Beamter"@de .
+
+<http://purl.org/lobid/rpb#n424000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n424020>, <http://purl.org/lobid/rpb#n424030>, <http://purl.org/lobid/rpb#n424040>, <http://purl.org/lobid/rpb#n424050>, <http://purl.org/lobid/rpb#n424060> ;
+    skos:notation "rpb424000" ;
+    skos:prefLabel "Öffentlicher Haushalt"@de .
+
+<http://purl.org/lobid/rpb#n424020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n424021>, <http://purl.org/lobid/rpb#n424022>, <http://purl.org/lobid/rpb#n424024>, <http://purl.org/lobid/rpb#n424026>, <http://purl.org/lobid/rpb#n424028> ;
+    skos:notation "rpb424020" ;
+    skos:prefLabel "Finanzverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n424021>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424020> ;
+    skos:notation "rpb424021" ;
+    skos:prefLabel "Finanzamt"@de .
+
+<http://purl.org/lobid/rpb#n424022>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424020> ;
+    skos:notation "rpb424022" ;
+    skos:prefLabel "Finanzausgleich"@de .
+
+<http://purl.org/lobid/rpb#n424024>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424020> ;
+    skos:notation "rpb424024" ;
+    skos:prefLabel "Finanzreform"@de .
+
+<http://purl.org/lobid/rpb#n424026>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424020> ;
+    skos:notation "rpb424026" ;
+    skos:prefLabel "Öffentliche Beschaffung"@de .
+
+<http://purl.org/lobid/rpb#n424028>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424020> ;
+    skos:notation "rpb424028" ;
+    skos:prefLabel "Rechnungshof"@de .
+
+<http://purl.org/lobid/rpb#n424030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424000> ;
+    skos:notation "rpb424030" ;
+    skos:prefLabel "Abgabe"@de .
+
+<http://purl.org/lobid/rpb#n424040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n424042> ;
+    skos:notation "rpb424040" ;
+    skos:prefLabel "Steuer"@de .
+
+<http://purl.org/lobid/rpb#n424042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424040> ;
+    skos:notation "rpb424042" ;
+    skos:prefLabel "Steuerberatung"@de .
+
+<http://purl.org/lobid/rpb#n424050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424000> ;
+    skos:notation "rpb424050" ;
+    skos:prefLabel "Gebühr"@de .
+
+<http://purl.org/lobid/rpb#n424060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n424000> ;
+    skos:notation "rpb424060" ;
+    skos:prefLabel "Zoll"@de .
+
+<http://purl.org/lobid/rpb#n425000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n425020>, <http://purl.org/lobid/rpb#n425030>, <http://purl.org/lobid/rpb#n425040>, <http://purl.org/lobid/rpb#n425050>, <http://purl.org/lobid/rpb#n425200> ;
+    skos:notation "rpb425000" ;
+    skos:prefLabel "Bezirksverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n425020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n425000> ;
+    skos:notation "rpb425020" ;
+    skos:prefLabel "Regierungspräsident"@de .
+
+<http://purl.org/lobid/rpb#n425030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n425000> ;
+    skos:notation "rpb425030" ;
+    skos:prefLabel "Regierungsbezirk Koblenz"@de .
+
+<http://purl.org/lobid/rpb#n425040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n425000> ;
+    skos:notation "rpb425040" ;
+    skos:prefLabel "Regierungsbezirk Trier"@de .
+
+<http://purl.org/lobid/rpb#n425050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n425000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n425052> ;
+    skos:notation "rpb425050" ;
+    skos:prefLabel "Regierungsbezirk Rheinhessen-Pfalz"@de .
+
+<http://purl.org/lobid/rpb#n425052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n425050> ;
+    skos:notation "rpb425052" ;
+    skos:prefLabel "Bezirksverband Pfalz"@de .
+
+<http://purl.org/lobid/rpb#n425200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n425000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n425220>, <http://purl.org/lobid/rpb#n425230>, <http://purl.org/lobid/rpb#n425290> ;
+    skos:notation "rpb425200" ;
+    skos:prefLabel "Kreisverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n425220>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n425200> ;
+    skos:notation "rpb425220" ;
+    skos:prefLabel "Kreisrecht"@de .
+
+<http://purl.org/lobid/rpb#n425230>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n425200> ;
+    skos:notation "rpb425230" ;
+    skos:prefLabel "Kreisparlament"@de .
+
+<http://purl.org/lobid/rpb#n425290>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n425200> ;
+    skos:notation "rpb425290" ;
+    skos:prefLabel "Kreispartnerschaft"@de .
+
+<http://purl.org/lobid/rpb#n426000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n426020>, <http://purl.org/lobid/rpb#n426030>, <http://purl.org/lobid/rpb#n426040>, <http://purl.org/lobid/rpb#n426050>, <http://purl.org/lobid/rpb#n426060>, <http://purl.org/lobid/rpb#n426070>, <http://purl.org/lobid/rpb#n426090> ;
+    skos:notation "rpb426000" ;
+    skos:prefLabel "Gemeindeverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n426020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n426000> ;
+    skos:notation "rpb426020" ;
+    skos:prefLabel "Ortsrecht"@de .
+
+<http://purl.org/lobid/rpb#n426030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n426000> ;
+    skos:notation "rpb426030" ;
+    skos:prefLabel "Gemeinderat"@de .
+
+<http://purl.org/lobid/rpb#n426040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n426000> ;
+    skos:notation "rpb426040" ;
+    skos:prefLabel "Kommunale Selbstverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n426050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n426000> ;
+    skos:notation "rpb426050" ;
+    skos:prefLabel "Auftragsverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n426060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n426000> ;
+    skos:notation "rpb426060" ;
+    skos:prefLabel "Kommunaler Spitzenverband"@de .
+
+<http://purl.org/lobid/rpb#n426070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n426000> ;
+    skos:notation "rpb426070" ;
+    skos:prefLabel "Verbandsgemeinde"@de .
+
+<http://purl.org/lobid/rpb#n426090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n426000> ;
+    skos:notation "rpb426090" ;
+    skos:prefLabel "Kommunale Partnerschaft"@de .
+
+<http://purl.org/lobid/rpb#n427000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n427010>, <http://purl.org/lobid/rpb#n427020>, <http://purl.org/lobid/rpb#n427030>, <http://purl.org/lobid/rpb#n427040> ;
+    skos:notation "rpb427000" ;
+    skos:prefLabel "Obere Landesbehörde"@de .
+
+<http://purl.org/lobid/rpb#n427010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n427000> ;
+    skos:notation "rpb427010" ;
+    skos:prefLabel "Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Nord"@de .
+
+<http://purl.org/lobid/rpb#n427020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n427000> ;
+    skos:notation "rpb427020" ;
+    skos:prefLabel "Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Süd"@de .
+
+<http://purl.org/lobid/rpb#n427030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n427000> ;
+    skos:notation "rpb427030" ;
+    skos:prefLabel "Rheinland-Pfalz / Aufsichts- und Dienstleistungsdirektion"@de .
+
+<http://purl.org/lobid/rpb#n427040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n427000> ;
+    skos:notation "rpb427040" ;
+    skos:prefLabel "Rheinland-Pfalz / Landesuntersuchungsamt"@de .
+
+<http://purl.org/lobid/rpb#n428000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n420000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n428020>, <http://purl.org/lobid/rpb#n428030>, <http://purl.org/lobid/rpb#n428040>, <http://purl.org/lobid/rpb#n428050>, <http://purl.org/lobid/rpb#n428060>, <http://purl.org/lobid/rpb#n428070>, <http://purl.org/lobid/rpb#n428080> ;
+    skos:notation "rpb428000" ;
+    skos:prefLabel "Sicherheit und Ordnung"@de .
+
+<http://purl.org/lobid/rpb#n428020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428000> ;
+    skos:notation "rpb428020" ;
+    skos:prefLabel "Ordnungsrecht"@de .
+
+<http://purl.org/lobid/rpb#n428030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n428032>, <http://purl.org/lobid/rpb#n428033> ;
+    skos:notation "rpb428030" ;
+    skos:prefLabel "Polizei"@de .
+
+<http://purl.org/lobid/rpb#n428032>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428030> ;
+    skos:notation "rpb428032" ;
+    skos:prefLabel "Polizeiorganisation"@de .
+
+<http://purl.org/lobid/rpb#n428033>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428030> ;
+    skos:notation "rpb428033" ;
+    skos:prefLabel "Polizei / Ausrüstung"@de .
+
+<http://purl.org/lobid/rpb#n428040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428000> ;
+    skos:notation "rpb428040" ;
+    skos:prefLabel "Zivilschutz"@de .
+
+<http://purl.org/lobid/rpb#n428050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n428052>, <http://purl.org/lobid/rpb#n428054> ;
+    skos:notation "rpb428050" ;
+    skos:prefLabel "Staatsschutz"@de .
+
+<http://purl.org/lobid/rpb#n428052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428050> ;
+    skos:notation "rpb428052" ;
+    skos:prefLabel "Grenzschutz"@de .
+
+<http://purl.org/lobid/rpb#n428054>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428050> ;
+    skos:notation "rpb428054" ;
+    skos:prefLabel "Verfassungsschutz"@de .
+
+<http://purl.org/lobid/rpb#n428060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428000> ;
+    skos:notation "rpb428060" ;
+    skos:prefLabel "Personenstandswesen"@de .
+
+<http://purl.org/lobid/rpb#n428070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n428072>, <http://purl.org/lobid/rpb#n428074>, <http://purl.org/lobid/rpb#n428076>, <http://purl.org/lobid/rpb#n428078> ;
+    skos:notation "rpb428070" ;
+    skos:prefLabel "Sicherheitsbehörde"@de .
+
+<http://purl.org/lobid/rpb#n428072>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428070> ;
+    skos:notation "rpb428072" ;
+    skos:prefLabel "Technischer Überwachungsverein"@de .
+
+<http://purl.org/lobid/rpb#n428074>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428070> ;
+    skos:notation "rpb428074" ;
+    skos:prefLabel "Feuerwehr"@de .
+
+<http://purl.org/lobid/rpb#n428076>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428070> ;
+    skos:notation "rpb428076" ;
+    skos:prefLabel "Rettungswesen"@de .
+
+<http://purl.org/lobid/rpb#n428078>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428070> ;
+    skos:notation "rpb428078" ;
+    skos:prefLabel "Katastrophe. Unfall"@de .
+
+<http://purl.org/lobid/rpb#n428080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n428000> ;
+    skos:notation "rpb428080" ;
+    skos:prefLabel "Friedhofsordnung"@de .
+
+<http://purl.org/lobid/rpb#n440000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n440100>, <http://purl.org/lobid/rpb#n442000>, <http://purl.org/lobid/rpb#n443000>, <http://purl.org/lobid/rpb#n444000>, <http://purl.org/lobid/rpb#n446000>, <http://purl.org/lobid/rpb#n447000>, <http://purl.org/lobid/rpb#n448000> ;
+    skos:notation "rpb440000" ;
+    skos:prefLabel "Recht"@de .
+
+<http://purl.org/lobid/rpb#n440100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n440000> ;
+    skos:notation "rpb440100" ;
+    skos:prefLabel "Recht allgemein"@de .
+
+<http://purl.org/lobid/rpb#n442000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n440000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n442050> ;
+    skos:notation "rpb442000" ;
+    skos:prefLabel "Recht / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n442050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n442000> ;
+    skos:notation "rpb442050" ;
+    skos:prefLabel "Recht / Geschichte / Quelle"@de .
+
+<http://purl.org/lobid/rpb#n443000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n440000> ;
+    skos:notation "rpb443000" ;
+    skos:prefLabel "Privatrecht"@de .
+
+<http://purl.org/lobid/rpb#n444000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n440000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n444030>, <http://purl.org/lobid/rpb#n444050>, <http://purl.org/lobid/rpb#n444070> ;
+    skos:notation "rpb444000" ;
+    skos:prefLabel "Strafrecht"@de .
+
+<http://purl.org/lobid/rpb#n444030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n444000> ;
+    skos:notation "rpb444030" ;
+    skos:prefLabel "Strafvollzug"@de .
+
+<http://purl.org/lobid/rpb#n444050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n444000> ;
+    skos:notation "rpb444050" ;
+    skos:prefLabel "Kriminalität"@de .
+
+<http://purl.org/lobid/rpb#n444070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n444000> ;
+    skos:notation "rpb444070" ;
+    skos:prefLabel "Kriminalfall"@de .
+
+<http://purl.org/lobid/rpb#n446000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n440000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n446010>, <http://purl.org/lobid/rpb#n446030>, <http://purl.org/lobid/rpb#n446050>, <http://purl.org/lobid/rpb#n446060>, <http://purl.org/lobid/rpb#n446070>, <http://purl.org/lobid/rpb#n446080> ;
+    skos:notation "rpb446000" ;
+    skos:prefLabel "Gerichtsbarkeit"@de .
+
+<http://purl.org/lobid/rpb#n446010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n446000> ;
+    skos:notation "rpb446010" ;
+    skos:prefLabel "Verfassungsgerichtsbarkeit"@de .
+
+<http://purl.org/lobid/rpb#n446030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n446000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n446032>, <http://purl.org/lobid/rpb#n446034> ;
+    skos:notation "rpb446030" ;
+    skos:prefLabel "Ordentliche Gerichtsbarkeit"@de .
+
+<http://purl.org/lobid/rpb#n446032>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n446030> ;
+    skos:notation "rpb446032" ;
+    skos:prefLabel "Strafgerichtsbarkeit"@de .
+
+<http://purl.org/lobid/rpb#n446034>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n446030> ;
+    skos:notation "rpb446034" ;
+    skos:prefLabel "Zivilgerichtsbarkeit"@de .
+
+<http://purl.org/lobid/rpb#n446050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n446000> ;
+    skos:notation "rpb446050" ;
+    skos:prefLabel "Verwaltungsgerichtsbarkeit"@de .
+
+<http://purl.org/lobid/rpb#n446060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n446000> ;
+    skos:notation "rpb446060" ;
+    skos:prefLabel "Finanzgerichtsbarkeit"@de .
+
+<http://purl.org/lobid/rpb#n446070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n446000> ;
+    skos:notation "rpb446070" ;
+    skos:prefLabel "Arbeitsgerichtsbarkeit"@de .
+
+<http://purl.org/lobid/rpb#n446080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n446000> ;
+    skos:notation "rpb446080" ;
+    skos:prefLabel "Sozialgerichtsbarkeit"@de .
+
+<http://purl.org/lobid/rpb#n447000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n440000> ;
+    skos:notation "rpb447000" ;
+    skos:prefLabel "Rechtsprechung"@de .
+
+<http://purl.org/lobid/rpb#n448000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n440000> ;
+    skos:notation "rpb448000" ;
+    skos:prefLabel "Rechtspflege"@de .
+
+<http://purl.org/lobid/rpb#n500000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n500100>, <http://purl.org/lobid/rpb#n502000>, <http://purl.org/lobid/rpb#n503000>, <http://purl.org/lobid/rpb#n503200>, <http://purl.org/lobid/rpb#n503400>, <http://purl.org/lobid/rpb#n503600> ;
+    skos:notation "rpb500000" ;
+    skos:prefLabel "Bevölkerung"@de .
+
+<http://purl.org/lobid/rpb#n500100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n500000> ;
+    skos:notation "rpb500100" ;
+    skos:prefLabel "Bevölkerung allgemein"@de .
+
+<http://purl.org/lobid/rpb#n502000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n500000> ;
+    skos:notation "rpb502000" ;
+    skos:prefLabel "Bevölkerung / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n503000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n500000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n503020>, <http://purl.org/lobid/rpb#n503030>, <http://purl.org/lobid/rpb#n503040>, <http://purl.org/lobid/rpb#n503050>, <http://purl.org/lobid/rpb#n503060>, <http://purl.org/lobid/rpb#n503070>, <http://purl.org/lobid/rpb#n503080>, <http://purl.org/lobid/rpb#n503090> ;
+    skos:notation "rpb503000" ;
+    skos:prefLabel "Bevölkerungsstruktur"@de .
+
+<http://purl.org/lobid/rpb#n503020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503000> ;
+    skos:notation "rpb503020" ;
+    skos:prefLabel "Altersstruktur"@de .
+
+<http://purl.org/lobid/rpb#n503030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503000> ;
+    skos:notation "rpb503030" ;
+    skos:prefLabel "Geschlechtsverhältnis"@de .
+
+<http://purl.org/lobid/rpb#n503040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503000> ;
+    skos:notation "rpb503040" ;
+    skos:prefLabel "Volkszählung"@de .
+
+<http://purl.org/lobid/rpb#n503050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503000> ;
+    skos:notation "rpb503050" ;
+    skos:prefLabel "Einwohnerverzeichnis"@de .
+
+<http://purl.org/lobid/rpb#n503060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503000> ;
+    skos:notation "rpb503060" ;
+    skos:prefLabel "Haushaltsgrösse"@de .
+
+<http://purl.org/lobid/rpb#n503070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503000> ;
+    skos:notation "rpb503070" ;
+    skos:prefLabel "Wohnstandard"@de .
+
+<http://purl.org/lobid/rpb#n503080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503000> ;
+    skos:notation "rpb503080" ;
+    skos:prefLabel "Einkommensstatistik"@de .
+
+<http://purl.org/lobid/rpb#n503090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503000> ;
+    skos:notation "rpb503090" ;
+    skos:prefLabel "Denomination / Religion"@de .
+
+<http://purl.org/lobid/rpb#n503200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n500000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n503220>, <http://purl.org/lobid/rpb#n503230>, <http://purl.org/lobid/rpb#n503240>, <http://purl.org/lobid/rpb#n503250>, <http://purl.org/lobid/rpb#n503260> ;
+    skos:notation "rpb503200" ;
+    skos:prefLabel "Bevölkerungsentwicklung"@de .
+
+<http://purl.org/lobid/rpb#n503220>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503200> ;
+    skos:notation "rpb503220" ;
+    skos:prefLabel "Bevölkerungspolitik"@de .
+
+<http://purl.org/lobid/rpb#n503230>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503200> ;
+    skos:notation "rpb503230" ;
+    skos:prefLabel "Geburt / Statistik"@de .
+
+<http://purl.org/lobid/rpb#n503240>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503200> ;
+    skos:notation "rpb503240" ;
+    skos:prefLabel "Heirat / Statistik"@de .
+
+<http://purl.org/lobid/rpb#n503250>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503200> ;
+    skos:notation "rpb503250" ;
+    skos:prefLabel "Tod / Statistik"@de .
+
+<http://purl.org/lobid/rpb#n503260>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503200> ;
+    skos:notation "rpb503260" ;
+    skos:prefLabel "Bevölkerungsentwicklung / Prognose"@de .
+
+<http://purl.org/lobid/rpb#n503400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n500000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n503420>, <http://purl.org/lobid/rpb#n503430>, <http://purl.org/lobid/rpb#n503440> ;
+    skos:notation "rpb503400" ;
+    skos:prefLabel "Migration"@de .
+
+<http://purl.org/lobid/rpb#n503420>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503400> ;
+    skos:narrower <http://purl.org/lobid/rpb#n503424> ;
+    skos:notation "rpb503420" ;
+    skos:prefLabel "Binnenwanderung"@de .
+
+<http://purl.org/lobid/rpb#n503424>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503420> ;
+    skos:notation "rpb503424" ;
+    skos:prefLabel "Berufspendlerin. Berufspendler"@de .
+
+<http://purl.org/lobid/rpb#n503430>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503400> ;
+    skos:notation "rpb503430" ;
+    skos:prefLabel "Auswanderung"@de .
+
+<http://purl.org/lobid/rpb#n503440>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n503400> ;
+    skos:notation "rpb503440" ;
+    skos:prefLabel "Einwanderung"@de .
+
+<http://purl.org/lobid/rpb#n503600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n500000> ;
+    skos:notation "rpb503600" ;
+    skos:prefLabel "Bevölkerungsdichte"@de .
+
+<http://purl.org/lobid/rpb#n520000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n520100>, <http://purl.org/lobid/rpb#n521000>, <http://purl.org/lobid/rpb#n521200>, <http://purl.org/lobid/rpb#n521400>, <http://purl.org/lobid/rpb#n522000>, <http://purl.org/lobid/rpb#n523000>, <http://purl.org/lobid/rpb#n524000> ;
+    skos:notation "rpb520000" ;
+    skos:prefLabel "Sozialwesen"@de .
+
+<http://purl.org/lobid/rpb#n520100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n520000> ;
+    skos:notation "rpb520100" ;
+    skos:prefLabel "Sozialwesen allgemein"@de .
+
+<http://purl.org/lobid/rpb#n521000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n520000> ;
+    skos:notation "rpb521000" ;
+    skos:prefLabel "Sozialpolitik"@de .
+
+<http://purl.org/lobid/rpb#n521200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n520000> ;
+    skos:notation "rpb521200" ;
+    skos:prefLabel "Sozialrecht"@de .
+
+<http://purl.org/lobid/rpb#n521400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n520000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n521410>, <http://purl.org/lobid/rpb#n521420>, <http://purl.org/lobid/rpb#n521430>, <http://purl.org/lobid/rpb#n521450> ;
+    skos:notation "rpb521400" ;
+    skos:prefLabel "Sozialversicherung"@de .
+
+<http://purl.org/lobid/rpb#n521410>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n521400> ;
+    skos:notation "rpb521410" ;
+    skos:prefLabel "Krankenversicherung"@de .
+
+<http://purl.org/lobid/rpb#n521420>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n521400> ;
+    skos:notation "rpb521420" ;
+    skos:prefLabel "Unfallversicherung"@de .
+
+<http://purl.org/lobid/rpb#n521430>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n521400> ;
+    skos:notation "rpb521430" ;
+    skos:prefLabel "Rentenversicherung"@de .
+
+<http://purl.org/lobid/rpb#n521450>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n521400> ;
+    skos:notation "rpb521450" ;
+    skos:prefLabel "Arbeitslosenversicherung"@de .
+
+<http://purl.org/lobid/rpb#n522000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n520000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n522010>, <http://purl.org/lobid/rpb#n522020>, <http://purl.org/lobid/rpb#n522030>, <http://purl.org/lobid/rpb#n522050> ;
+    skos:notation "rpb522000" ;
+    skos:prefLabel "Sozialhilfe / Kostenträger"@de .
+
+<http://purl.org/lobid/rpb#n522010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n522000> ;
+    skos:notation "rpb522010" ;
+    skos:prefLabel "Öffentlicher Träger"@de .
+
+<http://purl.org/lobid/rpb#n522020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n522000> ;
+    skos:notation "rpb522020" ;
+    skos:prefLabel "Kirchlicher Träger"@de .
+
+<http://purl.org/lobid/rpb#n522030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n522000> ;
+    skos:notation "rpb522030" ;
+    skos:prefLabel "Privater Träger"@de .
+
+<http://purl.org/lobid/rpb#n522050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n522000> ;
+    skos:notation "rpb522050" ;
+    skos:prefLabel "Karitative Stiftung"@de .
+
+<http://purl.org/lobid/rpb#n523000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n520000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n523010>, <http://purl.org/lobid/rpb#n523030>, <http://purl.org/lobid/rpb#n523040>, <http://purl.org/lobid/rpb#n523050>, <http://purl.org/lobid/rpb#n523060>, <http://purl.org/lobid/rpb#n523070>, <http://purl.org/lobid/rpb#n523075>, <http://purl.org/lobid/rpb#n523080>, <http://purl.org/lobid/rpb#n523090> ;
+    skos:notation "rpb523000" ;
+    skos:prefLabel "Sozialhilfe"@de .
+
+<http://purl.org/lobid/rpb#n523010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523000> ;
+    skos:notation "rpb523010" ;
+    skos:prefLabel "Arbeitslosenunterstützung"@de .
+
+<http://purl.org/lobid/rpb#n523030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n523035> ;
+    skos:notation "rpb523030" ;
+    skos:prefLabel "Fürsorge"@de .
+
+<http://purl.org/lobid/rpb#n523035>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523030> ;
+    skos:notation "rpb523035" ;
+    skos:prefLabel "Obdachlosenhilfe"@de .
+
+<http://purl.org/lobid/rpb#n523040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523000> ;
+    skos:notation "rpb523040" ;
+    skos:prefLabel "Unfallfürsorge"@de .
+
+<http://purl.org/lobid/rpb#n523050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523000> ;
+    skos:notation "rpb523050" ;
+    skos:prefLabel "Krankenfürsorge"@de .
+
+<http://purl.org/lobid/rpb#n523060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523000> ;
+    skos:notation "rpb523060" ;
+    skos:prefLabel "Behindertenhilfe"@de .
+
+<http://purl.org/lobid/rpb#n523070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523000> ;
+    skos:notation "rpb523070" ;
+    skos:prefLabel "Kriegsopferfürsorge"@de .
+
+<http://purl.org/lobid/rpb#n523075>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523000> ;
+    skos:notation "rpb523075" ;
+    skos:prefLabel "Gefangenenfürsorge"@de .
+
+<http://purl.org/lobid/rpb#n523080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523000> ;
+    skos:notation "rpb523080" ;
+    skos:prefLabel "Waisenfürsorge"@de .
+
+<http://purl.org/lobid/rpb#n523090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n523000> ;
+    skos:notation "rpb523090" ;
+    skos:prefLabel "Altenhilfe"@de .
+
+<http://purl.org/lobid/rpb#n524000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n520000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n524010>, <http://purl.org/lobid/rpb#n524050>, <http://purl.org/lobid/rpb#n524060>, <http://purl.org/lobid/rpb#n524070>, <http://purl.org/lobid/rpb#n524080> ;
+    skos:notation "rpb524000" ;
+    skos:prefLabel "Sozialpädagogik"@de .
+
+<http://purl.org/lobid/rpb#n524010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n524000> ;
+    skos:notation "rpb524010" ;
+    skos:prefLabel "Jugendhilfe"@de .
+
+<http://purl.org/lobid/rpb#n524050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n524000> ;
+    skos:notation "rpb524050" ;
+    skos:prefLabel "Bewährungshilfe"@de .
+
+<http://purl.org/lobid/rpb#n524060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n524000> ;
+    skos:notation "rpb524060" ;
+    skos:prefLabel "Erziehungsberatung"@de .
+
+<http://purl.org/lobid/rpb#n524070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n524000> ;
+    skos:notation "rpb524070" ;
+    skos:prefLabel "Familienfürsorge"@de .
+
+<http://purl.org/lobid/rpb#n524080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n524000> ;
+    skos:notation "rpb524080" ;
+    skos:prefLabel "Berufsbetreuung"@de .
+
+<http://purl.org/lobid/rpb#n530000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n530100>, <http://purl.org/lobid/rpb#n532000>, <http://purl.org/lobid/rpb#n533000>, <http://purl.org/lobid/rpb#n534000>, <http://purl.org/lobid/rpb#n535000>, <http://purl.org/lobid/rpb#n537000> ;
+    skos:notation "rpb530000" ;
+    skos:prefLabel "Gesundheitswesen"@de .
+
+<http://purl.org/lobid/rpb#n530100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n530000> ;
+    skos:notation "rpb530100" ;
+    skos:prefLabel "Gesundheitswesen allgemein"@de .
+
+<http://purl.org/lobid/rpb#n532000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n530000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n532010>, <http://purl.org/lobid/rpb#n532030>, <http://purl.org/lobid/rpb#n532050>, <http://purl.org/lobid/rpb#n532070> ;
+    skos:notation "rpb532000" ;
+    skos:prefLabel "Medizin"@de .
+
+<http://purl.org/lobid/rpb#n532010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n532000> ;
+    skos:notation "rpb532010" ;
+    skos:prefLabel "Medizin / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n532030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n532000> ;
+    skos:notation "rpb532030" ;
+    skos:prefLabel "Medizinische Versorgung"@de .
+
+<http://purl.org/lobid/rpb#n532050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n532000> ;
+    skos:notation "rpb532050" ;
+    skos:prefLabel "Ärztin. Arzt. Heilberuf"@de .
+
+<http://purl.org/lobid/rpb#n532070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n532000> ;
+    skos:notation "rpb532070" ;
+    skos:prefLabel "Gesundheitsvorsorge"@de .
+
+<http://purl.org/lobid/rpb#n533000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n530000> ;
+    skos:notation "rpb533000" ;
+    skos:prefLabel "Apotheke"@de .
+
+<http://purl.org/lobid/rpb#n534000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n530000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n534010>, <http://purl.org/lobid/rpb#n534020>, <http://purl.org/lobid/rpb#n534030>, <http://purl.org/lobid/rpb#n534050>, <http://purl.org/lobid/rpb#n534060>, <http://purl.org/lobid/rpb#n534080> ;
+    skos:notation "rpb534000" ;
+    skos:prefLabel "Krankenversorgung"@de .
+
+<http://purl.org/lobid/rpb#n534010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n534000> ;
+    skos:notation "rpb534010" ;
+    skos:prefLabel "Krankenpflege"@de .
+
+<http://purl.org/lobid/rpb#n534020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n534000> ;
+    skos:notation "rpb534020" ;
+    skos:prefLabel "Krankenpflege / Beruf"@de .
+
+<http://purl.org/lobid/rpb#n534030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n534000> ;
+    skos:notation "rpb534030" ;
+    skos:prefLabel "Krankenhaus"@de .
+
+<http://purl.org/lobid/rpb#n534050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n534000> ;
+    skos:notation "rpb534050" ;
+    skos:prefLabel "Sanatorium"@de .
+
+<http://purl.org/lobid/rpb#n534060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n534000> ;
+    skos:notation "rpb534060" ;
+    skos:prefLabel "Suchtkrankenhilfe"@de .
+
+<http://purl.org/lobid/rpb#n534080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n534000> ;
+    skos:notation "rpb534080" ;
+    skos:prefLabel "Psychiatrie"@de .
+
+<http://purl.org/lobid/rpb#n535000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n530000> ;
+    skos:notation "rpb535000" ;
+    skos:prefLabel "Hygiene"@de .
+
+<http://purl.org/lobid/rpb#n537000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n530000> ;
+    skos:notation "rpb537000" ;
+    skos:prefLabel "Veterinärwesen"@de .
+
+<http://purl.org/lobid/rpb#n540000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n540100>, <http://purl.org/lobid/rpb#n541000>, <http://purl.org/lobid/rpb#n541500>, <http://purl.org/lobid/rpb#n542000>, <http://purl.org/lobid/rpb#n543000>, <http://purl.org/lobid/rpb#n543200>, <http://purl.org/lobid/rpb#n543400>, <http://purl.org/lobid/rpb#n543600>, <http://purl.org/lobid/rpb#n543800>, <http://purl.org/lobid/rpb#n544000>, <http://purl.org/lobid/rpb#n544200>, <http://purl.org/lobid/rpb#n544300>, <http://purl.org/lobid/rpb#n544310>, <http://purl.org/lobid/rpb#n544400>, <http://purl.org/lobid/rpb#n544600>, <http://purl.org/lobid/rpb#n545000>, <http://purl.org/lobid/rpb#n546000>, <http://purl.org/lobid/rpb#n547000>, <http://purl.org/lobid/rpb#n548000>, <http://purl.org/lobid/rpb#n548200>, <http://purl.org/lobid/rpb#n548300>, <http://purl.org/lobid/rpb#n548400>, <http://purl.org/lobid/rpb#n548600>, <http://purl.org/lobid/rpb#n548800> ;
+    skos:notation "rpb540000" ;
+    skos:prefLabel "Wirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n540100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb540100" ;
+    skos:prefLabel "Wirtschaft allgemein"@de .
+
+<http://purl.org/lobid/rpb#n541000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb541000" ;
+    skos:prefLabel "Wirtschaftspolitik"@de .
+
+<http://purl.org/lobid/rpb#n541500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb541500" ;
+    skos:prefLabel "Wirtschaftsrecht"@de .
+
+<http://purl.org/lobid/rpb#n542000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb542000" ;
+    skos:prefLabel "Wirtschaft / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n543000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n543010>, <http://purl.org/lobid/rpb#n543040>, <http://purl.org/lobid/rpb#n543060>, <http://purl.org/lobid/rpb#n543080> ;
+    skos:notation "rpb543000" ;
+    skos:prefLabel "Wirtschaftsstruktur"@de .
+
+<http://purl.org/lobid/rpb#n543010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543000> ;
+    skos:notation "rpb543010" ;
+    skos:prefLabel "Wirtschaftsförderung"@de .
+
+<http://purl.org/lobid/rpb#n543040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543000> ;
+    skos:notation "rpb543040" ;
+    skos:prefLabel "Bruttoinlandsprodukt"@de .
+
+<http://purl.org/lobid/rpb#n543060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543000> ;
+    skos:notation "rpb543060" ;
+    skos:prefLabel "Außenwirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n543080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543000> ;
+    skos:notation "rpb543080" ;
+    skos:prefLabel "Wirtschaftsstatistik"@de .
+
+<http://purl.org/lobid/rpb#n543200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb543200" ;
+    skos:prefLabel "Wirtschaftsverfassung"@de .
+
+<http://purl.org/lobid/rpb#n543400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n543430>, <http://purl.org/lobid/rpb#n543440>, <http://purl.org/lobid/rpb#n543460>, <http://purl.org/lobid/rpb#n543480> ;
+    skos:notation "rpb543400" ;
+    skos:prefLabel "Wirtschaftsverband"@de .
+
+<http://purl.org/lobid/rpb#n543430>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543400> ;
+    skos:notation "rpb543430" ;
+    skos:prefLabel "Industrie- und Handelskammer"@de .
+
+<http://purl.org/lobid/rpb#n543440>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543400> ;
+    skos:notation "rpb543440" ;
+    skos:prefLabel "Verbraucherverband"@de .
+
+<http://purl.org/lobid/rpb#n543460>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543400> ;
+    skos:notation "rpb543460" ;
+    skos:prefLabel "Arbeitgeberverband"@de .
+
+<http://purl.org/lobid/rpb#n543480>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543400> ;
+    skos:notation "rpb543480" ;
+    skos:prefLabel "Gewerkschaft"@de .
+
+<http://purl.org/lobid/rpb#n543600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n543620>, <http://purl.org/lobid/rpb#n543630>, <http://purl.org/lobid/rpb#n543640>, <http://purl.org/lobid/rpb#n543660>, <http://purl.org/lobid/rpb#n543680> ;
+    skos:notation "rpb543600" ;
+    skos:prefLabel "Arbeitsmarkt"@de .
+
+<http://purl.org/lobid/rpb#n543620>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543600> ;
+    skos:notation "rpb543620" ;
+    skos:prefLabel "Unternehmerin. Unternehmer"@de .
+
+<http://purl.org/lobid/rpb#n543630>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543600> ;
+    skos:notation "rpb543630" ;
+    skos:prefLabel "Arbeitnehmerin. Arbeitnehmer"@de .
+
+<http://purl.org/lobid/rpb#n543640>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543600> ;
+    skos:notation "rpb543640" ;
+    skos:prefLabel "Freier Beruf"@de .
+
+<http://purl.org/lobid/rpb#n543660>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543600> ;
+    skos:notation "rpb543660" ;
+    skos:prefLabel "Lohn"@de .
+
+<http://purl.org/lobid/rpb#n543680>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n543600> ;
+    skos:notation "rpb543680" ;
+    skos:prefLabel "Arbeitslosigkeit"@de .
+
+<http://purl.org/lobid/rpb#n543800>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb543800" ;
+    skos:prefLabel "Marketing"@de .
+
+<http://purl.org/lobid/rpb#n544000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544010>, <http://purl.org/lobid/rpb#n544020>, <http://purl.org/lobid/rpb#n544030>, <http://purl.org/lobid/rpb#n544040>, <http://purl.org/lobid/rpb#n544050>, <http://purl.org/lobid/rpb#n544060>, <http://purl.org/lobid/rpb#n544090> ;
+    skos:notation "rpb544000" ;
+    skos:prefLabel "Landwirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n544010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544000> ;
+    skos:notation "rpb544010" ;
+    skos:prefLabel "Agrarpolitik"@de .
+
+<http://purl.org/lobid/rpb#n544020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544000> ;
+    skos:notation "rpb544020" ;
+    skos:prefLabel "Landwirtschaft / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n544030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544000> ;
+    skos:notation "rpb544030" ;
+    skos:prefLabel "Bauernhof / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n544040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544000> ;
+    skos:notation "rpb544040" ;
+    skos:prefLabel "Flurform"@de .
+
+<http://purl.org/lobid/rpb#n544050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544052>, <http://purl.org/lobid/rpb#n544054>, <http://purl.org/lobid/rpb#n544056> ;
+    skos:notation "rpb544050" ;
+    skos:prefLabel "Landwirtschaft / Beruf"@de .
+
+<http://purl.org/lobid/rpb#n544052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544050> ;
+    skos:notation "rpb544052" ;
+    skos:prefLabel "Bäuerin. Bauer"@de .
+
+<http://purl.org/lobid/rpb#n544054>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544050> ;
+    skos:notation "rpb544054" ;
+    skos:prefLabel "Landfrau"@de .
+
+<http://purl.org/lobid/rpb#n544056>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544050> ;
+    skos:notation "rpb544056" ;
+    skos:prefLabel "Landarbeiterin. Landarbeiter"@de .
+
+<http://purl.org/lobid/rpb#n544060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544000> ;
+    skos:notation "rpb544060" ;
+    skos:prefLabel "Landwirtschaftliche Betriebslehre"@de .
+
+<http://purl.org/lobid/rpb#n544090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544000> ;
+    skos:notation "rpb544090" ;
+    skos:prefLabel "Landwirtschaftsgenossenschaft"@de .
+
+<http://purl.org/lobid/rpb#n544200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544220>, <http://purl.org/lobid/rpb#n544230>, <http://purl.org/lobid/rpb#n544240>, <http://purl.org/lobid/rpb#n544250>, <http://purl.org/lobid/rpb#n544280> ;
+    skos:notation "rpb544200" ;
+    skos:prefLabel "Agrarproduktion"@de .
+
+<http://purl.org/lobid/rpb#n544220>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544200> ;
+    skos:notation "rpb544220" ;
+    skos:prefLabel "Ackerbau"@de .
+
+<http://purl.org/lobid/rpb#n544230>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544200> ;
+    skos:notation "rpb544230" ;
+    skos:prefLabel "Grünlandwirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n544240>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544200> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544245> ;
+    skos:notation "rpb544240" ;
+    skos:prefLabel "Gartenbau"@de .
+
+<http://purl.org/lobid/rpb#n544245>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544240> ;
+    skos:notation "rpb544245" ;
+    skos:prefLabel "Baumschule"@de .
+
+<http://purl.org/lobid/rpb#n544250>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544200> ;
+    skos:notation "rpb544250" ;
+    skos:prefLabel "Obstbau"@de .
+
+<http://purl.org/lobid/rpb#n544280>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544200> ;
+    skos:notation "rpb544280" ;
+    skos:prefLabel "Tierzucht"@de .
+
+<http://purl.org/lobid/rpb#n544300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb544300" ;
+    skos:prefLabel "Weinbau"@de .
+
+<http://purl.org/lobid/rpb#n544310>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544320>, <http://purl.org/lobid/rpb#n544340>, <http://purl.org/lobid/rpb#n544360> ;
+    skos:notation "rpb544310" ;
+    skos:prefLabel "Weinbau / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n544320>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544310> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544322>, <http://purl.org/lobid/rpb#n544325> ;
+    skos:notation "rpb544320" ;
+    skos:prefLabel "Weinbaugebiet"@de .
+
+<http://purl.org/lobid/rpb#n544322>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544320> ;
+    skos:notation "rpb544322" ;
+    skos:prefLabel "Großlage"@de .
+
+<http://purl.org/lobid/rpb#n544325>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544320> ;
+    skos:notation "rpb544325" ;
+    skos:prefLabel "Weingut"@de .
+
+<http://purl.org/lobid/rpb#n544340>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544310> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544341>, <http://purl.org/lobid/rpb#n544344> ;
+    skos:notation "rpb544340" ;
+    skos:prefLabel "Weinherstellung"@de .
+
+<http://purl.org/lobid/rpb#n544341>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544340> ;
+    skos:notation "rpb544341" ;
+    skos:prefLabel "Schaumweinherstellung"@de .
+
+<http://purl.org/lobid/rpb#n544344>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544340> ;
+    skos:notation "rpb544344" ;
+    skos:prefLabel "Branntweinherstellung"@de .
+
+<http://purl.org/lobid/rpb#n544360>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544310> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544361> ;
+    skos:notation "rpb544360" ;
+    skos:prefLabel "Weinhandel"@de .
+
+<http://purl.org/lobid/rpb#n544361>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544360> ;
+    skos:notation "rpb544361" ;
+    skos:prefLabel "Schaumwein / Handel"@de .
+
+<http://purl.org/lobid/rpb#n544400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544410>, <http://purl.org/lobid/rpb#n544420>, <http://purl.org/lobid/rpb#n544440>, <http://purl.org/lobid/rpb#n544450>, <http://purl.org/lobid/rpb#n544460>, <http://purl.org/lobid/rpb#n544490> ;
+    skos:notation "rpb544400" ;
+    skos:prefLabel "Forstwirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n544410>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544400> ;
+    skos:notation "rpb544410" ;
+    skos:prefLabel "Forstrecht"@de .
+
+<http://purl.org/lobid/rpb#n544420>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544400> ;
+    skos:notation "rpb544420" ;
+    skos:prefLabel "Forstwirtschaft / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n544440>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544400> ;
+    skos:notation "rpb544440" ;
+    skos:prefLabel "Forstproduktion"@de .
+
+<http://purl.org/lobid/rpb#n544450>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544400> ;
+    skos:notation "rpb544450" ;
+    skos:prefLabel "Baumart"@de .
+
+<http://purl.org/lobid/rpb#n544460>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544400> ;
+    skos:notation "rpb544460" ;
+    skos:prefLabel "Forst"@de .
+
+<http://purl.org/lobid/rpb#n544490>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544400> ;
+    skos:notation "rpb544490" ;
+    skos:prefLabel "Försterin. Förster"@de .
+
+<http://purl.org/lobid/rpb#n544600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n544610>, <http://purl.org/lobid/rpb#n544620>, <http://purl.org/lobid/rpb#n544640>, <http://purl.org/lobid/rpb#n544650>, <http://purl.org/lobid/rpb#n544660>, <http://purl.org/lobid/rpb#n544670> ;
+    skos:notation "rpb544600" ;
+    skos:prefLabel "Jagd. Fischfang"@de .
+
+<http://purl.org/lobid/rpb#n544610>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544600> ;
+    skos:notation "rpb544610" ;
+    skos:prefLabel "Jagd"@de .
+
+<http://purl.org/lobid/rpb#n544620>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544600> ;
+    skos:notation "rpb544620" ;
+    skos:prefLabel "Jagdrecht"@de .
+
+<http://purl.org/lobid/rpb#n544640>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544600> ;
+    skos:notation "rpb544640" ;
+    skos:prefLabel "Wild"@de .
+
+<http://purl.org/lobid/rpb#n544650>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544600> ;
+    skos:notation "rpb544650" ;
+    skos:prefLabel "Fischfang"@de .
+
+<http://purl.org/lobid/rpb#n544660>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544600> ;
+    skos:notation "rpb544660" ;
+    skos:prefLabel "Fischereirecht"@de .
+
+<http://purl.org/lobid/rpb#n544670>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n544600> ;
+    skos:notation "rpb544670" ;
+    skos:prefLabel "Fischzucht"@de .
+
+<http://purl.org/lobid/rpb#n545000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n545010>, <http://purl.org/lobid/rpb#n545020>, <http://purl.org/lobid/rpb#n545030>, <http://purl.org/lobid/rpb#n545040>, <http://purl.org/lobid/rpb#n545050>, <http://purl.org/lobid/rpb#n545060>, <http://purl.org/lobid/rpb#n545070>, <http://purl.org/lobid/rpb#n545080> ;
+    skos:notation "rpb545000" ;
+    skos:prefLabel "Bergbau"@de .
+
+<http://purl.org/lobid/rpb#n545010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n545000> ;
+    skos:notation "rpb545010" ;
+    skos:prefLabel "Bergrecht"@de .
+
+<http://purl.org/lobid/rpb#n545020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n545000> ;
+    skos:notation "rpb545020" ;
+    skos:prefLabel "Bergbau / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n545030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n545000> ;
+    skos:notation "rpb545030" ;
+    skos:prefLabel "Kohlenbergbau"@de .
+
+<http://purl.org/lobid/rpb#n545040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n545000> ;
+    skos:notation "rpb545040" ;
+    skos:prefLabel "Gesteinsabbau"@de .
+
+<http://purl.org/lobid/rpb#n545050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n545000> ;
+    skos:notation "rpb545050" ;
+    skos:prefLabel "Erzbergbau"@de .
+
+<http://purl.org/lobid/rpb#n545060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n545000> ;
+    skos:notation "rpb545060" ;
+    skos:prefLabel "Salzbergbau. Kalibergbau"@de .
+
+<http://purl.org/lobid/rpb#n545070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n545000> ;
+    skos:notation "rpb545070" ;
+    skos:prefLabel "Erdöl"@de .
+
+<http://purl.org/lobid/rpb#n545080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n545000> ;
+    skos:notation "rpb545080" ;
+    skos:prefLabel "Erdgas"@de .
+
+<http://purl.org/lobid/rpb#n546000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n546020>, <http://purl.org/lobid/rpb#n546040>, <http://purl.org/lobid/rpb#n546060> ;
+    skos:notation "rpb546000" ;
+    skos:prefLabel "Energiewirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n546020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n546000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n546022>, <http://purl.org/lobid/rpb#n546024>, <http://purl.org/lobid/rpb#n546026>, <http://purl.org/lobid/rpb#n546028> ;
+    skos:notation "rpb546020" ;
+    skos:prefLabel "Elektrizitätsversorgung"@de .
+
+<http://purl.org/lobid/rpb#n546022>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n546020> ;
+    skos:notation "rpb546022" ;
+    skos:prefLabel "Wasserkraftwerk"@de .
+
+<http://purl.org/lobid/rpb#n546024>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n546020> ;
+    skos:notation "rpb546024" ;
+    skos:prefLabel "Wärmekraftwerk"@de .
+
+<http://purl.org/lobid/rpb#n546026>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n546020> ;
+    skos:notation "rpb546026" ;
+    skos:prefLabel "Kernkraftwerk"@de .
+
+<http://purl.org/lobid/rpb#n546028>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n546020> ;
+    skos:notation "rpb546028" ;
+    skos:prefLabel "Alternative Energiequelle"@de .
+
+<http://purl.org/lobid/rpb#n546040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n546000> ;
+    skos:notation "rpb546040" ;
+    skos:prefLabel "Gasversorgung"@de .
+
+<http://purl.org/lobid/rpb#n546060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n546000> ;
+    skos:notation "rpb546060" ;
+    skos:prefLabel "Verbundwirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n547000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n547020>, <http://purl.org/lobid/rpb#n547030>, <http://purl.org/lobid/rpb#n547040>, <http://purl.org/lobid/rpb#n547400>, <http://purl.org/lobid/rpb#n547600> ;
+    skos:notation "rpb547000" ;
+    skos:prefLabel "Handwerk"@de .
+
+<http://purl.org/lobid/rpb#n547020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547000> ;
+    skos:notation "rpb547020" ;
+    skos:prefLabel "Handwerk / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n547030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n547035> ;
+    skos:notation "rpb547030" ;
+    skos:prefLabel "Handwerk / Beruf"@de .
+
+<http://purl.org/lobid/rpb#n547035>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547030> ;
+    skos:notation "rpb547035" ;
+    skos:prefLabel "Handwerksbetrieb"@de .
+
+<http://purl.org/lobid/rpb#n547040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n547042>, <http://purl.org/lobid/rpb#n547044> ;
+    skos:notation "rpb547040" ;
+    skos:prefLabel "Handwerksorganisation"@de .
+
+<http://purl.org/lobid/rpb#n547042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547040> ;
+    skos:notation "rpb547042" ;
+    skos:prefLabel "Handwerkskammer"@de .
+
+<http://purl.org/lobid/rpb#n547044>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547040> ;
+    skos:notation "rpb547044" ;
+    skos:prefLabel "Innung"@de .
+
+<http://purl.org/lobid/rpb#n547400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n547420>, <http://purl.org/lobid/rpb#n547440>, <http://purl.org/lobid/rpb#n547460> ;
+    skos:notation "rpb547400" ;
+    skos:prefLabel "Industrie"@de .
+
+<http://purl.org/lobid/rpb#n547420>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547400> ;
+    skos:notation "rpb547420" ;
+    skos:prefLabel "Industrie / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n547440>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547400> ;
+    skos:notation "rpb547440" ;
+    skos:prefLabel "Industriezweig"@de .
+
+<http://purl.org/lobid/rpb#n547460>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547400> ;
+    skos:notation "rpb547460" ;
+    skos:prefLabel "Industriebetrieb"@de .
+
+<http://purl.org/lobid/rpb#n547600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n547000> ;
+    skos:notation "rpb547600" ;
+    skos:prefLabel "Technik. Technologie"@de .
+
+<http://purl.org/lobid/rpb#n548000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n548010>, <http://purl.org/lobid/rpb#n548020>, <http://purl.org/lobid/rpb#n548030>, <http://purl.org/lobid/rpb#n548040>, <http://purl.org/lobid/rpb#n548050>, <http://purl.org/lobid/rpb#n548060>, <http://purl.org/lobid/rpb#n548090> ;
+    skos:notation "rpb548000" ;
+    skos:prefLabel "Handel"@de .
+
+<http://purl.org/lobid/rpb#n548010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548000> ;
+    skos:notation "rpb548010" ;
+    skos:prefLabel "Handelsrecht"@de .
+
+<http://purl.org/lobid/rpb#n548020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548000> ;
+    skos:notation "rpb548020" ;
+    skos:prefLabel "Handel / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n548030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548000> ;
+    skos:notation "rpb548030" ;
+    skos:prefLabel "Handelsform"@de .
+
+<http://purl.org/lobid/rpb#n548040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n548045> ;
+    skos:notation "rpb548040" ;
+    skos:prefLabel "Messe / Wirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n548045>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548040> ;
+    skos:notation "rpb548045" ;
+    skos:prefLabel "Markt"@de .
+
+<http://purl.org/lobid/rpb#n548050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548000> ;
+    skos:notation "rpb548050" ;
+    skos:prefLabel "Firma"@de .
+
+<http://purl.org/lobid/rpb#n548060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548000> ;
+    skos:notation "rpb548060" ;
+    skos:prefLabel "Handelsgut"@de .
+
+<http://purl.org/lobid/rpb#n548090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548000> ;
+    skos:notation "rpb548090" ;
+    skos:prefLabel "Handelsgenossenschaft"@de .
+
+<http://purl.org/lobid/rpb#n548200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n548250> ;
+    skos:notation "rpb548200" ;
+    skos:prefLabel "Dienstleistungssektor"@de .
+
+<http://purl.org/lobid/rpb#n548250>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548200> ;
+    skos:notation "rpb548250" ;
+    skos:prefLabel "Dienstleistungsbetrieb"@de .
+
+<http://purl.org/lobid/rpb#n548300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb548300" ;
+    skos:prefLabel "Öffentliches Unternehmen"@de .
+
+<http://purl.org/lobid/rpb#n548400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb548400" ;
+    skos:prefLabel "Bank"@de .
+
+<http://purl.org/lobid/rpb#n548600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:notation "rpb548600" ;
+    skos:prefLabel "Versicherung"@de .
+
+<http://purl.org/lobid/rpb#n548800>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n540000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n548820>, <http://purl.org/lobid/rpb#n548830>, <http://purl.org/lobid/rpb#n548840>, <http://purl.org/lobid/rpb#n548870> ;
+    skos:notation "rpb548800" ;
+    skos:prefLabel "Tourismus"@de .
+
+<http://purl.org/lobid/rpb#n548820>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548800> ;
+    skos:notation "rpb548820" ;
+    skos:prefLabel "Kurort"@de .
+
+<http://purl.org/lobid/rpb#n548830>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548800> ;
+    skos:notation "rpb548830" ;
+    skos:prefLabel "Naherholung"@de .
+
+<http://purl.org/lobid/rpb#n548840>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548800> ;
+    skos:notation "rpb548840" ;
+    skos:prefLabel "Gastgewerbe"@de .
+
+<http://purl.org/lobid/rpb#n548870>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n548800> ;
+    skos:notation "rpb548870" ;
+    skos:prefLabel "Jugendherberge"@de .
+
+<http://purl.org/lobid/rpb#n550000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n550100>, <http://purl.org/lobid/rpb#n551000>, <http://purl.org/lobid/rpb#n552000>, <http://purl.org/lobid/rpb#n553000>, <http://purl.org/lobid/rpb#n554000>, <http://purl.org/lobid/rpb#n555000>, <http://purl.org/lobid/rpb#n556000>, <http://purl.org/lobid/rpb#n557000>, <http://purl.org/lobid/rpb#n558000> ;
+    skos:notation "rpb550000" ;
+    skos:prefLabel "Verkehr"@de .
+
+<http://purl.org/lobid/rpb#n550100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n550000> ;
+    skos:notation "rpb550100" ;
+    skos:prefLabel "Verkehr allgemein"@de .
+
+<http://purl.org/lobid/rpb#n551000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n550000> ;
+    skos:notation "rpb551000" ;
+    skos:prefLabel "Verkehrsrecht"@de .
+
+<http://purl.org/lobid/rpb#n552000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n550000> ;
+    skos:notation "rpb552000" ;
+    skos:prefLabel "Verkehr / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n553000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n550000> ;
+    skos:notation "rpb553000" ;
+    skos:prefLabel "Straßenverkehr"@de .
+
+<http://purl.org/lobid/rpb#n554000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n550000> ;
+    skos:notation "rpb554000" ;
+    skos:prefLabel "Öffentlicher Personennahverkehr"@de .
+
+<http://purl.org/lobid/rpb#n555000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n550000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n555020> ;
+    skos:notation "rpb555000" ;
+    skos:prefLabel "Eisenbahn"@de .
+
+<http://purl.org/lobid/rpb#n555020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n555000> ;
+    skos:notation "rpb555020" ;
+    skos:prefLabel "Eisenbahn / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n556000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n550000> ;
+    skos:notation "rpb556000" ;
+    skos:prefLabel "Luftverkehr"@de .
+
+<http://purl.org/lobid/rpb#n557000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n550000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n557020>, <http://purl.org/lobid/rpb#n557040>, <http://purl.org/lobid/rpb#n557060> ;
+    skos:notation "rpb557000" ;
+    skos:prefLabel "Schifffahrt"@de .
+
+<http://purl.org/lobid/rpb#n557020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n557000> ;
+    skos:notation "rpb557020" ;
+    skos:prefLabel "Schifffahrt / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n557040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n557000> ;
+    skos:notation "rpb557040" ;
+    skos:prefLabel "Kanal"@de .
+
+<http://purl.org/lobid/rpb#n557060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n557000> ;
+    skos:notation "rpb557060" ;
+    skos:prefLabel "Hafen"@de .
+
+<http://purl.org/lobid/rpb#n558000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n550000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n558020>, <http://purl.org/lobid/rpb#n558040>, <http://purl.org/lobid/rpb#n558050> ;
+    skos:notation "rpb558000" ;
+    skos:prefLabel "Post. Fernmeldewesen"@de .
+
+<http://purl.org/lobid/rpb#n558020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n558000> ;
+    skos:notation "rpb558020" ;
+    skos:prefLabel "Post / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n558040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n558000> ;
+    skos:notation "rpb558040" ;
+    skos:prefLabel "Briefmarke"@de .
+
+<http://purl.org/lobid/rpb#n558050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n558000> ;
+    skos:notation "rpb558050" ;
+    skos:prefLabel "Fernmeldewesen"@de .
+
+<http://purl.org/lobid/rpb#n560000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n560100>, <http://purl.org/lobid/rpb#n562000>, <http://purl.org/lobid/rpb#n562300>, <http://purl.org/lobid/rpb#n562600>, <http://purl.org/lobid/rpb#n563000>, <http://purl.org/lobid/rpb#n564000>, <http://purl.org/lobid/rpb#n566000> ;
+    skos:notation "rpb560000" ;
+    skos:prefLabel "Siedlung"@de .
+
+<http://purl.org/lobid/rpb#n560100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n560000> ;
+    skos:notation "rpb560100" ;
+    skos:prefLabel "Siedlung allgemein"@de .
+
+<http://purl.org/lobid/rpb#n562000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n560000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n562040>, <http://purl.org/lobid/rpb#n562060> ;
+    skos:notation "rpb562000" ;
+    skos:prefLabel "Siedlung / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n562040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n562000> ;
+    skos:notation "rpb562040" ;
+    skos:prefLabel "Wüstung"@de .
+
+<http://purl.org/lobid/rpb#n562060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n562000> ;
+    skos:notation "rpb562060" ;
+    skos:prefLabel "Allmende"@de .
+
+<http://purl.org/lobid/rpb#n562300>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n560000> ;
+    skos:notation "rpb562300" ;
+    skos:prefLabel "Kulturlandschaft"@de .
+
+<http://purl.org/lobid/rpb#n562600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n560000> ;
+    skos:notation "rpb562600" ;
+    skos:prefLabel "Siedlungsraum"@de .
+
+<http://purl.org/lobid/rpb#n563000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n560000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n563020>, <http://purl.org/lobid/rpb#n563030>, <http://purl.org/lobid/rpb#n563040>, <http://purl.org/lobid/rpb#n563050> ;
+    skos:notation "rpb563000" ;
+    skos:prefLabel "Siedlungsform"@de .
+
+<http://purl.org/lobid/rpb#n563020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n563000> ;
+    skos:notation "rpb563020" ;
+    skos:prefLabel "Industriestadt"@de .
+
+<http://purl.org/lobid/rpb#n563030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n563000> ;
+    skos:notation "rpb563030" ;
+    skos:prefLabel "Marktzentrum"@de .
+
+<http://purl.org/lobid/rpb#n563040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n563000> ;
+    skos:notation "rpb563040" ;
+    skos:prefLabel "Wohnsiedlung"@de .
+
+<http://purl.org/lobid/rpb#n563050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n563000> ;
+    skos:notation "rpb563050" ;
+    skos:prefLabel "Gewerbegebiet"@de .
+
+<http://purl.org/lobid/rpb#n564000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n560000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n564040>, <http://purl.org/lobid/rpb#n564050>, <http://purl.org/lobid/rpb#n564080> ;
+    skos:notation "rpb564000" ;
+    skos:prefLabel "Ländliche Siedlung"@de .
+
+<http://purl.org/lobid/rpb#n564040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n564000> ;
+    skos:notation "rpb564040" ;
+    skos:prefLabel "Ländliche Siedlungsform"@de .
+
+<http://purl.org/lobid/rpb#n564050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n564000> ;
+    skos:notation "rpb564050" ;
+    skos:prefLabel "Dorf / Topographie"@de .
+
+<http://purl.org/lobid/rpb#n564080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n564000> ;
+    skos:notation "rpb564080" ;
+    skos:prefLabel "Dorferneuerung"@de .
+
+<http://purl.org/lobid/rpb#n566000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n560000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n566010>, <http://purl.org/lobid/rpb#n566020>, <http://purl.org/lobid/rpb#n566040>, <http://purl.org/lobid/rpb#n566050>, <http://purl.org/lobid/rpb#n566060>, <http://purl.org/lobid/rpb#n566070>, <http://purl.org/lobid/rpb#n566080> ;
+    skos:notation "rpb566000" ;
+    skos:prefLabel "Stadt"@de .
+
+<http://purl.org/lobid/rpb#n566010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566000> ;
+    skos:notation "rpb566010" ;
+    skos:prefLabel "Stadttyp"@de .
+
+<http://purl.org/lobid/rpb#n566020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566000> ;
+    skos:notation "rpb566020" ;
+    skos:prefLabel "Städtische Siedlungsform"@de .
+
+<http://purl.org/lobid/rpb#n566040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n566041>, <http://purl.org/lobid/rpb#n566042>, <http://purl.org/lobid/rpb#n566043>, <http://purl.org/lobid/rpb#n566045>, <http://purl.org/lobid/rpb#n566046> ;
+    skos:notation "rpb566040" ;
+    skos:prefLabel "Stadtgliederung"@de .
+
+<http://purl.org/lobid/rpb#n566041>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566040> ;
+    skos:notation "rpb566041" ;
+    skos:prefLabel "Stadtkern"@de .
+
+<http://purl.org/lobid/rpb#n566042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566040> ;
+    skos:notation "rpb566042" ;
+    skos:prefLabel "Vorort"@de .
+
+<http://purl.org/lobid/rpb#n566043>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566040> ;
+    skos:notation "rpb566043" ;
+    skos:prefLabel "Geschäftsviertel"@de .
+
+<http://purl.org/lobid/rpb#n566045>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566040> ;
+    skos:notation "rpb566045" ;
+    skos:prefLabel "Stadtteil"@de .
+
+<http://purl.org/lobid/rpb#n566046>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566040> ;
+    skos:notation "rpb566046" ;
+    skos:prefLabel "Stadt / Erholungsgebiet"@de .
+
+<http://purl.org/lobid/rpb#n566050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n566051>, <http://purl.org/lobid/rpb#n566052>, <http://purl.org/lobid/rpb#n566053> ;
+    skos:notation "rpb566050" ;
+    skos:prefLabel "Stadt / Topographie"@de .
+
+<http://purl.org/lobid/rpb#n566051>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566050> ;
+    skos:notation "rpb566051" ;
+    skos:prefLabel "Platz"@de .
+
+<http://purl.org/lobid/rpb#n566052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566050> ;
+    skos:notation "rpb566052" ;
+    skos:prefLabel "Straße"@de .
+
+<http://purl.org/lobid/rpb#n566053>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566050> ;
+    skos:notation "rpb566053" ;
+    skos:prefLabel "Öffentliches Gebäude"@de .
+
+<http://purl.org/lobid/rpb#n566060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566000> ;
+    skos:notation "rpb566060" ;
+    skos:prefLabel "Verstädterung"@de .
+
+<http://purl.org/lobid/rpb#n566070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566000> ;
+    skos:notation "rpb566070" ;
+    skos:prefLabel "Ballungsraum"@de .
+
+<http://purl.org/lobid/rpb#n566080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n566000> ;
+    skos:notation "rpb566080" ;
+    skos:prefLabel "Stadt / Umland"@de .
+
+<http://purl.org/lobid/rpb#n570000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n570100>, <http://purl.org/lobid/rpb#n572000>, <http://purl.org/lobid/rpb#n574000> ;
+    skos:notation "rpb570000" ;
+    skos:prefLabel "Raumordnung und Städtebau"@de .
+
+<http://purl.org/lobid/rpb#n570100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n570000> ;
+    skos:notation "rpb570100" ;
+    skos:prefLabel "Raumordnung und Städtebau allgemein"@de .
+
+<http://purl.org/lobid/rpb#n572000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n570000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n572020>, <http://purl.org/lobid/rpb#n572030>, <http://purl.org/lobid/rpb#n572040>, <http://purl.org/lobid/rpb#n572050>, <http://purl.org/lobid/rpb#n572060> ;
+    skos:notation "rpb572000" ;
+    skos:prefLabel "Raumordnung"@de .
+
+<http://purl.org/lobid/rpb#n572020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n572000> ;
+    skos:notation "rpb572020" ;
+    skos:prefLabel "Landesplanung"@de .
+
+<http://purl.org/lobid/rpb#n572030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n572000> ;
+    skos:notation "rpb572030" ;
+    skos:prefLabel "Regionalplanung"@de .
+
+<http://purl.org/lobid/rpb#n572040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n572000> ;
+    skos:notation "rpb572040" ;
+    skos:prefLabel "Kreisplanung"@de .
+
+<http://purl.org/lobid/rpb#n572050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n572000> ;
+    skos:notation "rpb572050" ;
+    skos:prefLabel "Landschaftsplanung"@de .
+
+<http://purl.org/lobid/rpb#n572060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n572000> ;
+    skos:notation "rpb572060" ;
+    skos:prefLabel "Gemeindeplanung"@de .
+
+<http://purl.org/lobid/rpb#n574000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n570000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n574020>, <http://purl.org/lobid/rpb#n574030>, <http://purl.org/lobid/rpb#n574040>, <http://purl.org/lobid/rpb#n574050>, <http://purl.org/lobid/rpb#n574060> ;
+    skos:notation "rpb574000" ;
+    skos:prefLabel "Bauwesen"@de .
+
+<http://purl.org/lobid/rpb#n574020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n574000> ;
+    skos:notation "rpb574020" ;
+    skos:prefLabel "Bau- und Bodenrecht"@de .
+
+<http://purl.org/lobid/rpb#n574030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n574000> ;
+    skos:notation "rpb574030" ;
+    skos:prefLabel "Städtebau"@de .
+
+<http://purl.org/lobid/rpb#n574040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n574000> ;
+    skos:notation "rpb574040" ;
+    skos:prefLabel "Straßenbau"@de .
+
+<http://purl.org/lobid/rpb#n574050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n574000> ;
+    skos:notation "rpb574050" ;
+    skos:prefLabel "Wohnungsbau"@de .
+
+<http://purl.org/lobid/rpb#n574060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n574000> ;
+    skos:notation "rpb574060" ;
+    skos:prefLabel "Wohnungswirtschaft"@de .
+
+<http://purl.org/lobid/rpb#n580000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n580100>, <http://purl.org/lobid/rpb#n582000>, <http://purl.org/lobid/rpb#n584000>, <http://purl.org/lobid/rpb#n586000> ;
+    skos:notation "rpb580000" ;
+    skos:prefLabel "Umwelt- und Naturschutz"@de .
+
+<http://purl.org/lobid/rpb#n580100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n580000> ;
+    skos:notation "rpb580100" ;
+    skos:prefLabel "Umwelt- und Naturschutz allgemein"@de .
+
+<http://purl.org/lobid/rpb#n582000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n580000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n582010>, <http://purl.org/lobid/rpb#n582020>, <http://purl.org/lobid/rpb#n582030>, <http://purl.org/lobid/rpb#n582040>, <http://purl.org/lobid/rpb#n582050>, <http://purl.org/lobid/rpb#n582060>, <http://purl.org/lobid/rpb#n582070> ;
+    skos:notation "rpb582000" ;
+    skos:prefLabel "Umweltschutz"@de .
+
+<http://purl.org/lobid/rpb#n582010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n582000> ;
+    skos:notation "rpb582010" ;
+    skos:prefLabel "Klimaschutz"@de .
+
+<http://purl.org/lobid/rpb#n582020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n582000> ;
+    skos:notation "rpb582020" ;
+    skos:prefLabel "Bodenschutz"@de .
+
+<http://purl.org/lobid/rpb#n582030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n582000> ;
+    skos:notation "rpb582030" ;
+    skos:prefLabel "Luftverschmutzung"@de .
+
+<http://purl.org/lobid/rpb#n582040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n582000> ;
+    skos:notation "rpb582040" ;
+    skos:prefLabel "Lärmbelastung"@de .
+
+<http://purl.org/lobid/rpb#n582050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n582000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n582052>, <http://purl.org/lobid/rpb#n582054> ;
+    skos:notation "rpb582050" ;
+    skos:prefLabel "Gewässerschutz"@de .
+
+<http://purl.org/lobid/rpb#n582052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n582050> ;
+    skos:notation "rpb582052" ;
+    skos:prefLabel "Abwasser"@de .
+
+<http://purl.org/lobid/rpb#n582054>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n582050> ;
+    skos:notation "rpb582054" ;
+    skos:prefLabel "Kanalisation"@de .
+
+<http://purl.org/lobid/rpb#n582060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n582000> ;
+    skos:notation "rpb582060" ;
+    skos:prefLabel "Abfallbeseitigung"@de .
+
+<http://purl.org/lobid/rpb#n582070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n582000> ;
+    skos:notation "rpb582070" ;
+    skos:prefLabel "Strahlenbelastung"@de .
+
+<http://purl.org/lobid/rpb#n584000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n580000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n584040>, <http://purl.org/lobid/rpb#n584050>, <http://purl.org/lobid/rpb#n584060>, <http://purl.org/lobid/rpb#n584070>, <http://purl.org/lobid/rpb#n584075>, <http://purl.org/lobid/rpb#n584080>, <http://purl.org/lobid/rpb#n584090> ;
+    skos:notation "rpb584000" ;
+    skos:prefLabel "Naturschutz. Landschaftspflege"@de .
+
+<http://purl.org/lobid/rpb#n584040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n584000> ;
+    skos:notation "rpb584040" ;
+    skos:prefLabel "Naturdenkmal"@de .
+
+<http://purl.org/lobid/rpb#n584050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n584000> ;
+    skos:notation "rpb584050" ;
+    skos:prefLabel "Pflanzen / Artenschutz"@de .
+
+<http://purl.org/lobid/rpb#n584060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n584000> ;
+    skos:notation "rpb584060" ;
+    skos:prefLabel "Tierschutz"@de .
+
+<http://purl.org/lobid/rpb#n584070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n584000> ;
+    skos:notation "rpb584070" ;
+    skos:prefLabel "Naturschutzgebiet"@de .
+
+<http://purl.org/lobid/rpb#n584075>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n584000> ;
+    skos:notation "rpb584075" ;
+    skos:prefLabel "Nationalpark"@de .
+
+<http://purl.org/lobid/rpb#n584080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n584000> ;
+    skos:notation "rpb584080" ;
+    skos:prefLabel "Naturpark"@de .
+
+<http://purl.org/lobid/rpb#n584090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n584000> ;
+    skos:notation "rpb584090" ;
+    skos:prefLabel "Landschaftsentwicklung"@de .
+
+<http://purl.org/lobid/rpb#n586000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n580000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n586020>, <http://purl.org/lobid/rpb#n586030>, <http://purl.org/lobid/rpb#n586040>, <http://purl.org/lobid/rpb#n586080> ;
+    skos:notation "rpb586000" ;
+    skos:prefLabel "Grünanlage"@de .
+
+<http://purl.org/lobid/rpb#n586020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n586000> ;
+    skos:notation "rpb586020" ;
+    skos:prefLabel "Park"@de .
+
+<http://purl.org/lobid/rpb#n586030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n586000> ;
+    skos:notation "rpb586030" ;
+    skos:prefLabel "Botanischer Garten"@de .
+
+<http://purl.org/lobid/rpb#n586040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n586000> ;
+    skos:notation "rpb586040" ;
+    skos:prefLabel "Zoologischer Garten"@de .
+
+<http://purl.org/lobid/rpb#n586080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n586000> ;
+    skos:notation "rpb586080" ;
+    skos:prefLabel "Gartenbauausstellung"@de .
+
+<http://purl.org/lobid/rpb#n610000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n610100>, <http://purl.org/lobid/rpb#n611000>, <http://purl.org/lobid/rpb#n612000>, <http://purl.org/lobid/rpb#n612500>, <http://purl.org/lobid/rpb#n613000>, <http://purl.org/lobid/rpb#n615000>, <http://purl.org/lobid/rpb#n616000>, <http://purl.org/lobid/rpb#n617000> ;
+    skos:notation "rpb610000" ;
+    skos:prefLabel "Kirche"@de .
+
+<http://purl.org/lobid/rpb#n610100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n610000> ;
+    skos:notation "rpb610100" ;
+    skos:prefLabel "Kirche allgemein"@de .
+
+<http://purl.org/lobid/rpb#n611000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n610000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n611010>, <http://purl.org/lobid/rpb#n611020>, <http://purl.org/lobid/rpb#n611025>, <http://purl.org/lobid/rpb#n611030>, <http://purl.org/lobid/rpb#n611040>, <http://purl.org/lobid/rpb#n611050>, <http://purl.org/lobid/rpb#n611060>, <http://purl.org/lobid/rpb#n611070>, <http://purl.org/lobid/rpb#n611080>, <http://purl.org/lobid/rpb#n611090> ;
+    skos:notation "rpb611000" ;
+    skos:prefLabel "Katholische Kirche"@de .
+
+<http://purl.org/lobid/rpb#n611010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:notation "rpb611010" ;
+    skos:prefLabel "Kirchengeschichte"@de .
+
+<http://purl.org/lobid/rpb#n611020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:notation "rpb611020" ;
+    skos:prefLabel "Kirchenrecht"@de .
+
+<http://purl.org/lobid/rpb#n611025>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:notation "rpb611025" ;
+    skos:prefLabel "Kirchenverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n611030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:notation "rpb611030" ;
+    skos:prefLabel "Kirchengemeinde"@de .
+
+<http://purl.org/lobid/rpb#n611040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n611042>, <http://purl.org/lobid/rpb#n611043>, <http://purl.org/lobid/rpb#n611044>, <http://purl.org/lobid/rpb#n611045> ;
+    skos:notation "rpb611040" ;
+    skos:prefLabel "Kirchliches Leben"@de .
+
+<http://purl.org/lobid/rpb#n611042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611040> ;
+    skos:notation "rpb611042" ;
+    skos:prefLabel "Seelsorge"@de .
+
+<http://purl.org/lobid/rpb#n611043>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611040> ;
+    skos:notation "rpb611043" ;
+    skos:prefLabel "Laienamt"@de .
+
+<http://purl.org/lobid/rpb#n611044>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611040> ;
+    skos:notation "rpb611044" ;
+    skos:prefLabel "Kirchlicher Verein"@de .
+
+<http://purl.org/lobid/rpb#n611045>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611040> ;
+    skos:notation "rpb611045" ;
+    skos:prefLabel "Kirchliche Stiftung"@de .
+
+<http://purl.org/lobid/rpb#n611050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:notation "rpb611050" ;
+    skos:prefLabel "Geistlicher. Ordensleute"@de .
+
+<http://purl.org/lobid/rpb#n611060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:notation "rpb611060" ;
+    skos:prefLabel "Kloster. Stift"@de .
+
+<http://purl.org/lobid/rpb#n611070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:notation "rpb611070" ;
+    skos:prefLabel "Orden"@de .
+
+<http://purl.org/lobid/rpb#n611080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n611082>, <http://purl.org/lobid/rpb#n611083>, <http://purl.org/lobid/rpb#n611084>, <http://purl.org/lobid/rpb#n611085> ;
+    skos:notation "rpb611080" ;
+    skos:prefLabel "Gottesdienst"@de .
+
+<http://purl.org/lobid/rpb#n611082>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611080> ;
+    skos:notation "rpb611082" ;
+    skos:prefLabel "Sakrament"@de .
+
+<http://purl.org/lobid/rpb#n611083>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611080> ;
+    skos:notation "rpb611083" ;
+    skos:prefLabel "Kirchenfest"@de .
+
+<http://purl.org/lobid/rpb#n611084>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611080> ;
+    skos:notation "rpb611084" ;
+    skos:prefLabel "Prozession"@de .
+
+<http://purl.org/lobid/rpb#n611085>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611080> ;
+    skos:notation "rpb611085" ;
+    skos:prefLabel "Wallfahrt"@de .
+
+<http://purl.org/lobid/rpb#n611090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n611000> ;
+    skos:notation "rpb611090" ;
+    skos:prefLabel "Heiligenverehrung"@de .
+
+<http://purl.org/lobid/rpb#n612000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n610000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n612020>, <http://purl.org/lobid/rpb#n612030>, <http://purl.org/lobid/rpb#n612040>, <http://purl.org/lobid/rpb#n612050>, <http://purl.org/lobid/rpb#n612070>, <http://purl.org/lobid/rpb#n612080> ;
+    skos:notation "rpb612000" ;
+    skos:prefLabel "Reformation"@de .
+
+<http://purl.org/lobid/rpb#n612020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n612000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n612022> ;
+    skos:notation "rpb612020" ;
+    skos:prefLabel "Calvinismus"@de .
+
+<http://purl.org/lobid/rpb#n612022>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n612020> ;
+    skos:notation "rpb612022" ;
+    skos:prefLabel "Zwinglianer"@de .
+
+<http://purl.org/lobid/rpb#n612030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n612000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n612032> ;
+    skos:notation "rpb612030" ;
+    skos:prefLabel "Täufer"@de .
+
+<http://purl.org/lobid/rpb#n612032>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n612030> ;
+    skos:notation "rpb612032" ;
+    skos:prefLabel "Mennoniten"@de .
+
+<http://purl.org/lobid/rpb#n612040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n612000> ;
+    skos:notation "rpb612040" ;
+    skos:prefLabel "Schwärmer / Theologie"@de .
+
+<http://purl.org/lobid/rpb#n612050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n612000> ;
+    skos:notation "rpb612050" ;
+    skos:prefLabel "Reformator"@de .
+
+<http://purl.org/lobid/rpb#n612070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n612000> ;
+    skos:notation "rpb612070" ;
+    skos:prefLabel "Glaubensflüchtling"@de .
+
+<http://purl.org/lobid/rpb#n612080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n612000> ;
+    skos:notation "rpb612080" ;
+    skos:prefLabel "Hugenotten"@de .
+
+<http://purl.org/lobid/rpb#n612500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n610000> ;
+    skos:notation "rpb612500" ;
+    skos:prefLabel "Gegenreformation"@de .
+
+<http://purl.org/lobid/rpb#n613000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n610000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n613010>, <http://purl.org/lobid/rpb#n613020>, <http://purl.org/lobid/rpb#n613025>, <http://purl.org/lobid/rpb#n613030>, <http://purl.org/lobid/rpb#n613040>, <http://purl.org/lobid/rpb#n613050>, <http://purl.org/lobid/rpb#n613070> ;
+    skos:notation "rpb613000" ;
+    skos:prefLabel "Evangelische Kirche"@de .
+
+<http://purl.org/lobid/rpb#n613010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613000> ;
+    skos:notation "rpb613010" ;
+    skos:prefLabel "Kirchengeschichte"@de .
+
+<http://purl.org/lobid/rpb#n613020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613000> ;
+    skos:notation "rpb613020" ;
+    skos:prefLabel "Kirchenrecht"@de .
+
+<http://purl.org/lobid/rpb#n613025>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613000> ;
+    skos:notation "rpb613025" ;
+    skos:prefLabel "Kirchenverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n613030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613000> ;
+    skos:notation "rpb613030" ;
+    skos:prefLabel "Kirchengemeinde"@de .
+
+<http://purl.org/lobid/rpb#n613040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n613042>, <http://purl.org/lobid/rpb#n613043>, <http://purl.org/lobid/rpb#n613044>, <http://purl.org/lobid/rpb#n613045> ;
+    skos:notation "rpb613040" ;
+    skos:prefLabel "Kirchliches Leben"@de .
+
+<http://purl.org/lobid/rpb#n613042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613040> ;
+    skos:notation "rpb613042" ;
+    skos:prefLabel "Seelsorge"@de .
+
+<http://purl.org/lobid/rpb#n613043>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613040> ;
+    skos:notation "rpb613043" ;
+    skos:prefLabel "Diakonie"@de .
+
+<http://purl.org/lobid/rpb#n613044>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613040> ;
+    skos:notation "rpb613044" ;
+    skos:prefLabel "Kirchlicher Verein"@de .
+
+<http://purl.org/lobid/rpb#n613045>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613040> ;
+    skos:notation "rpb613045" ;
+    skos:prefLabel "Kirchliche Stiftung"@de .
+
+<http://purl.org/lobid/rpb#n613050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613000> ;
+    skos:notation "rpb613050" ;
+    skos:prefLabel "Pfarrerin. Pfarrer. Geistliche"@de .
+
+<http://purl.org/lobid/rpb#n613070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n613072>, <http://purl.org/lobid/rpb#n613073> ;
+    skos:notation "rpb613070" ;
+    skos:prefLabel "Gottesdienst"@de .
+
+<http://purl.org/lobid/rpb#n613072>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613070> ;
+    skos:notation "rpb613072" ;
+    skos:prefLabel "Sakrament"@de .
+
+<http://purl.org/lobid/rpb#n613073>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n613070> ;
+    skos:notation "rpb613073" ;
+    skos:prefLabel "Kirchenfest"@de .
+
+<http://purl.org/lobid/rpb#n615000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n610000> ;
+    skos:notation "rpb615000" ;
+    skos:prefLabel "Sonstige christliche Religionsgemeinschaften"@de .
+
+<http://purl.org/lobid/rpb#n616000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n610000> ;
+    skos:notation "rpb616000" ;
+    skos:prefLabel "Ökumene"@de .
+
+<http://purl.org/lobid/rpb#n617000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n610000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n617030>, <http://purl.org/lobid/rpb#n617050> ;
+    skos:notation "rpb617000" ;
+    skos:prefLabel "Bestattung"@de .
+
+<http://purl.org/lobid/rpb#n617030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n617000> ;
+    skos:notation "rpb617030" ;
+    skos:prefLabel "Friedhof"@de .
+
+<http://purl.org/lobid/rpb#n617050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n617000> ;
+    skos:notation "rpb617050" ;
+    skos:prefLabel "Grabmal"@de .
+
+<http://purl.org/lobid/rpb#n630000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n630100>, <http://purl.org/lobid/rpb#n631000>, <http://purl.org/lobid/rpb#n632000> ;
+    skos:notation "rpb630000" ;
+    skos:prefLabel "Juden"@de .
+
+<http://purl.org/lobid/rpb#n630100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n630000> ;
+    skos:notation "rpb630100" ;
+    skos:prefLabel "Juden allgemein"@de .
+
+<http://purl.org/lobid/rpb#n631000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n630000> ;
+    skos:notation "rpb631000" ;
+    skos:prefLabel "Judentum"@de .
+
+<http://purl.org/lobid/rpb#n632000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n630000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n632050> ;
+    skos:notation "rpb632000" ;
+    skos:prefLabel "Juden / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n632050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n632000> ;
+    skos:notation "rpb632050" ;
+    skos:prefLabel "Judenverfolgung"@de .
+
+<http://purl.org/lobid/rpb#n650000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n651000>, <http://purl.org/lobid/rpb#n655000> ;
+    skos:notation "rpb650000" ;
+    skos:prefLabel "Nichtchristliche Religion"@de .
+
+<http://purl.org/lobid/rpb#n651000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n650000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n651020>, <http://purl.org/lobid/rpb#n651030> ;
+    skos:notation "rpb651000" ;
+    skos:prefLabel "Nichtchristliche Religion allgemein"@de .
+
+<http://purl.org/lobid/rpb#n651020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n651000> ;
+    skos:notation "rpb651020" ;
+    skos:prefLabel "Islam"@de .
+
+<http://purl.org/lobid/rpb#n651030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n651000> ;
+    skos:notation "rpb651030" ;
+    skos:prefLabel "Buddhismus"@de .
+
+<http://purl.org/lobid/rpb#n655000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n650000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n655030> ;
+    skos:notation "rpb655000" ;
+    skos:prefLabel "Weltanschauungsgemeinschaft"@de .
+
+<http://purl.org/lobid/rpb#n655030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n655000> ;
+    skos:notation "rpb655030" ;
+    skos:prefLabel "Freimaurer"@de .
+
+<http://purl.org/lobid/rpb#n700000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n700100>, <http://purl.org/lobid/rpb#n702000>, <http://purl.org/lobid/rpb#n704000>, <http://purl.org/lobid/rpb#n704200>, <http://purl.org/lobid/rpb#n704400>, <http://purl.org/lobid/rpb#n704600>, <http://purl.org/lobid/rpb#n704700>, <http://purl.org/lobid/rpb#n706000>, <http://purl.org/lobid/rpb#n706200>, <http://purl.org/lobid/rpb#n708000>, <http://purl.org/lobid/rpb#n708400> ;
+    skos:notation "rpb700000" ;
+    skos:prefLabel "Volkskunde"@de .
+
+<http://purl.org/lobid/rpb#n700100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:notation "rpb700100" ;
+    skos:prefLabel "Volkskunde allgemein"@de .
+
+<http://purl.org/lobid/rpb#n702000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:notation "rpb702000" ;
+    skos:prefLabel "Alltag"@de .
+
+<http://purl.org/lobid/rpb#n704000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n704020>, <http://purl.org/lobid/rpb#n704040>, <http://purl.org/lobid/rpb#n704060>, <http://purl.org/lobid/rpb#n704080>, <http://purl.org/lobid/rpb#n704090> ;
+    skos:notation "rpb704000" ;
+    skos:prefLabel "Brauch"@de .
+
+<http://purl.org/lobid/rpb#n704020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704000> ;
+    skos:notation "rpb704020" ;
+    skos:prefLabel "Brauch / Alltag"@de .
+
+<http://purl.org/lobid/rpb#n704040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n704042>, <http://purl.org/lobid/rpb#n704043>, <http://purl.org/lobid/rpb#n704044>, <http://purl.org/lobid/rpb#n704045>, <http://purl.org/lobid/rpb#n704046>, <http://purl.org/lobid/rpb#n704047> ;
+    skos:notation "rpb704040" ;
+    skos:prefLabel "Brauch / Jahreslauf"@de .
+
+<http://purl.org/lobid/rpb#n704042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704040> ;
+    skos:notation "rpb704042" ;
+    skos:prefLabel "Winter / Brauch. Weihnachten. Neujahr"@de .
+
+<http://purl.org/lobid/rpb#n704043>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704040> ;
+    skos:notation "rpb704043" ;
+    skos:prefLabel "Karneval"@de .
+
+<http://purl.org/lobid/rpb#n704044>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704040> ;
+    skos:notation "rpb704044" ;
+    skos:prefLabel "Frühling / Brauch. Ostern"@de .
+
+<http://purl.org/lobid/rpb#n704045>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704040> ;
+    skos:notation "rpb704045" ;
+    skos:prefLabel "Mai / Brauch. Pfingsten. Sommer / Brauch"@de .
+
+<http://purl.org/lobid/rpb#n704046>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704040> ;
+    skos:notation "rpb704046" ;
+    skos:prefLabel "Erntedankfest"@de .
+
+<http://purl.org/lobid/rpb#n704047>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704040> ;
+    skos:notation "rpb704047" ;
+    skos:prefLabel "Kirchweih"@de .
+
+<http://purl.org/lobid/rpb#n704060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n704061>, <http://purl.org/lobid/rpb#n704063>, <http://purl.org/lobid/rpb#n704064> ;
+    skos:notation "rpb704060" ;
+    skos:prefLabel "Lebenslauf / Brauch"@de .
+
+<http://purl.org/lobid/rpb#n704061>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704060> ;
+    skos:notation "rpb704061" ;
+    skos:prefLabel "Geburt"@de .
+
+<http://purl.org/lobid/rpb#n704063>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704060> ;
+    skos:notation "rpb704063" ;
+    skos:prefLabel "Liebe / Brauch. Verlobung. Hochzeit"@de .
+
+<http://purl.org/lobid/rpb#n704064>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704060> ;
+    skos:notation "rpb704064" ;
+    skos:prefLabel "Tod / Brauch. Bestattung"@de .
+
+<http://purl.org/lobid/rpb#n704080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n704082> ;
+    skos:notation "rpb704080" ;
+    skos:prefLabel "Beruf / Brauch"@de .
+
+<http://purl.org/lobid/rpb#n704082>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704080> ;
+    skos:notation "rpb704082" ;
+    skos:prefLabel "Handwerk / Brauch"@de .
+
+<http://purl.org/lobid/rpb#n704090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704000> ;
+    skos:notation "rpb704090" ;
+    skos:prefLabel "Brauchtumspflege / Verein"@de .
+
+<http://purl.org/lobid/rpb#n704200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n704220>, <http://purl.org/lobid/rpb#n704230>, <http://purl.org/lobid/rpb#n704240>, <http://purl.org/lobid/rpb#n704250>, <http://purl.org/lobid/rpb#n704260>, <http://purl.org/lobid/rpb#n704270>, <http://purl.org/lobid/rpb#n704280> ;
+    skos:notation "rpb704200" ;
+    skos:prefLabel "Volkswissen"@de .
+
+<http://purl.org/lobid/rpb#n704220>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704200> ;
+    skos:notation "rpb704220" ;
+    skos:prefLabel "Volksmedizin"@de .
+
+<http://purl.org/lobid/rpb#n704230>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704200> ;
+    skos:notation "rpb704230" ;
+    skos:prefLabel "Ethnobotanik"@de .
+
+<http://purl.org/lobid/rpb#n704240>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704200> ;
+    skos:notation "rpb704240" ;
+    skos:prefLabel "Volkszoologie"@de .
+
+<http://purl.org/lobid/rpb#n704250>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704200> ;
+    skos:notation "rpb704250" ;
+    skos:prefLabel "Wetter / Bauernregel"@de .
+
+<http://purl.org/lobid/rpb#n704260>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704200> ;
+    skos:notation "rpb704260" ;
+    skos:prefLabel "Astrologie"@de .
+
+<http://purl.org/lobid/rpb#n704270>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704200> ;
+    skos:notation "rpb704270" ;
+    skos:prefLabel "Wahrsagen"@de .
+
+<http://purl.org/lobid/rpb#n704280>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704200> ;
+    skos:notation "rpb704280" ;
+    skos:prefLabel "Alchemie"@de .
+
+<http://purl.org/lobid/rpb#n704400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:notation "rpb704400" ;
+    skos:prefLabel "Rechtliche Volkskunde"@de .
+
+<http://purl.org/lobid/rpb#n704600>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n704630> ;
+    skos:notation "rpb704600" ;
+    skos:prefLabel "Religiöse Volkskunde"@de .
+
+<http://purl.org/lobid/rpb#n704630>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704600> ;
+    skos:narrower <http://purl.org/lobid/rpb#n704634> ;
+    skos:notation "rpb704630" ;
+    skos:prefLabel "Volksfrömmigkeit"@de .
+
+<http://purl.org/lobid/rpb#n704634>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n704630> ;
+    skos:notation "rpb704634" ;
+    skos:prefLabel "Gegenstände der Volksfrömmigkeit"@de .
+
+<http://purl.org/lobid/rpb#n704700>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:notation "rpb704700" ;
+    skos:prefLabel "Volksglaube"@de .
+
+<http://purl.org/lobid/rpb#n706000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n706020>, <http://purl.org/lobid/rpb#n706040>, <http://purl.org/lobid/rpb#n706050>, <http://purl.org/lobid/rpb#n706060>, <http://purl.org/lobid/rpb#n706070>, <http://purl.org/lobid/rpb#n706080>, <http://purl.org/lobid/rpb#n706090> ;
+    skos:notation "rpb706000" ;
+    skos:prefLabel "Volksliteratur"@de .
+
+<http://purl.org/lobid/rpb#n706020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706000> ;
+    skos:notation "rpb706020" ;
+    skos:prefLabel "Volksbuch"@de .
+
+<http://purl.org/lobid/rpb#n706040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706000> ;
+    skos:notation "rpb706040" ;
+    skos:prefLabel "Märchen. Sage. Legende"@de .
+
+<http://purl.org/lobid/rpb#n706050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n706052> ;
+    skos:notation "rpb706050" ;
+    skos:prefLabel "Schwank"@de .
+
+<http://purl.org/lobid/rpb#n706052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706050> ;
+    skos:notation "rpb706052" ;
+    skos:prefLabel "Witz"@de .
+
+<http://purl.org/lobid/rpb#n706060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706000> ;
+    skos:notation "rpb706060" ;
+    skos:prefLabel "Sprichwort"@de .
+
+<http://purl.org/lobid/rpb#n706070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706000> ;
+    skos:notation "rpb706070" ;
+    skos:prefLabel "Inschrift"@de .
+
+<http://purl.org/lobid/rpb#n706080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706000> ;
+    skos:notation "rpb706080" ;
+    skos:prefLabel "Rätsel"@de .
+
+<http://purl.org/lobid/rpb#n706090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706000> ;
+    skos:notation "rpb706090" ;
+    skos:prefLabel "Mundartliteratur"@de .
+
+<http://purl.org/lobid/rpb#n706200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n706210>, <http://purl.org/lobid/rpb#n706230>, <http://purl.org/lobid/rpb#n706240> ;
+    skos:notation "rpb706200" ;
+    skos:prefLabel "Volksmusik. Volkstanz"@de .
+
+<http://purl.org/lobid/rpb#n706210>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706200> ;
+    skos:notation "rpb706210" ;
+    skos:prefLabel "Volksmusik"@de .
+
+<http://purl.org/lobid/rpb#n706230>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706200> ;
+    skos:notation "rpb706230" ;
+    skos:prefLabel "Volkslied"@de .
+
+<http://purl.org/lobid/rpb#n706240>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n706200> ;
+    skos:notation "rpb706240" ;
+    skos:prefLabel "Volkstanz"@de .
+
+<http://purl.org/lobid/rpb#n708000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n708020>, <http://purl.org/lobid/rpb#n708030>, <http://purl.org/lobid/rpb#n708040>, <http://purl.org/lobid/rpb#n708050>, <http://purl.org/lobid/rpb#n708060>, <http://purl.org/lobid/rpb#n708200> ;
+    skos:notation "rpb708000" ;
+    skos:prefLabel "Sachkulturforschung"@de .
+
+<http://purl.org/lobid/rpb#n708020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n708024>, <http://purl.org/lobid/rpb#n708026>, <http://purl.org/lobid/rpb#n708028>, <http://purl.org/lobid/rpb#n708029> ;
+    skos:notation "rpb708020" ;
+    skos:prefLabel "Hausform"@de .
+
+<http://purl.org/lobid/rpb#n708024>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708020> ;
+    skos:notation "rpb708024" ;
+    skos:prefLabel "Bürgerhaus"@de .
+
+<http://purl.org/lobid/rpb#n708026>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708020> ;
+    skos:notation "rpb708026" ;
+    skos:prefLabel "Bauernhaus"@de .
+
+<http://purl.org/lobid/rpb#n708028>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708020> ;
+    skos:notation "rpb708028" ;
+    skos:prefLabel "Landwirtschaftliches Gebäude"@de .
+
+<http://purl.org/lobid/rpb#n708029>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708020> ;
+    skos:notation "rpb708029" ;
+    skos:prefLabel "Mühle"@de .
+
+<http://purl.org/lobid/rpb#n708030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708000> ;
+    skos:notation "rpb708030" ;
+    skos:prefLabel "Hausrat"@de .
+
+<http://purl.org/lobid/rpb#n708040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708000> ;
+    skos:notation "rpb708040" ;
+    skos:prefLabel "Gerät"@de .
+
+<http://purl.org/lobid/rpb#n708050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708000> ;
+    skos:notation "rpb708050" ;
+    skos:prefLabel "Spielzeug"@de .
+
+<http://purl.org/lobid/rpb#n708060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708000> ;
+    skos:notation "rpb708060" ;
+    skos:prefLabel "Nahrung"@de .
+
+<http://purl.org/lobid/rpb#n708200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n708220>, <http://purl.org/lobid/rpb#n708230>, <http://purl.org/lobid/rpb#n708250>, <http://purl.org/lobid/rpb#n708260>, <http://purl.org/lobid/rpb#n708270>, <http://purl.org/lobid/rpb#n708280>, <http://purl.org/lobid/rpb#n708290> ;
+    skos:notation "rpb708200" ;
+    skos:prefLabel "Volkskunst"@de .
+
+<http://purl.org/lobid/rpb#n708220>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708200> ;
+    skos:notation "rpb708220" ;
+    skos:prefLabel "Holzbearbeitung"@de .
+
+<http://purl.org/lobid/rpb#n708230>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708200> ;
+    skos:notation "rpb708230" ;
+    skos:prefLabel "Malerei"@de .
+
+<http://purl.org/lobid/rpb#n708250>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708200> ;
+    skos:notation "rpb708250" ;
+    skos:prefLabel "Keramik"@de .
+
+<http://purl.org/lobid/rpb#n708260>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708200> ;
+    skos:notation "rpb708260" ;
+    skos:prefLabel "Steinbearbeitung"@de .
+
+<http://purl.org/lobid/rpb#n708270>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708200> ;
+    skos:notation "rpb708270" ;
+    skos:prefLabel "Metallbearbeitung"@de .
+
+<http://purl.org/lobid/rpb#n708280>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708200> ;
+    skos:notation "rpb708280" ;
+    skos:prefLabel "Glas"@de .
+
+<http://purl.org/lobid/rpb#n708290>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708200> ;
+    skos:notation "rpb708290" ;
+    skos:prefLabel "Textilien"@de .
+
+<http://purl.org/lobid/rpb#n708400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n700000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n708420>, <http://purl.org/lobid/rpb#n708430>, <http://purl.org/lobid/rpb#n708450> ;
+    skos:notation "rpb708400" ;
+    skos:prefLabel "Kleidung"@de .
+
+<http://purl.org/lobid/rpb#n708420>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708400> ;
+    skos:notation "rpb708420" ;
+    skos:prefLabel "Kostümkunde"@de .
+
+<http://purl.org/lobid/rpb#n708430>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708400> ;
+    skos:notation "rpb708430" ;
+    skos:prefLabel "Tracht"@de .
+
+<http://purl.org/lobid/rpb#n708450>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n708400> ;
+    skos:notation "rpb708450" ;
+    skos:prefLabel "Schmuck"@de .
+
+<http://purl.org/lobid/rpb#n720000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n720100>, <http://purl.org/lobid/rpb#n722000>, <http://purl.org/lobid/rpb#n724000>, <http://purl.org/lobid/rpb#n725000>, <http://purl.org/lobid/rpb#n726000> ;
+    skos:notation "rpb720000" ;
+    skos:prefLabel "Gesellschaft"@de .
+
+<http://purl.org/lobid/rpb#n720100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n720000> ;
+    skos:notation "rpb720100" ;
+    skos:prefLabel "Gesellschaft allgemein"@de .
+
+<http://purl.org/lobid/rpb#n722000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n720000> ;
+    skos:notation "rpb722000" ;
+    skos:prefLabel "Sozialgeschichte"@de .
+
+<http://purl.org/lobid/rpb#n724000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n720000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n724020>, <http://purl.org/lobid/rpb#n724030>, <http://purl.org/lobid/rpb#n724040>, <http://purl.org/lobid/rpb#n724050>, <http://purl.org/lobid/rpb#n724060>, <http://purl.org/lobid/rpb#n724070> ;
+    skos:notation "rpb724000" ;
+    skos:prefLabel "Sozialstruktur"@de .
+
+<http://purl.org/lobid/rpb#n724020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n724000> ;
+    skos:notation "rpb724020" ;
+    skos:prefLabel "Kind"@de .
+
+<http://purl.org/lobid/rpb#n724030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n724000> ;
+    skos:notation "rpb724030" ;
+    skos:prefLabel "Jugend"@de .
+
+<http://purl.org/lobid/rpb#n724040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n724000> ;
+    skos:notation "rpb724040" ;
+    skos:prefLabel "Frau"@de .
+
+<http://purl.org/lobid/rpb#n724050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n724000> ;
+    skos:notation "rpb724050" ;
+    skos:prefLabel "Mann"@de .
+
+<http://purl.org/lobid/rpb#n724060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n724000> ;
+    skos:notation "rpb724060" ;
+    skos:prefLabel "Alter"@de .
+
+<http://purl.org/lobid/rpb#n724070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n724000> ;
+    skos:notation "rpb724070" ;
+    skos:prefLabel "Original / Person"@de .
+
+<http://purl.org/lobid/rpb#n725000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n720000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n725010>, <http://purl.org/lobid/rpb#n725020>, <http://purl.org/lobid/rpb#n725030>, <http://purl.org/lobid/rpb#n725040>, <http://purl.org/lobid/rpb#n725050>, <http://purl.org/lobid/rpb#n725060>, <http://purl.org/lobid/rpb#n725070>, <http://purl.org/lobid/rpb#n725080> ;
+    skos:notation "rpb725000" ;
+    skos:prefLabel "Gruppe"@de .
+
+<http://purl.org/lobid/rpb#n725010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n725000> ;
+    skos:notation "rpb725010" ;
+    skos:prefLabel "Familie"@de .
+
+<http://purl.org/lobid/rpb#n725020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n725000> ;
+    skos:notation "rpb725020" ;
+    skos:prefLabel "Nachbarschaft"@de .
+
+<http://purl.org/lobid/rpb#n725030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n725000> ;
+    skos:notation "rpb725030" ;
+    skos:prefLabel "Dorfgemeinschaft"@de .
+
+<http://purl.org/lobid/rpb#n725040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n725000> ;
+    skos:notation "rpb725040" ;
+    skos:prefLabel "Alternativbewegung"@de .
+
+<http://purl.org/lobid/rpb#n725050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n725000> ;
+    skos:notation "rpb725050" ;
+    skos:prefLabel "Interessenverband"@de .
+
+<http://purl.org/lobid/rpb#n725060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n725000> ;
+    skos:notation "rpb725060" ;
+    skos:prefLabel "Randgruppe"@de .
+
+<http://purl.org/lobid/rpb#n725070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n725000> ;
+    skos:notation "rpb725070" ;
+    skos:prefLabel "Ausländerin. Ausländer"@de .
+
+<http://purl.org/lobid/rpb#n725080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n725000> ;
+    skos:notation "rpb725080" ;
+    skos:prefLabel "Behinderter Mensch"@de .
+
+<http://purl.org/lobid/rpb#n726000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n720000> ;
+    skos:notation "rpb726000" ;
+    skos:prefLabel "Sozialer Wandel"@de .
+
+<http://purl.org/lobid/rpb#n730000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n730100>, <http://purl.org/lobid/rpb#n731000>, <http://purl.org/lobid/rpb#n732000>, <http://purl.org/lobid/rpb#n733000>, <http://purl.org/lobid/rpb#n734000>, <http://purl.org/lobid/rpb#n735000>, <http://purl.org/lobid/rpb#n736000> ;
+    skos:notation "rpb730000" ;
+    skos:prefLabel "Kultur und Freizeit"@de .
+
+<http://purl.org/lobid/rpb#n730100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n730000> ;
+    skos:notation "rpb730100" ;
+    skos:prefLabel "Kultur und Freizeit allgemein"@de .
+
+<http://purl.org/lobid/rpb#n731000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n730000> ;
+    skos:notation "rpb731000" ;
+    skos:prefLabel "Kulturpolitik"@de .
+
+<http://purl.org/lobid/rpb#n732000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n730000> ;
+    skos:notation "rpb732000" ;
+    skos:prefLabel "Kulturgeschichte"@de .
+
+<http://purl.org/lobid/rpb#n733000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n730000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n733030>, <http://purl.org/lobid/rpb#n733050>, <http://purl.org/lobid/rpb#n733070> ;
+    skos:notation "rpb733000" ;
+    skos:prefLabel "Kulturleben"@de .
+
+<http://purl.org/lobid/rpb#n733030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n733000> ;
+    skos:notation "rpb733030" ;
+    skos:prefLabel "Kulturveranstaltung"@de .
+
+<http://purl.org/lobid/rpb#n733050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n733000> ;
+    skos:notation "rpb733050" ;
+    skos:prefLabel "Kulturpreis"@de .
+
+<http://purl.org/lobid/rpb#n733070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n733000> ;
+    skos:notation "rpb733070" ;
+    skos:prefLabel "Kulturverein"@de .
+
+<http://purl.org/lobid/rpb#n734000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n730000> ;
+    skos:notation "rpb734000" ;
+    skos:prefLabel "Feier. Fest"@de .
+
+<http://purl.org/lobid/rpb#n735000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n730000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n735020>, <http://purl.org/lobid/rpb#n735040>, <http://purl.org/lobid/rpb#n735090> ;
+    skos:notation "rpb735000" ;
+    skos:prefLabel "Freizeit und Erholung"@de .
+
+<http://purl.org/lobid/rpb#n735020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n735000> ;
+    skos:notation "rpb735020" ;
+    skos:prefLabel "Freizeiteinrichtung"@de .
+
+<http://purl.org/lobid/rpb#n735040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n735000> ;
+    skos:notation "rpb735040" ;
+    skos:prefLabel "Freizeitgestaltung"@de .
+
+<http://purl.org/lobid/rpb#n735090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n735000> ;
+    skos:notation "rpb735090" ;
+    skos:prefLabel "Verein"@de .
+
+<http://purl.org/lobid/rpb#n736000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n730000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n736030>, <http://purl.org/lobid/rpb#n736050>, <http://purl.org/lobid/rpb#n736080> ;
+    skos:notation "rpb736000" ;
+    skos:prefLabel "Sport und Spiel"@de .
+
+<http://purl.org/lobid/rpb#n736030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n736000> ;
+    skos:notation "rpb736030" ;
+    skos:prefLabel "Sportart"@de .
+
+<http://purl.org/lobid/rpb#n736050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n736000> ;
+    skos:notation "rpb736050" ;
+    skos:prefLabel "Sportverein"@de .
+
+<http://purl.org/lobid/rpb#n736080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n736000> ;
+    skos:notation "rpb736080" ;
+    skos:prefLabel "Sportlerin. Sportler"@de .
+
+<http://purl.org/lobid/rpb#n740000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n740100>, <http://purl.org/lobid/rpb#n742000>, <http://purl.org/lobid/rpb#n743000>, <http://purl.org/lobid/rpb#n744000>, <http://purl.org/lobid/rpb#n745000>, <http://purl.org/lobid/rpb#n746000>, <http://purl.org/lobid/rpb#n747000> ;
+    skos:notation "rpb740000" ;
+    skos:prefLabel "Sprache"@de .
+
+<http://purl.org/lobid/rpb#n740100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n740000> ;
+    skos:notation "rpb740100" ;
+    skos:prefLabel "Sprache allgemein"@de .
+
+<http://purl.org/lobid/rpb#n742000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n740000> ;
+    skos:notation "rpb742000" ;
+    skos:prefLabel "Sprache / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n743000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n740000> ;
+    skos:notation "rpb743000" ;
+    skos:prefLabel "Grammatik"@de .
+
+<http://purl.org/lobid/rpb#n744000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n740000> ;
+    skos:notation "rpb744000" ;
+    skos:prefLabel "Mundart"@de .
+
+<http://purl.org/lobid/rpb#n745000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n740000> ;
+    skos:notation "rpb745000" ;
+    skos:prefLabel "Sprachgeographie"@de .
+
+<http://purl.org/lobid/rpb#n746000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n740000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n746020>, <http://purl.org/lobid/rpb#n746030>, <http://purl.org/lobid/rpb#n746040>, <http://purl.org/lobid/rpb#n746050>, <http://purl.org/lobid/rpb#n746060> ;
+    skos:notation "rpb746000" ;
+    skos:prefLabel "Namenkunde"@de .
+
+<http://purl.org/lobid/rpb#n746020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746000> ;
+    skos:notation "rpb746020" ;
+    skos:prefLabel "Personenname"@de .
+
+<http://purl.org/lobid/rpb#n746030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n746032>, <http://purl.org/lobid/rpb#n746034> ;
+    skos:notation "rpb746030" ;
+    skos:prefLabel "Hausname. Hofname"@de .
+
+<http://purl.org/lobid/rpb#n746032>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746030> ;
+    skos:notation "rpb746032" ;
+    skos:prefLabel "Hausname"@de .
+
+<http://purl.org/lobid/rpb#n746034>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746030> ;
+    skos:notation "rpb746034" ;
+    skos:prefLabel "Hofname"@de .
+
+<http://purl.org/lobid/rpb#n746040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n746042>, <http://purl.org/lobid/rpb#n746043>, <http://purl.org/lobid/rpb#n746044>, <http://purl.org/lobid/rpb#n746045>, <http://purl.org/lobid/rpb#n746046> ;
+    skos:notation "rpb746040" ;
+    skos:prefLabel "Geographischer Name"@de .
+
+<http://purl.org/lobid/rpb#n746042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746040> ;
+    skos:notation "rpb746042" ;
+    skos:prefLabel "Ortsname"@de .
+
+<http://purl.org/lobid/rpb#n746043>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746040> ;
+    skos:notation "rpb746043" ;
+    skos:prefLabel "Straßenname"@de .
+
+<http://purl.org/lobid/rpb#n746044>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746040> ;
+    skos:notation "rpb746044" ;
+    skos:prefLabel "Flurname"@de .
+
+<http://purl.org/lobid/rpb#n746045>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746040> ;
+    skos:notation "rpb746045" ;
+    skos:prefLabel "Bergname"@de .
+
+<http://purl.org/lobid/rpb#n746046>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746040> ;
+    skos:notation "rpb746046" ;
+    skos:prefLabel "Gewässername"@de .
+
+<http://purl.org/lobid/rpb#n746050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746000> ;
+    skos:notation "rpb746050" ;
+    skos:prefLabel "Tiername"@de .
+
+<http://purl.org/lobid/rpb#n746060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n746000> ;
+    skos:notation "rpb746060" ;
+    skos:prefLabel "Pflanzenname"@de .
+
+<http://purl.org/lobid/rpb#n747000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n740000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n747010>, <http://purl.org/lobid/rpb#n747020>, <http://purl.org/lobid/rpb#n747030>, <http://purl.org/lobid/rpb#n747040>, <http://purl.org/lobid/rpb#n747050>, <http://purl.org/lobid/rpb#n747060> ;
+    skos:notation "rpb747000" ;
+    skos:prefLabel "Soziolinguistik"@de .
+
+<http://purl.org/lobid/rpb#n747010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n747000> ;
+    skos:notation "rpb747010" ;
+    skos:prefLabel "Umgangssprache"@de .
+
+<http://purl.org/lobid/rpb#n747020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n747000> ;
+    skos:notation "rpb747020" ;
+    skos:prefLabel "Geheimsprache"@de .
+
+<http://purl.org/lobid/rpb#n747030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n747000> ;
+    skos:notation "rpb747030" ;
+    skos:prefLabel "Fachsprache"@de .
+
+<http://purl.org/lobid/rpb#n747040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n747000> ;
+    skos:notation "rpb747040" ;
+    skos:prefLabel "Spracherwerb"@de .
+
+<http://purl.org/lobid/rpb#n747050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n747000> ;
+    skos:notation "rpb747050" ;
+    skos:prefLabel "Sprachunterricht"@de .
+
+<http://purl.org/lobid/rpb#n747060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n747000> ;
+    skos:notation "rpb747060" ;
+    skos:prefLabel "Sprachpflege"@de .
+
+<http://purl.org/lobid/rpb#n760000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n760100>, <http://purl.org/lobid/rpb#n761000>, <http://purl.org/lobid/rpb#n762000>, <http://purl.org/lobid/rpb#n766000>, <http://purl.org/lobid/rpb#n767000>, <http://purl.org/lobid/rpb#n768000>, <http://purl.org/lobid/rpb#n769000> ;
+    skos:notation "rpb760000" ;
+    skos:prefLabel "Literatur"@de .
+
+<http://purl.org/lobid/rpb#n760100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n760000> ;
+    skos:notation "rpb760100" ;
+    skos:prefLabel "Literatur allgemein"@de .
+
+<http://purl.org/lobid/rpb#n761000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n760000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n761020>, <http://purl.org/lobid/rpb#n761050> ;
+    skos:notation "rpb761000" ;
+    skos:prefLabel "Literaturwissenschaft"@de .
+
+<http://purl.org/lobid/rpb#n761020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n761000> ;
+    skos:notation "rpb761020" ;
+    skos:prefLabel "Literaturgeographie"@de .
+
+<http://purl.org/lobid/rpb#n761050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n761000> ;
+    skos:notation "rpb761050" ;
+    skos:prefLabel "Stoff / Literatur. Motiv / Literatur"@de .
+
+<http://purl.org/lobid/rpb#n762000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n760000> ;
+    skos:notation "rpb762000" ;
+    skos:prefLabel "Literatur / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n766000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n760000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n766030>, <http://purl.org/lobid/rpb#n766050>, <http://purl.org/lobid/rpb#n766060> ;
+    skos:notation "rpb766000" ;
+    skos:prefLabel "Literatursoziologie"@de .
+
+<http://purl.org/lobid/rpb#n766030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n766000> ;
+    skos:notation "rpb766030" ;
+    skos:prefLabel "Leserin. Leser"@de .
+
+<http://purl.org/lobid/rpb#n766050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n766000> ;
+    skos:notation "rpb766050" ;
+    skos:prefLabel "Literaturförderung"@de .
+
+<http://purl.org/lobid/rpb#n766060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n766000> ;
+    skos:notation "rpb766060" ;
+    skos:prefLabel "Literaturausstellung"@de .
+
+<http://purl.org/lobid/rpb#n767000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n760000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n767040> ;
+    skos:notation "rpb767000" ;
+    skos:prefLabel "Literarischer Text"@de .
+
+<http://purl.org/lobid/rpb#n767040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n767000> ;
+    skos:notation "rpb767040" ;
+    skos:prefLabel "Anthologie"@de .
+
+<http://purl.org/lobid/rpb#n768000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n760000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n768010>, <http://purl.org/lobid/rpb#n768030> ;
+    skos:notation "rpb768000" ;
+    skos:prefLabel "Schriftstellerin. Schriftsteller"@de .
+
+<http://purl.org/lobid/rpb#n768010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n768000> ;
+    skos:notation "rpb768010" ;
+    skos:prefLabel "Schriftstellerin. Schriftsteller / Primärliteratur"@de .
+
+<http://purl.org/lobid/rpb#n768030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n768000> ;
+    skos:notation "rpb768030" ;
+    skos:prefLabel "Schriftstellerin. Schriftsteller / Sekundärliteratur"@de .
+
+<http://purl.org/lobid/rpb#n769000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n760000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n769020>, <http://purl.org/lobid/rpb#n769030>, <http://purl.org/lobid/rpb#n769040>, <http://purl.org/lobid/rpb#n769050> ;
+    skos:notation "rpb769000" ;
+    skos:prefLabel "Literaturgattung"@de .
+
+<http://purl.org/lobid/rpb#n769020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n769000> ;
+    skos:notation "rpb769020" ;
+    skos:prefLabel "Lyrik"@de .
+
+<http://purl.org/lobid/rpb#n769030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n769000> ;
+    skos:notation "rpb769030" ;
+    skos:prefLabel "Drama"@de .
+
+<http://purl.org/lobid/rpb#n769040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n769000> ;
+    skos:notation "rpb769040" ;
+    skos:prefLabel "Epik"@de .
+
+<http://purl.org/lobid/rpb#n769050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n769000> ;
+    skos:notation "rpb769050" ;
+    skos:prefLabel "Kurzform"@de .
+
+<http://purl.org/lobid/rpb#n780000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n780100>, <http://purl.org/lobid/rpb#n781000>, <http://purl.org/lobid/rpb#n782000>, <http://purl.org/lobid/rpb#n783000>, <http://purl.org/lobid/rpb#n784000>, <http://purl.org/lobid/rpb#n785000>, <http://purl.org/lobid/rpb#n785500>, <http://purl.org/lobid/rpb#n786000> ;
+    skos:notation "rpb780000" ;
+    skos:prefLabel "Bildung. Erziehung"@de .
+
+<http://purl.org/lobid/rpb#n780100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n780000> ;
+    skos:notation "rpb780100" ;
+    skos:prefLabel "Bildung. Erziehung allgemein"@de .
+
+<http://purl.org/lobid/rpb#n781000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n780000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n781040> ;
+    skos:notation "rpb781000" ;
+    skos:prefLabel "Bildungspolitik"@de .
+
+<http://purl.org/lobid/rpb#n781040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n781000> ;
+    skos:notation "rpb781040" ;
+    skos:prefLabel "Ausbildungsförderung"@de .
+
+<http://purl.org/lobid/rpb#n782000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n780000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n782500> ;
+    skos:notation "rpb782000" ;
+    skos:prefLabel "Erziehung"@de .
+
+<http://purl.org/lobid/rpb#n782500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n782000> ;
+    skos:notation "rpb782500" ;
+    skos:prefLabel "Vorschulerziehung"@de .
+
+<http://purl.org/lobid/rpb#n783000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n780000> ;
+    skos:notation "rpb783000" ;
+    skos:prefLabel "Schule / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n784000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n780000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n784010>, <http://purl.org/lobid/rpb#n784016>, <http://purl.org/lobid/rpb#n784020>, <http://purl.org/lobid/rpb#n784025>, <http://purl.org/lobid/rpb#n784030>, <http://purl.org/lobid/rpb#n784035>, <http://purl.org/lobid/rpb#n784040>, <http://purl.org/lobid/rpb#n784041>, <http://purl.org/lobid/rpb#n784042>, <http://purl.org/lobid/rpb#n784043>, <http://purl.org/lobid/rpb#n784044>, <http://purl.org/lobid/rpb#n784045>, <http://purl.org/lobid/rpb#n784046>, <http://purl.org/lobid/rpb#n784047>, <http://purl.org/lobid/rpb#n784048>, <http://purl.org/lobid/rpb#n784049>, <http://purl.org/lobid/rpb#n784050>, <http://purl.org/lobid/rpb#n784060>, <http://purl.org/lobid/rpb#n784070>, <http://purl.org/lobid/rpb#n784080>, <http://purl.org/lobid/rpb#n784090> ;
+    skos:notation "rpb784000" ;
+    skos:prefLabel "Allgemein bildende Schule"@de .
+
+<http://purl.org/lobid/rpb#n784010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n784012>, <http://purl.org/lobid/rpb#n784014> ;
+    skos:notation "rpb784010" ;
+    skos:prefLabel "Schulpolitik"@de .
+
+<http://purl.org/lobid/rpb#n784012>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784010> ;
+    skos:notation "rpb784012" ;
+    skos:prefLabel "Schulreform"@de .
+
+<http://purl.org/lobid/rpb#n784014>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784010> ;
+    skos:notation "rpb784014" ;
+    skos:prefLabel "Schulversuch"@de .
+
+<http://purl.org/lobid/rpb#n784016>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784016" ;
+    skos:prefLabel "Privatschule"@de .
+
+<http://purl.org/lobid/rpb#n784020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784020" ;
+    skos:prefLabel "Schulrecht"@de .
+
+<http://purl.org/lobid/rpb#n784025>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784025" ;
+    skos:prefLabel "Elternarbeit"@de .
+
+<http://purl.org/lobid/rpb#n784030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784030" ;
+    skos:prefLabel "Schulverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n784035>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784035" ;
+    skos:prefLabel "Schulbau"@de .
+
+<http://purl.org/lobid/rpb#n784040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784040" ;
+    skos:prefLabel "Schulgliederung"@de .
+
+<http://purl.org/lobid/rpb#n784041>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784041" ;
+    skos:prefLabel "Grundschule"@de .
+
+<http://purl.org/lobid/rpb#n784042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784042" ;
+    skos:prefLabel "Hauptschule"@de .
+
+<http://purl.org/lobid/rpb#n784043>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n784033> ;
+    skos:notation "rpb784043" ;
+    skos:prefLabel "Realschule"@de .
+
+<http://purl.org/lobid/rpb#n784033>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784043> ;
+    skos:notation "rpb784033" ;
+    skos:prefLabel "Realschule Plus"@de .
+
+<http://purl.org/lobid/rpb#n784044>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784044" ;
+    skos:prefLabel "Gymnasium"@de .
+
+<http://purl.org/lobid/rpb#n784045>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784045" ;
+    skos:prefLabel "Gesamtschule"@de .
+
+<http://purl.org/lobid/rpb#n784046>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784046" ;
+    skos:prefLabel "Kollegschule"@de .
+
+<http://purl.org/lobid/rpb#n784047>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784047" ;
+    skos:prefLabel "Sonderschule"@de .
+
+<http://purl.org/lobid/rpb#n784048>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784048" ;
+    skos:prefLabel "Regionale Schule"@de .
+
+<http://purl.org/lobid/rpb#n784049>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784049" ;
+    skos:prefLabel "Duale Oberschule"@de .
+
+<http://purl.org/lobid/rpb#n784050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n784052>, <http://purl.org/lobid/rpb#n784053>, <http://purl.org/lobid/rpb#n784054> ;
+    skos:notation "rpb784050" ;
+    skos:prefLabel "Schulstufe"@de .
+
+<http://purl.org/lobid/rpb#n784052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784050> ;
+    skos:notation "rpb784052" ;
+    skos:prefLabel "Primarstufe"@de .
+
+<http://purl.org/lobid/rpb#n784053>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784050> ;
+    skos:notation "rpb784053" ;
+    skos:prefLabel "Sekundarstufe 1"@de .
+
+<http://purl.org/lobid/rpb#n784054>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784050> ;
+    skos:notation "rpb784054" ;
+    skos:prefLabel "Sekundarstufe 2"@de .
+
+<http://purl.org/lobid/rpb#n784060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n784062>, <http://purl.org/lobid/rpb#n784064>, <http://purl.org/lobid/rpb#n784066> ;
+    skos:notation "rpb784060" ;
+    skos:prefLabel "Lehrerin. Lehrer"@de .
+
+<http://purl.org/lobid/rpb#n784062>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784060> ;
+    skos:notation "rpb784062" ;
+    skos:prefLabel "Lehrerbildung"@de .
+
+<http://purl.org/lobid/rpb#n784064>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784060> ;
+    skos:notation "rpb784064" ;
+    skos:prefLabel "Lehrerfortbildung"@de .
+
+<http://purl.org/lobid/rpb#n784066>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784060> ;
+    skos:notation "rpb784066" ;
+    skos:prefLabel "Lehrerin. Lehrer / Besoldung"@de .
+
+<http://purl.org/lobid/rpb#n784070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n784072>, <http://purl.org/lobid/rpb#n784074>, <http://purl.org/lobid/rpb#n784076>, <http://purl.org/lobid/rpb#n784078> ;
+    skos:notation "rpb784070" ;
+  skos:prefLabel "Schülerin. Schüler"@de .
+
+<http://purl.org/lobid/rpb#n784072>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784070> ;
+    skos:notation "rpb784072" ;
+    skos:prefLabel "Schülermitverwaltung"@de .
+
+<http://purl.org/lobid/rpb#n784074>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784070> ;
+    skos:notation "rpb784074" ;
+    skos:prefLabel "Schülertransport"@de .
+
+<http://purl.org/lobid/rpb#n784076>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784070> ;
+    skos:notation "rpb784076" ;
+    skos:prefLabel "Schulverpflegung"@de .
+
+<http://purl.org/lobid/rpb#n784078>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784070> ;
+    skos:notation "rpb784078" ;
+    skos:prefLabel "Schüleraustausch"@de .
+
+<http://purl.org/lobid/rpb#n784080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784080" ;
+    skos:prefLabel "Unterricht"@de .
+
+<http://purl.org/lobid/rpb#n784090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n784000> ;
+    skos:notation "rpb784090" ;
+    skos:prefLabel "Schulleben"@de .
+
+<http://purl.org/lobid/rpb#n785000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n780000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n785020>, <http://purl.org/lobid/rpb#n785030>, <http://purl.org/lobid/rpb#n785040>, <http://purl.org/lobid/rpb#n785050>, <http://purl.org/lobid/rpb#n785060>, <http://purl.org/lobid/rpb#n785070>, <http://purl.org/lobid/rpb#n785080> ;
+    skos:notation "rpb785000" ;
+    skos:prefLabel "Berufsbildende Schule"@de .
+
+<http://purl.org/lobid/rpb#n785020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n785000> ;
+    skos:notation "rpb785020" ;
+    skos:prefLabel "Berufsschule"@de .
+
+<http://purl.org/lobid/rpb#n785030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n785000> ;
+    skos:notation "rpb785030" ;
+    skos:prefLabel "Berufsfachschule"@de .
+
+<http://purl.org/lobid/rpb#n785040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n785000> ;
+    skos:notation "rpb785040" ;
+    skos:prefLabel "Berufsaufbauschule"@de .
+
+<http://purl.org/lobid/rpb#n785050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n785000> ;
+    skos:notation "rpb785050" ;
+    skos:prefLabel "Fachoberschule"@de .
+
+<http://purl.org/lobid/rpb#n785060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n785000> ;
+    skos:notation "rpb785060" ;
+    skos:prefLabel "Berufliches Gymnasium"@de .
+
+<http://purl.org/lobid/rpb#n785070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n785000> ;
+    skos:notation "rpb785070" ;
+    skos:prefLabel "Fachschule"@de .
+
+<http://purl.org/lobid/rpb#n785080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n785000> ;
+    skos:notation "rpb785080" ;
+    skos:prefLabel "Nichtstaatliche Berufsschule"@de .
+
+<http://purl.org/lobid/rpb#n785500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n780000> ;
+    skos:notation "rpb785500" ;
+    skos:prefLabel "Berufsausbildung"@de .
+
+<http://purl.org/lobid/rpb#n786000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n780000> ;
+    skos:notation "rpb786000" ;
+    skos:prefLabel "Außerschulische Bildung"@de .
+
+<http://purl.org/lobid/rpb#n790000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n790100>, <http://purl.org/lobid/rpb#n791000>, <http://purl.org/lobid/rpb#n792000>, <http://purl.org/lobid/rpb#n794000>, <http://purl.org/lobid/rpb#n796000>, <http://purl.org/lobid/rpb#n797000>, <http://purl.org/lobid/rpb#n798000>, <http://purl.org/lobid/rpb#n798200>, <http://purl.org/lobid/rpb#n799000> ;
+    skos:notation "rpb790000" ;
+    skos:prefLabel "Hochschule. Wissenschaft"@de .
+
+<http://purl.org/lobid/rpb#n790100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n790000> ;
+    skos:notation "rpb790100" ;
+    skos:prefLabel "Hochschule. Wissenschaft allgemein"@de .
+
+<http://purl.org/lobid/rpb#n791000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n790000> ;
+    skos:notation "rpb791000" ;
+    skos:prefLabel "Hochschulrecht"@de .
+
+<http://purl.org/lobid/rpb#n792000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n790000> ;
+    skos:notation "rpb792000" ;
+    skos:prefLabel "Hochschulpolitik"@de .
+
+<http://purl.org/lobid/rpb#n794000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n790000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n794010> ;
+    skos:notation "rpb794000" ;
+    skos:prefLabel "Hochschule"@de .
+
+<http://purl.org/lobid/rpb#n794010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n794000> ;
+    skos:notation "rpb794010" ;
+    skos:prefLabel "Einzelne Hochschule"@de .
+
+<http://purl.org/lobid/rpb#n796000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n790000> ;
+    skos:notation "rpb796000" ;
+    skos:prefLabel "Fachhochschule"@de .
+
+<http://purl.org/lobid/rpb#n797000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n790000> ;
+    skos:notation "rpb797000" ;
+    skos:prefLabel "Hochschullehrerin. Hochschullehrer. Wissenschaft"@de .
+
+<http://purl.org/lobid/rpb#n798000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n790000> ;
+    skos:notation "rpb798000" ;
+    skos:prefLabel "Studentin. Student"@de .
+
+<http://purl.org/lobid/rpb#n798200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n790000> ;
+    skos:notation "rpb798200" ;
+    skos:prefLabel "Außeruniversitäre Forschung"@de .
+
+<http://purl.org/lobid/rpb#n799000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n790000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n799200> ;
+    skos:notation "rpb799000" ;
+    skos:prefLabel "Wissenschaftsförderung"@de .
+
+<http://purl.org/lobid/rpb#n799200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n799000> ;
+    skos:notation "rpb799200" ;
+    skos:prefLabel "Wissenschaftliche Gesellschaft"@de .
+
+<http://purl.org/lobid/rpb#n800000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n800100>, <http://purl.org/lobid/rpb#n802000>, <http://purl.org/lobid/rpb#n803000>, <http://purl.org/lobid/rpb#n804000>, <http://purl.org/lobid/rpb#n806000> ;
+    skos:notation "rpb800000" ;
+    skos:prefLabel "Darstellende Kunst"@de .
+
+<http://purl.org/lobid/rpb#n800100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n800000> ;
+    skos:notation "rpb800100" ;
+    skos:prefLabel "Darstellende Kunst allgemein"@de .
+
+<http://purl.org/lobid/rpb#n802000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n800000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n802020>, <http://purl.org/lobid/rpb#n802030>, <http://purl.org/lobid/rpb#n802040>, <http://purl.org/lobid/rpb#n802050>, <http://purl.org/lobid/rpb#n802060>, <http://purl.org/lobid/rpb#n802070>, <http://purl.org/lobid/rpb#n802080> ;
+    skos:notation "rpb802000" ;
+    skos:prefLabel "Theater"@de .
+
+<http://purl.org/lobid/rpb#n802020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n802000> ;
+    skos:notation "rpb802020" ;
+    skos:prefLabel "Theater / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n802030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n802000> ;
+    skos:notation "rpb802030" ;
+    skos:prefLabel "Volksschauspiel"@de .
+
+<http://purl.org/lobid/rpb#n802040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n802000> ;
+    skos:notation "rpb802040" ;
+    skos:prefLabel "Laienspiel"@de .
+
+<http://purl.org/lobid/rpb#n802050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n802000> ;
+    skos:notation "rpb802050" ;
+    skos:prefLabel "Kindertheater. Jugendtheater"@de .
+
+<http://purl.org/lobid/rpb#n802060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n802000> ;
+    skos:notation "rpb802060" ;
+    skos:prefLabel "Einzelne Theater"@de .
+
+<http://purl.org/lobid/rpb#n802070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n802000> ;
+    skos:notation "rpb802070" ;
+    skos:prefLabel "Inszenierung"@de .
+
+<http://purl.org/lobid/rpb#n802080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n802000> ;
+    skos:notation "rpb802080" ;
+    skos:prefLabel "Schauspielerin. Schauspieler"@de .
+
+<http://purl.org/lobid/rpb#n803000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n800000> ;
+    skos:notation "rpb803000" ;
+    skos:prefLabel "Ballett"@de .
+
+<http://purl.org/lobid/rpb#n804000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n800000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n804020> ;
+    skos:notation "rpb804000" ;
+    skos:prefLabel "Film"@de .
+
+<http://purl.org/lobid/rpb#n804020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n804000> ;
+    skos:notation "rpb804020" ;
+    skos:prefLabel "Filmtheater"@de .
+
+<http://purl.org/lobid/rpb#n806000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n800000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n806020> ;
+    skos:notation "rpb806000" ;
+    skos:prefLabel "Kleinkunst"@de .
+
+<http://purl.org/lobid/rpb#n806020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n806000> ;
+    skos:notation "rpb806020" ;
+    skos:prefLabel "Kabarett"@de .
+
+<http://purl.org/lobid/rpb#n820000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n820100>, <http://purl.org/lobid/rpb#n821000>, <http://purl.org/lobid/rpb#n822000>, <http://purl.org/lobid/rpb#n822400>, <http://purl.org/lobid/rpb#n822500>, <http://purl.org/lobid/rpb#n823000>, <http://purl.org/lobid/rpb#n824000>, <http://purl.org/lobid/rpb#n824500>, <http://purl.org/lobid/rpb#n825000>, <http://purl.org/lobid/rpb#n826000>, <http://purl.org/lobid/rpb#n827000>, <http://purl.org/lobid/rpb#n828000>, <http://purl.org/lobid/rpb#n829000> ;
+    skos:notation "rpb820000" ;
+    skos:prefLabel "Musik"@de .
+
+<http://purl.org/lobid/rpb#n820100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb820100" ;
+    skos:prefLabel "Musik allgemein"@de .
+
+<http://purl.org/lobid/rpb#n821000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb821000" ;
+    skos:prefLabel "Musikwissenschaft"@de .
+
+<http://purl.org/lobid/rpb#n822000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb822000" ;
+    skos:prefLabel "Musikerin. Musiker / Ausbildung"@de .
+
+<http://purl.org/lobid/rpb#n822400>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb822400" ;
+    skos:prefLabel "Musikförderung"@de .
+
+<http://purl.org/lobid/rpb#n822500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb822500" ;
+    skos:prefLabel "Musikpreis"@de .
+
+<http://purl.org/lobid/rpb#n823000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb823000" ;
+    skos:prefLabel "Musik / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n824000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n824020>, <http://purl.org/lobid/rpb#n824040>, <http://purl.org/lobid/rpb#n824060>, <http://purl.org/lobid/rpb#n824080> ;
+    skos:notation "rpb824000" ;
+    skos:prefLabel "Musikerin. Musiker"@de .
+
+<http://purl.org/lobid/rpb#n824020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n824000> ;
+    skos:notation "rpb824020" ;
+    skos:prefLabel "Instrumentalmusikerin. Instrumentalmusiker"@de .
+
+<http://purl.org/lobid/rpb#n824040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n824000> ;
+    skos:notation "rpb824040" ;
+    skos:prefLabel "Komponistin. Komponist"@de .
+
+<http://purl.org/lobid/rpb#n824060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n824000> ;
+    skos:notation "rpb824060" ;
+    skos:prefLabel "Dirigentin. Dirigent"@de .
+
+<http://purl.org/lobid/rpb#n824080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n824000> ;
+    skos:notation "rpb824080" ;
+    skos:prefLabel "Sängerin. Sänger"@de .
+
+<http://purl.org/lobid/rpb#n824500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb824500" ;
+    skos:prefLabel "Chor"@de .
+
+<http://purl.org/lobid/rpb#n825000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb825000" ;
+    skos:prefLabel "Orchester"@de .
+
+<http://purl.org/lobid/rpb#n826000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n826020> ;
+    skos:notation "rpb826000" ;
+    skos:prefLabel "Konzert. Musikveranstaltung"@de .
+
+<http://purl.org/lobid/rpb#n826020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n826000> ;
+    skos:notation "rpb826020" ;
+    skos:prefLabel "Einzelne Aufführungen"@de .
+
+<http://purl.org/lobid/rpb#n827000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n827010> ;
+    skos:notation "rpb827000" ;
+    skos:prefLabel "Kirchenmusik"@de .
+
+<http://purl.org/lobid/rpb#n827010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n827000> ;
+    skos:notation "rpb827010" ;
+    skos:prefLabel "Kirchenmusik / Aufführung"@de .
+
+<http://purl.org/lobid/rpb#n828000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb828000" ;
+    skos:prefLabel "Musikinstrument"@de .
+
+<http://purl.org/lobid/rpb#n829000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n820000> ;
+    skos:notation "rpb829000" ;
+    skos:prefLabel "Laienmusik"@de .
+
+<http://purl.org/lobid/rpb#n840000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n840100>, <http://purl.org/lobid/rpb#n841000>, <http://purl.org/lobid/rpb#n842000>, <http://purl.org/lobid/rpb#n843000>, <http://purl.org/lobid/rpb#n844000>, <http://purl.org/lobid/rpb#n844200>, <http://purl.org/lobid/rpb#n844500>, <http://purl.org/lobid/rpb#n845000>, <http://purl.org/lobid/rpb#n846000>, <http://purl.org/lobid/rpb#n847000>, <http://purl.org/lobid/rpb#n847500>, <http://purl.org/lobid/rpb#n848000>, <http://purl.org/lobid/rpb#n849000> ;
+    skos:notation "rpb840000" ;
+    skos:prefLabel "Kunst. Architektur"@de .
+
+<http://purl.org/lobid/rpb#n840100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:notation "rpb840100" ;
+    skos:prefLabel "Kunst. Architektur allgemein"@de .
+
+<http://purl.org/lobid/rpb#n841000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n841020>, <http://purl.org/lobid/rpb#n841040>, <http://purl.org/lobid/rpb#n841050>, <http://purl.org/lobid/rpb#n841060>, <http://purl.org/lobid/rpb#n841070>, <http://purl.org/lobid/rpb#n841080>, <http://purl.org/lobid/rpb#n841090> ;
+    skos:notation "rpb841000" ;
+    skos:prefLabel "Kunst"@de .
+
+<http://purl.org/lobid/rpb#n841020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841000> ;
+    skos:notation "rpb841020" ;
+    skos:prefLabel "Kunststudium"@de .
+
+<http://purl.org/lobid/rpb#n841040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841000> ;
+    skos:notation "rpb841040" ;
+    skos:prefLabel "Kunstmuseum. Kunstsammlung"@de .
+
+<http://purl.org/lobid/rpb#n841050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841000> ;
+    skos:notation "rpb841050" ;
+    skos:prefLabel "Kunstgalerie"@de .
+
+<http://purl.org/lobid/rpb#n841060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841000> ;
+    skos:notation "rpb841060" ;
+    skos:prefLabel "Kunstausstellung"@de .
+
+<http://purl.org/lobid/rpb#n841070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841000> ;
+	skos:narrower <http://purl.org/lobid/rpb#n841072>, <http://purl.org/lobid/rpb#n841074>, <http://purl.org/lobid/rpb#n841076>, <http://purl.org/lobid/rpb#n841078>, <http://purl.org/lobid/rpb#n841079> ;
+    skos:notation "rpb841070" ;
+    skos:prefLabel "Künstlerin.Künstler"@de .
+
+<http://purl.org/lobid/rpb#n841072>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841070> ;
+    skos:notation "rpb841072" ;
+    skos:prefLabel "Bildhauerin. Bildhauer"@de .
+
+<http://purl.org/lobid/rpb#n841074>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841070> ;
+    skos:notation "rpb841074" ;
+    skos:prefLabel "Malerin. Maler"@de .
+
+<http://purl.org/lobid/rpb#n841076>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841070> ;
+    skos:notation "rpb841076" ;
+    skos:prefLabel "Zeichnerin. Zeichner"@de .
+
+<http://purl.org/lobid/rpb#n841078>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841070> ;
+    skos:notation "rpb841078" ;
+    skos:prefLabel "Grafikerin. Grafiker"@de .
+
+<http://purl.org/lobid/rpb#n841079>
+	a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841070> ;
+    skos:notation "rpb841079" ;
+    skos:prefLabel "Fotografin. Fotograf"@de .
+
+<http://purl.org/lobid/rpb#n841080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841000> ;
+    skos:notation "rpb841080" ;
+    skos:prefLabel "Künstlervereinigung"@de .
+
+<http://purl.org/lobid/rpb#n841090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n841000> ;
+    skos:notation "rpb841090" ;
+    skos:prefLabel "Kunstförderung"@de .
+
+<http://purl.org/lobid/rpb#n842000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:notation "rpb842000" ;
+    skos:prefLabel "Kunst / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n843000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n843010>, <http://purl.org/lobid/rpb#n843020>, <http://purl.org/lobid/rpb#n843040>, <http://purl.org/lobid/rpb#n843050>, <http://purl.org/lobid/rpb#n843060>, <http://purl.org/lobid/rpb#n843090> ;
+    skos:notation "rpb843000" ;
+    skos:prefLabel "Architektur"@de .
+
+<http://purl.org/lobid/rpb#n843010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n843000> ;
+    skos:notation "rpb843010" ;
+    skos:prefLabel "Baukonstruktion. Bautechnik"@de .
+
+<http://purl.org/lobid/rpb#n843020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n843000> ;
+    skos:notation "rpb843020" ;
+    skos:prefLabel "Öffentliches Gebäude"@de .
+
+<http://purl.org/lobid/rpb#n843040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n843000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n843042>, <http://purl.org/lobid/rpb#n843044>, <http://purl.org/lobid/rpb#n843046> ;
+    skos:notation "rpb843040" ;
+    skos:prefLabel "Büro-, Geschäfts- und Industriebauten"@de .
+
+<http://purl.org/lobid/rpb#n843042>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n843040> ;
+    skos:notation "rpb843042" ;
+    skos:prefLabel "Bürohaus"@de .
+
+<http://purl.org/lobid/rpb#n843044>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n843040> ;
+    skos:notation "rpb843044" ;
+    skos:prefLabel "Geschäftshaus"@de .
+
+<http://purl.org/lobid/rpb#n843046>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n843040> ;
+    skos:notation "rpb843046" ;
+    skos:prefLabel "Industriebau"@de .
+
+<http://purl.org/lobid/rpb#n843050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n843000> ;
+    skos:notation "rpb843050" ;
+    skos:prefLabel "Bauernhaus"@de .
+
+<http://purl.org/lobid/rpb#n843060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n843000> ;
+    skos:notation "rpb843060" ;
+    skos:prefLabel "Wohnhaus"@de .
+
+<http://purl.org/lobid/rpb#n843090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n843000> ;
+    skos:notation "rpb843090" ;
+    skos:prefLabel "Architektin. Architekt"@de .
+
+<http://purl.org/lobid/rpb#n844000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n844010>, <http://purl.org/lobid/rpb#n844020>, <http://purl.org/lobid/rpb#n844030>, <http://purl.org/lobid/rpb#n844040>, <http://purl.org/lobid/rpb#n844050>, <http://purl.org/lobid/rpb#n844060>, <http://purl.org/lobid/rpb#n844070>, <http://purl.org/lobid/rpb#n844080> ;
+    skos:notation "rpb844000" ;
+    skos:prefLabel "Baudenkmal. Kunstwerk"@de .
+
+<http://purl.org/lobid/rpb#n844010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n844000> ;
+    skos:notation "rpb844010" ;
+    skos:prefLabel "Kunst / Inventar"@de .
+
+<http://purl.org/lobid/rpb#n844020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n844000> ;
+    skos:notation "rpb844020" ;
+    skos:prefLabel "Baustil"@de .
+
+<http://purl.org/lobid/rpb#n844030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n844000> ;
+    skos:notation "rpb844030" ;
+    skos:prefLabel "Sakralbau"@de .
+
+<http://purl.org/lobid/rpb#n844040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n844000> ;
+    skos:notation "rpb844040" ;
+    skos:prefLabel "Burg. Schloss"@de .
+
+<http://purl.org/lobid/rpb#n844050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n844000> ;
+    skos:notation "rpb844050" ;
+    skos:prefLabel "Profanarchitektur"@de .
+
+<http://purl.org/lobid/rpb#n844060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n844000> ;
+    skos:notation "rpb844060" ;
+    skos:prefLabel "Park. Garten"@de .
+
+<http://purl.org/lobid/rpb#n844070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n844000> ;
+    skos:notation "rpb844070" ;
+    skos:prefLabel "Brunnen"@de .
+
+<http://purl.org/lobid/rpb#n844080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n844000> ;
+    skos:notation "rpb844080" ;
+    skos:prefLabel "Denkmal"@de .
+
+<http://purl.org/lobid/rpb#n844200>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:notation "rpb844200" ;
+    skos:prefLabel "Denkmalpflege. Denkmalschutz"@de .
+
+<http://purl.org/lobid/rpb#n844500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:notation "rpb844500" ;
+    skos:prefLabel "Städtebau"@de .
+
+<http://purl.org/lobid/rpb#n845000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n845020> ;
+    skos:notation "rpb845000" ;
+    skos:prefLabel "Plastik"@de .
+
+<http://purl.org/lobid/rpb#n845020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n845000> ;
+    skos:notation "rpb845020" ;
+    skos:prefLabel "Plastik / Einzelne Objekte"@de .
+
+<http://purl.org/lobid/rpb#n846000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n846020> ;
+    skos:notation "rpb846000" ;
+    skos:prefLabel "Malerei"@de .
+
+<http://purl.org/lobid/rpb#n846020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n846000> ;
+    skos:notation "rpb846020" ;
+    skos:prefLabel "Malerei / Einzelne Objekte"@de .
+
+<http://purl.org/lobid/rpb#n847000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:notation "rpb847000" ;
+    skos:prefLabel "Zeichnung"@de .
+
+<http://purl.org/lobid/rpb#n847500>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:notation "rpb847500" ;
+    skos:prefLabel "Druckgrafik"@de .
+
+<http://purl.org/lobid/rpb#n848000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:notation "rpb848000" ;
+    skos:prefLabel "Fotografie"@de .
+
+<http://purl.org/lobid/rpb#n849000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n840000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n849020>, <http://purl.org/lobid/rpb#n849030>, <http://purl.org/lobid/rpb#n849032>, <http://purl.org/lobid/rpb#n849034>, <http://purl.org/lobid/rpb#n849040>, <http://purl.org/lobid/rpb#n849050>, <http://purl.org/lobid/rpb#n849060>, <http://purl.org/lobid/rpb#n849070>, <http://purl.org/lobid/rpb#n849080>, <http://purl.org/lobid/rpb#n849090> ;
+    skos:notation "rpb849000" ;
+    skos:prefLabel "Kunsthandwerk"@de .
+
+<http://purl.org/lobid/rpb#n849020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:notation "rpb849020" ;
+    skos:prefLabel "Goldschmiedekunst. Silberschmiedekunst. Schmuck"@de .
+
+<http://purl.org/lobid/rpb#n849030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:notation "rpb849030" ;
+    skos:prefLabel "Eisenguss"@de .
+
+<http://purl.org/lobid/rpb#n849032>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:notation "rpb849032" ;
+    skos:prefLabel "Bronzeguss"@de .
+
+<http://purl.org/lobid/rpb#n849034>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:notation "rpb849034" ;
+    skos:prefLabel "Zinnguss"@de .
+
+<http://purl.org/lobid/rpb#n849040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:notation "rpb849040" ;
+    skos:prefLabel "Keramik"@de .
+
+<http://purl.org/lobid/rpb#n849050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n849052>, <http://purl.org/lobid/rpb#n849054>, <http://purl.org/lobid/rpb#n849056> ;
+    skos:notation "rpb849050" ;
+    skos:prefLabel "Porzellan. Glas. Fayence"@de .
+
+<http://purl.org/lobid/rpb#n849052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849050> ;
+    skos:notation "rpb849052" ;
+    skos:prefLabel "Porzellan"@de .
+
+<http://purl.org/lobid/rpb#n849054>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849050> ;
+    skos:notation "rpb849054" ;
+    skos:prefLabel "Fayence"@de .
+
+<http://purl.org/lobid/rpb#n849056>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849050> ;
+    skos:notation "rpb849056" ;
+    skos:prefLabel "Glas"@de .
+
+<http://purl.org/lobid/rpb#n849060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:notation "rpb849060" ;
+    skos:prefLabel "Hausrat"@de .
+
+<http://purl.org/lobid/rpb#n849070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:notation "rpb849070" ;
+    skos:prefLabel "Möbel"@de .
+
+<http://purl.org/lobid/rpb#n849080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n849082>, <http://purl.org/lobid/rpb#n849084>, <http://purl.org/lobid/rpb#n849086> ;
+    skos:notation "rpb849080" ;
+    skos:prefLabel "Textilien. Teppich. Tapete"@de .
+
+<http://purl.org/lobid/rpb#n849082>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849080> ;
+    skos:notation "rpb849082" ;
+    skos:prefLabel "Textilien"@de .
+
+<http://purl.org/lobid/rpb#n849084>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849080> ;
+    skos:notation "rpb849084" ;
+    skos:prefLabel "Teppich"@de .
+
+<http://purl.org/lobid/rpb#n849086>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849080> ;
+    skos:notation "rpb849086" ;
+    skos:prefLabel "Tapete"@de .
+
+<http://purl.org/lobid/rpb#n849090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n849000> ;
+    skos:notation "rpb849090" ;
+    skos:prefLabel "Uhr. Musikinstrument"@de .
+
+<http://purl.org/lobid/rpb#n860000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n860100>, <http://purl.org/lobid/rpb#n861000>, <http://purl.org/lobid/rpb#n865000> ;
+    skos:notation "rpb860000" ;
+    skos:prefLabel "Buch. Bibliothek"@de .
+
+<http://purl.org/lobid/rpb#n860100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n860000> ;
+    skos:notation "rpb860100" ;
+    skos:prefLabel "Buch. Bibliothek allgemein"@de .
+
+<http://purl.org/lobid/rpb#n861000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n860000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n861010>, <http://purl.org/lobid/rpb#n861020>, <http://purl.org/lobid/rpb#n861030>, <http://purl.org/lobid/rpb#n861040>, <http://purl.org/lobid/rpb#n861050>, <http://purl.org/lobid/rpb#n861060> ;
+    skos:notation "rpb861000" ;
+    skos:prefLabel "Buch"@de .
+
+<http://purl.org/lobid/rpb#n861010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n861000> ;
+    skos:notation "rpb861010" ;
+    skos:prefLabel "Schrift / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n861020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n861000> ;
+    skos:notation "rpb861020" ;
+    skos:prefLabel "Handschrift"@de .
+
+<http://purl.org/lobid/rpb#n861030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n861000> ;
+    skos:notation "rpb861030" ;
+    skos:prefLabel "Buch / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n861040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n861000> ;
+    skos:notation "rpb861040" ;
+    skos:prefLabel "Buchdruck"@de .
+
+<http://purl.org/lobid/rpb#n861050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n861000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n861052>, <http://purl.org/lobid/rpb#n861054>, <http://purl.org/lobid/rpb#n861056> ;
+    skos:notation "rpb861050" ;
+    skos:prefLabel "Verlag"@de .
+
+<http://purl.org/lobid/rpb#n861052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n861050> ;
+    skos:notation "rpb861052" ;
+    skos:prefLabel "Urheberrecht"@de .
+
+<http://purl.org/lobid/rpb#n861054>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n861050> ;
+    skos:notation "rpb861054" ;
+    skos:prefLabel "Verlagsrecht"@de .
+
+<http://purl.org/lobid/rpb#n861056>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n861050> ;
+    skos:notation "rpb861056" ;
+    skos:prefLabel "Verlegerin. Verleger"@de .
+
+<http://purl.org/lobid/rpb#n861060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n861000> ;
+    skos:notation "rpb861060" ;
+    skos:prefLabel "Buchhandel"@de .
+
+<http://purl.org/lobid/rpb#n865000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n860000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n865010>, <http://purl.org/lobid/rpb#n865020>, <http://purl.org/lobid/rpb#n865030>, <http://purl.org/lobid/rpb#n865040>, <http://purl.org/lobid/rpb#n865050>, <http://purl.org/lobid/rpb#n865060>, <http://purl.org/lobid/rpb#n865070>, <http://purl.org/lobid/rpb#n865080>, <http://purl.org/lobid/rpb#n865090> ;
+    skos:notation "rpb865000" ;
+    skos:prefLabel "Bibliothek"@de .
+
+<http://purl.org/lobid/rpb#n865010>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865000> ;
+    skos:notation "rpb865010" ;
+    skos:prefLabel "Bibliotheksrecht"@de .
+
+<http://purl.org/lobid/rpb#n865020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865000> ;
+    skos:notation "rpb865020" ;
+    skos:prefLabel "Bibliothek / Geschichte"@de .
+
+<http://purl.org/lobid/rpb#n865030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865000> ;
+    skos:notation "rpb865030" ;
+    skos:prefLabel "Bibliotheksplanung"@de .
+
+<http://purl.org/lobid/rpb#n865040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865000> ;
+    skos:notation "rpb865040" ;
+    skos:prefLabel "Wissenschaftliche Bibliothek"@de .
+
+<http://purl.org/lobid/rpb#n865050>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n865052>, <http://purl.org/lobid/rpb#n865054> ;
+    skos:notation "rpb865050" ;
+    skos:prefLabel "Öffentliche Bibliothek"@de .
+
+<http://purl.org/lobid/rpb#n865052>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865050> ;
+    skos:notation "rpb865052" ;
+    skos:prefLabel "Stadtbibliothek"@de .
+
+<http://purl.org/lobid/rpb#n865054>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865050> ;
+    skos:notation "rpb865054" ;
+    skos:prefLabel "Kommunale Bibliothek"@de .
+
+<http://purl.org/lobid/rpb#n865060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865000> ;
+    skos:notation "rpb865060" ;
+    skos:prefLabel "Spezialbibliothek"@de .
+
+<http://purl.org/lobid/rpb#n865070>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865000> ;
+    skos:notation "rpb865070" ;
+    skos:prefLabel "Schulbibliothek"@de .
+
+<http://purl.org/lobid/rpb#n865080>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865000> ;
+    skos:notation "rpb865080" ;
+    skos:prefLabel "Privatbibliothek"@de .
+
+<http://purl.org/lobid/rpb#n865090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n865000> ;
+    skos:notation "rpb865090" ;
+    skos:prefLabel "Bibliothekarin. Bibliothekar"@de .
+
+<http://purl.org/lobid/rpb#n880000>
+    a skos:Concept ;
+    skos:narrower <http://purl.org/lobid/rpb#n880100>, <http://purl.org/lobid/rpb#n882000>, <http://purl.org/lobid/rpb#n884000> ;
+    skos:notation "rpb880000" ;
+    skos:prefLabel "Publizistik. Information. Dokumentation"@de .
+
+<http://purl.org/lobid/rpb#n880100>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n880000> ;
+    skos:notation "rpb880100" ;
+    skos:prefLabel "Publizistik. Information. Dokumentation allgemein"@de .
+
+<http://purl.org/lobid/rpb#n882000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n880000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n882020>, <http://purl.org/lobid/rpb#n882030>, <http://purl.org/lobid/rpb#n882040>, <http://purl.org/lobid/rpb#n882060>, <http://purl.org/lobid/rpb#n882090> ;
+    skos:notation "rpb882000" ;
+    skos:prefLabel "Publizistik"@de .
+
+<http://purl.org/lobid/rpb#n882020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n882000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n882022>, <http://purl.org/lobid/rpb#n882026> ;
+    skos:notation "rpb882020" ;
+    skos:prefLabel "Presse"@de .
+
+<http://purl.org/lobid/rpb#n882022>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n882020> ;
+    skos:notation "rpb882022" ;
+    skos:prefLabel "Presserecht"@de .
+
+<http://purl.org/lobid/rpb#n882026>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n882020> ;
+    skos:notation "rpb882026" ;
+    skos:prefLabel "Zeitung. Zeitschrift"@de .
+
+<http://purl.org/lobid/rpb#n882030>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n882000> ;
+    skos:notation "rpb882030" ;
+    skos:prefLabel "Audiovisuelle Medien"@de .
+
+<http://purl.org/lobid/rpb#n882040>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n882000> ;
+    skos:notation "rpb882040" ;
+    skos:prefLabel "Hörfunk"@de .
+
+<http://purl.org/lobid/rpb#n882060>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n882000> ;
+    skos:notation "rpb882060" ;
+    skos:prefLabel "Fernsehen"@de .
+
+<http://purl.org/lobid/rpb#n882090>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n882000> ;
+    skos:notation "rpb882090" ;
+    skos:prefLabel "Journalistin. Journalist"@de .
+
+<http://purl.org/lobid/rpb#n884000>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n880000> ;
+    skos:narrower <http://purl.org/lobid/rpb#n884020> ;
+    skos:notation "rpb884000" ;
+    skos:prefLabel "Information und Dokumentation"@de .
+
+<http://purl.org/lobid/rpb#n884020>
+    a skos:Concept ;
+    skos:broader <http://purl.org/lobid/rpb#n884000> ;
+    skos:notation "rpb884020" ;
+    skos:prefLabel "Internet"@de .

--- a/etl/output/test-output-0.json
+++ b/etl/output/test-output-0.json
@@ -29,24 +29,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Pfalz | Altkarte | Online-Ressource",
+    "label" : "4076031-5 | 4611904-8 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4076031-5",
-      "label" : "Pfalz",
+      "label" : "4076031-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4611904-8",
-      "label" : "Altkarte",
+      "label" : "4611904-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-1.json
+++ b/etl/output/test-output-1.json
@@ -29,24 +29,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Katholische Kirche. Erzdiözese Köln | Altkarte | Online-Ressource",
+    "label" : "2029646-0 | 4611904-8 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/2029646-0",
-      "label" : "Katholische Kirche. Erzdiözese Köln",
+      "label" : "2029646-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4611904-8",
-      "label" : "Altkarte",
+      "label" : "4611904-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-2.json
+++ b/etl/output/test-output-2.json
@@ -29,24 +29,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Erzstift Trier | Altkarte | Online-Ressource",
+    "label" : "4060882-7 | 4611904-8 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4060882-7",
-      "label" : "Erzstift Trier",
+      "label" : "4060882-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4611904-8",
-      "label" : "Altkarte",
+      "label" : "4611904-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-20.json
+++ b/etl/output/test-output-20.json
@@ -24,24 +24,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Sankt Barbara (Hainfeld, Südliche Weinstraße) | Grabplatte | Taufbecken",
+    "label" : "7746576-3 | 4113778-4 | 4135651-2",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/7746576-3",
-      "label" : "Sankt Barbara (Hainfeld, Südliche Weinstraße)",
+      "label" : "7746576-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4113778-4",
-      "label" : "Grabplatte",
+      "label" : "4113778-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4135651-2",
-      "label" : "Taufbecken",
+      "label" : "4135651-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -60,7 +60,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/11944027X",
-      "label" : "Müller, Carl Werner",
+      "label" : "11944027X",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-21.json
+++ b/etl/output/test-output-21.json
@@ -60,7 +60,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/11944027X",
-      "label" : "Müller, Carl Werner",
+      "label" : "11944027X",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-22.json
+++ b/etl/output/test-output-22.json
@@ -35,7 +35,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/11944027X",
-      "label" : "Müller, Carl Werner",
+      "label" : "11944027X",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-23.json
+++ b/etl/output/test-output-23.json
@@ -24,17 +24,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Burgruine Neuscharfeneck | Brunnen",
+    "label" : "4595996-1 | 4008491-7",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4595996-1",
-      "label" : "Burgruine Neuscharfeneck",
+      "label" : "4595996-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4008491-7",
-      "label" : "Brunnen",
+      "label" : "4008491-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -61,7 +61,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/11944027X",
-      "label" : "Müller, Carl Werner",
+      "label" : "11944027X",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-24.json
+++ b/etl/output/test-output-24.json
@@ -30,10 +30,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Hambacher Schloss (Neustadt an der Weinstraße)",
+    "label" : "4094596-0",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4094596-0",
-      "label" : "Hambacher Schloss (Neustadt an der Weinstraße)",
+      "label" : "4094596-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -52,7 +52,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/119277425",
-      "label" : "Böcher, Otto",
+      "label" : "119277425",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-25.json
+++ b/etl/output/test-output-25.json
@@ -23,17 +23,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Hambacher Schloss (Neustadt an der Weinstraße) | Maximilian II., Bayern, König",
+    "label" : "4094596-0 | 118579347",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4094596-0",
-      "label" : "Hambacher Schloss (Neustadt an der Weinstraße)",
+      "label" : "4094596-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/118579347",
-      "label" : "Maximilian II., Bayern, König",
+      "label" : "118579347",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -52,7 +52,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/107939061",
-      "label" : "Kermann, Joachim",
+      "label" : "107939061",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-26.json
+++ b/etl/output/test-output-26.json
@@ -32,17 +32,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Hambacher Fest | Hambacher Schloss (Neustadt an der Weinstraße)",
+    "label" : "4127289-4 | 4094596-0",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4127289-4",
-      "label" : "Hambacher Fest",
+      "label" : "4127289-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4094596-0",
-      "label" : "Hambacher Schloss (Neustadt an der Weinstraße)",
+      "label" : "4094596-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-27.json
+++ b/etl/output/test-output-27.json
@@ -27,10 +27,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Hambacher Schloss (Neustadt an der Weinstraße)",
+    "label" : "4094596-0",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4094596-0",
-      "label" : "Hambacher Schloss (Neustadt an der Weinstraße)",
+      "label" : "4094596-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -49,7 +49,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/116436425",
-      "label" : "Remling, Franz Xaver",
+      "label" : "116436425",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-28.json
+++ b/etl/output/test-output-28.json
@@ -34,7 +34,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/1123984425",
-      "label" : "Trautmann, Herbert",
+      "label" : "1123984425",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-29.json
+++ b/etl/output/test-output-29.json
@@ -30,10 +30,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Hambacher Schloss (Neustadt an der Weinstraße) | Geschichte 1979-1982",
+    "label" : "4094596-0 | Geschichte 1979-1982",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4094596-0",
-      "label" : "Hambacher Schloss (Neustadt an der Weinstraße)",
+      "label" : "4094596-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -59,7 +59,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/1123984425",
-      "label" : "Trautmann, Herbert",
+      "label" : "1123984425",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-3.json
+++ b/etl/output/test-output-3.json
@@ -29,38 +29,38 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Rethel, Alfred | Illustration | Lithografie | Rheinischer Sagenkreis | Pressendruck",
+    "label" : "118744615 | 4123412-1 | 4036042-8 | 7743324-5 | 4159043-0",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/118744615",
-      "label" : "Rethel, Alfred",
+      "label" : "118744615",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4123412-1",
-      "label" : "Illustration",
+      "label" : "4123412-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4036042-8",
-      "label" : "Lithografie",
+      "label" : "4036042-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/7743324-5",
-      "label" : "Rheinischer Sagenkreis",
+      "label" : "7743324-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4159043-0",
-      "label" : "Pressendruck",
+      "label" : "4159043-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -79,7 +79,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/116002468",
-      "label" : "Stolterfoth, Adelheid von",
+      "label" : "116002468",
       "type" : [ "Person" ]
     },
     "role" : {
@@ -101,7 +101,7 @@
   }, {
     "agent" : {
       "id" : "https://d-nb.info/gnd/118702424",
-      "label" : "Dielmann, Jakob Fürchtegott",
+      "label" : "118702424",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-30.json
+++ b/etl/output/test-output-30.json
@@ -32,24 +32,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Ludwigshafen am Rhein | Offener Kanal | Judenvernichtung",
+    "label" : "4036472-0 | 4172489-6 | 4073091-8",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4036472-0",
-      "label" : "Ludwigshafen am Rhein",
+      "label" : "4036472-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4172489-6",
-      "label" : "Offener Kanal",
+      "label" : "4172489-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4073091-8",
-      "label" : "Judenvernichtung",
+      "label" : "4073091-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -68,7 +68,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/106837800X",
-      "label" : "Minor, Ulrike",
+      "label" : "106837800X",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-31.json
+++ b/etl/output/test-output-31.json
@@ -33,17 +33,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Ludwigshafen am Rhein | Volkshochschule | Geschichte 1945-",
+    "label" : "4036472-0 | 4136151-9 | Geschichte 1945-",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4036472-0",
-      "label" : "Ludwigshafen am Rhein",
+      "label" : "4036472-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4136151-9",
-      "label" : "Volkshochschule",
+      "label" : "4136151-9",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -58,17 +58,17 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Ludwigshafen am Rhein | Offener Kanal | Geschichte 1945-",
+    "label" : "4036472-0 | 4172489-6 | Geschichte 1945-",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4036472-0",
-      "label" : "Ludwigshafen am Rhein",
+      "label" : "4036472-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4172489-6",
-      "label" : "Offener Kanal",
+      "label" : "4172489-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -83,17 +83,17 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Ludwigshafen am Rhein | Alter | Geschichte 1945-",
+    "label" : "4036472-0 | 4001446-0 | Geschichte 1945-",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4036472-0",
-      "label" : "Ludwigshafen am Rhein",
+      "label" : "4036472-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4001446-0",
-      "label" : "Alter",
+      "label" : "4001446-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-32.json
+++ b/etl/output/test-output-32.json
@@ -35,17 +35,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Ludwigshafen am Rhein | Offener Kanal",
+    "label" : "4036472-0 | 4172489-6",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4036472-0",
-      "label" : "Ludwigshafen am Rhein",
+      "label" : "4036472-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4172489-6",
-      "label" : "Offener Kanal",
+      "label" : "4172489-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-33.json
+++ b/etl/output/test-output-33.json
@@ -28,10 +28,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Südwestrundfunk | Geschichte 1945- | Zeitschrift",
+    "label" : "5295938-7 | Geschichte 1945- | 4067488-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/5295938-7",
-      "label" : "Südwestrundfunk",
+      "label" : "5295938-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -45,7 +45,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4067488-5",
-      "label" : "Zeitschrift",
+      "label" : "4067488-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -64,7 +64,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/5331496-7",
-      "label" : "SWR-3-Club",
+      "label" : "5331496-7",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-35.json
+++ b/etl/output/test-output-35.json
@@ -28,10 +28,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "SWF 3 | Geschichte 1945- | Zeitschrift",
+    "label" : "4264102-0 | Geschichte 1945- | 4067488-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4264102-0",
-      "label" : "SWF 3",
+      "label" : "4264102-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -45,7 +45,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4067488-5",
-      "label" : "Zeitschrift",
+      "label" : "4067488-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -64,7 +64,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/5166552-9",
-      "label" : "SWF 3, Der Club",
+      "label" : "5166552-9",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-37.json
+++ b/etl/output/test-output-37.json
@@ -28,17 +28,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Südwestrundfunk | Zeitschrift",
+    "label" : "5295938-7 | 4067488-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/5295938-7",
-      "label" : "Südwestrundfunk",
+      "label" : "5295938-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4067488-5",
-      "label" : "Zeitschrift",
+      "label" : "4067488-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -57,7 +57,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/5295938-7",
-      "label" : "Südwestrundfunk",
+      "label" : "5295938-7",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-39.json
+++ b/etl/output/test-output-39.json
@@ -34,7 +34,7 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Geschichte 1945- | Zeitschrift",
+    "label" : "Geschichte 1945- | 4067488-5",
     "componentList" : [ {
       "id" : "http://rpb.lobid.org/sw/z64",
       "label" : "Geschichte 1945-",
@@ -44,7 +44,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4067488-5",
-      "label" : "Zeitschrift",
+      "label" : "4067488-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -63,7 +63,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/1033772-6",
-      "label" : "Staatliche Vogelschutzwarte für Hessen, Rheinland-Pfalz und Saarland",
+      "label" : "1033772-6",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-4.json
+++ b/etl/output/test-output-4.json
@@ -29,31 +29,31 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Rethel, Alfred | Illustration | Lithografie | Rheinischer Sagenkreis",
+    "label" : "118744615 | 4123412-1 | 4036042-8 | 7743324-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/118744615",
-      "label" : "Rethel, Alfred",
+      "label" : "118744615",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4123412-1",
-      "label" : "Illustration",
+      "label" : "4123412-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4036042-8",
-      "label" : "Lithografie",
+      "label" : "4036042-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/7743324-5",
-      "label" : "Rheinischer Sagenkreis",
+      "label" : "7743324-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -72,7 +72,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/116002468",
-      "label" : "Stolterfoth, Adelheid von",
+      "label" : "116002468",
       "type" : [ "Person" ]
     },
     "role" : {
@@ -94,7 +94,7 @@
   }, {
     "agent" : {
       "id" : "https://d-nb.info/gnd/118702424",
-      "label" : "Dielmann, Jakob Fürchtegott",
+      "label" : "118702424",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-41.json
+++ b/etl/output/test-output-41.json
@@ -34,10 +34,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Verein für Rasenspiele Speyer 1950 | Geschichte 1945- | Zeitschrift",
+    "label" : "5325261-5 | Geschichte 1945- | 4067488-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/5325261-5",
-      "label" : "Verein für Rasenspiele Speyer 1950",
+      "label" : "5325261-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -51,7 +51,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4067488-5",
-      "label" : "Zeitschrift",
+      "label" : "4067488-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -70,7 +70,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/5325261-5",
-      "label" : "Verein für Rasenspiele Speyer 1950",
+      "label" : "5325261-5",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-43.json
+++ b/etl/output/test-output-43.json
@@ -25,7 +25,7 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Geschichte 1945- | Zeitschrift",
+    "label" : "Geschichte 1945- | 4067488-5",
     "componentList" : [ {
       "id" : "http://rpb.lobid.org/sw/z64",
       "label" : "Geschichte 1945-",
@@ -35,7 +35,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4067488-5",
-      "label" : "Zeitschrift",
+      "label" : "4067488-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -54,7 +54,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/7832695-3",
-      "label" : "Ebertsheim-Rodenbach",
+      "label" : "7832695-3",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-45.json
+++ b/etl/output/test-output-45.json
@@ -27,10 +27,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Technische Universität Kaiserslautern | Geschichte 1945- | Führer",
+    "label" : "10066624-3 | Geschichte 1945- | 4155569-7",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/10066624-3",
-      "label" : "Technische Universität Kaiserslautern",
+      "label" : "10066624-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -44,7 +44,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4155569-7",
-      "label" : "Führer",
+      "label" : "4155569-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -63,7 +63,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/26332-1",
-      "label" : "Universität Kaiserslautern",
+      "label" : "26332-1",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-47.json
+++ b/etl/output/test-output-47.json
@@ -25,17 +25,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Mittelrheintal (Süd) | Kalender",
+    "label" : "4221819-6 | 4029290-3",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4221819-6",
-      "label" : "Mittelrheintal (Süd)",
+      "label" : "4221819-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4029290-3",
-      "label" : "Kalender",
+      "label" : "4029290-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -43,17 +43,17 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Briefmarkenserie | Kalender",
+    "label" : "4335389-7 | 4029290-3",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4335389-7",
-      "label" : "Briefmarkenserie",
+      "label" : "4335389-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4029290-3",
-      "label" : "Kalender",
+      "label" : "4029290-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -62,7 +62,7 @@
   } ],
   "spatial" : [ {
     "id" : "https://d-nb.info/gnd/4221819-6",
-    "label" : "Mittelrheintal (Süd)",
+    "label" : "4221819-6",
     "type" : [ "PlaceOrGeographicName" ],
     "source" : {
       "id" : "https://d-nb.info/gnd/7749153-1",
@@ -72,7 +72,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/10366667-9",
-      "label" : "Sebapharma GmbH & Co. KG (Boppard)",
+      "label" : "10366667-9",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-48.json
+++ b/etl/output/test-output-48.json
@@ -30,24 +30,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Wied (Fluss) | Tiere <Motiv> | Kalender",
+    "label" : "4108127-4 | 4185464-0 | 4029290-3",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4108127-4",
-      "label" : "Wied (Fluss)",
+      "label" : "4108127-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4185464-0",
-      "label" : "Tiere <Motiv>",
+      "label" : "4185464-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4029290-3",
-      "label" : "Kalender",
+      "label" : "4029290-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -56,7 +56,7 @@
   } ],
   "spatial" : [ {
     "id" : "https://d-nb.info/gnd/4119314-3",
-    "label" : "Unterwesterwald",
+    "label" : "4119314-3",
     "type" : [ "PlaceOrGeographicName" ],
     "source" : {
       "id" : "https://d-nb.info/gnd/7749153-1",

--- a/etl/output/test-output-49.json
+++ b/etl/output/test-output-49.json
@@ -24,10 +24,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "KKG Rot-Weiß-Grün Kowelenzer Schängelcher | Geschichte 1922-2011",
+    "label" : "5114232-6 | Geschichte 1922-2011",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/5114232-6",
-      "label" : "KKG Rot-Weiß-Grün Kowelenzer Schängelcher",
+      "label" : "5114232-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-5.json
+++ b/etl/output/test-output-5.json
@@ -29,31 +29,31 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Rheinland | Literatur | Anthologie | Online-Ressource",
+    "label" : "4049788-4 | 4035964-5 | 4002214-6 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4049788-4",
-      "label" : "Rheinland",
+      "label" : "4049788-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4035964-5",
-      "label" : "Literatur",
+      "label" : "4035964-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4002214-6",
-      "label" : "Anthologie",
+      "label" : "4002214-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-50.json
+++ b/etl/output/test-output-50.json
@@ -28,17 +28,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Krankenhaus der Barmherzigen Brüder Montabaur | Zeitschrift",
+    "label" : "7741811-6 | 4067488-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/7741811-6",
-      "label" : "Krankenhaus der Barmherzigen Brüder Montabaur",
+      "label" : "7741811-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4067488-5",
-      "label" : "Zeitschrift",
+      "label" : "4067488-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -57,7 +57,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/5280327-2",
-      "label" : "Krankenhaus der Barmherzigen Brüder (Montabaur)",
+      "label" : "5280327-2",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-52.json
+++ b/etl/output/test-output-52.json
@@ -26,7 +26,7 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Volleyballclub Neuwied 77 / Neuwied | Zeitschrift",
+    "label" : "Volleyballclub Neuwied 77 / Neuwied | 4067488-5",
     "componentList" : [ {
       "id" : "http://rpb.lobid.org/sw/929n110300",
       "label" : "Volleyballclub Neuwied 77 / Neuwied",
@@ -37,7 +37,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4067488-5",
-      "label" : "Zeitschrift",
+      "label" : "4067488-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -56,7 +56,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/16107604-X",
-      "label" : "Volleyballclub Neuwied 77",
+      "label" : "16107604-X",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-54.json
+++ b/etl/output/test-output-54.json
@@ -24,24 +24,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Unkel | Niedecken, Wolfgang | Biografie",
+    "label" : "4061836-5 | 118942247 | 4006804-3",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4061836-5",
-      "label" : "Unkel",
+      "label" : "4061836-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/118942247",
-      "label" : "Niedecken, Wolfgang",
+      "label" : "118942247",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4006804-3",
-      "label" : "Biografie",
+      "label" : "4006804-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-55.json
+++ b/etl/output/test-output-55.json
@@ -32,7 +32,7 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Deutscher Orden / Kommende Waldbreitbach | Denkmalschutz | Schicker, Viktor | Private Investition | Geschichte 2009-2011",
+    "label" : "Deutscher Orden / Kommende Waldbreitbach | 4011457-0 | Schicker, Viktor | 4454409-1 | Geschichte 2009-2011",
     "componentList" : [ {
       "id" : "http://rpb.lobid.org/sw/929n090287",
       "label" : "Deutscher Orden / Kommende Waldbreitbach",
@@ -43,7 +43,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4011457-0",
-      "label" : "Denkmalschutz",
+      "label" : "4011457-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -57,7 +57,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4454409-1",
-      "label" : "Private Investition",
+      "label" : "4454409-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-56.json
+++ b/etl/output/test-output-56.json
@@ -24,10 +24,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Alten- und Pflegeheim St.-Vinzenzhaus (Gebhardshain) | Geschichte 1911-2011",
+    "label" : "16326855-1 | Geschichte 1911-2011",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/16326855-1",
-      "label" : "Alten- und Pflegeheim St.-Vinzenzhaus (Gebhardshain)",
+      "label" : "16326855-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-57.json
+++ b/etl/output/test-output-57.json
@@ -37,17 +37,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Kunst | Aufsatzsammlung",
+    "label" : "4114333-4 | 4143413-4",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4114333-4",
-      "label" : "Kunst",
+      "label" : "4114333-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4143413-4",
-      "label" : "Aufsatzsammlung",
+      "label" : "4143413-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -55,10 +55,10 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Sander, August",
+    "label" : "118605364",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/118605364",
-      "label" : "Sander, August",
+      "label" : "118605364",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-58.json
+++ b/etl/output/test-output-58.json
@@ -30,24 +30,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Mittelrhein-Gebiet | Altkarte | Online-Ressource",
+    "label" : "4074902-2 | 4611904-8 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4074902-2",
-      "label" : "Mittelrhein-Gebiet",
+      "label" : "4074902-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4611904-8",
-      "label" : "Altkarte",
+      "label" : "4611904-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -55,24 +55,24 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Niederrheinisches Tiefland | Altkarte | Online-Ressource",
+    "label" : "4042224-0 | 4611904-8 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4042224-0",
-      "label" : "Niederrheinisches Tiefland",
+      "label" : "4042224-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4611904-8",
-      "label" : "Altkarte",
+      "label" : "4611904-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -80,24 +80,24 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Bergisches Land | Altkarte | Online-Ressource",
+    "label" : "4005659-4 | 4611904-8 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4005659-4",
-      "label" : "Bergisches Land",
+      "label" : "4005659-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4611904-8",
-      "label" : "Altkarte",
+      "label" : "4611904-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-59.json
+++ b/etl/output/test-output-59.json
@@ -29,17 +29,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Landkreis Mayen-Koblenz | Zeitung",
+    "label" : "4038117-1 | 4067510-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4038117-1",
-      "label" : "Landkreis Mayen-Koblenz",
+      "label" : "4038117-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4067510-5",
-      "label" : "Zeitung",
+      "label" : "4067510-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-61.json
+++ b/etl/output/test-output-61.json
@@ -26,24 +26,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Ahrtal | Komödie | DVD-ROM",
+    "label" : "4084812-7 | 4031952-0 | 4585131-1",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4084812-7",
-      "label" : "Ahrtal",
+      "label" : "4084812-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4031952-0",
-      "label" : "Komödie",
+      "label" : "4031952-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4585131-1",
-      "label" : "DVD-ROM",
+      "label" : "4585131-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-62.json
+++ b/etl/output/test-output-62.json
@@ -25,24 +25,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Sankt-Johannes-Grundschule Erpel | Bewegte Schule | DVD-ROM",
+    "label" : "4839067-7 | 4510321-5 | 4585131-1",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4839067-7",
-      "label" : "Sankt-Johannes-Grundschule Erpel",
+      "label" : "4839067-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4510321-5",
-      "label" : "Bewegte Schule",
+      "label" : "4510321-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4585131-1",
-      "label" : "DVD-ROM",
+      "label" : "4585131-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -61,7 +61,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/10120647-1",
-      "label" : "St.-Johannes-Grundschule (Erpel)",
+      "label" : "10120647-1",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-63.json
+++ b/etl/output/test-output-63.json
@@ -25,38 +25,38 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Kussmaul, Heiner | Mozart, Wolfgang Amadeus | Reise | Malerei | Ausstellung | Reichenhall / 2007 | CD-ROM",
+    "label" : "136595545 | 118584596 | 4049275-8 | 4037220-0 | 4129601-1 | Reichenhall / 2007 | 4139307-7",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/136595545",
-      "label" : "Kussmaul, Heiner",
+      "label" : "136595545",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/118584596",
-      "label" : "Mozart, Wolfgang Amadeus",
+      "label" : "118584596",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4049275-8",
-      "label" : "Reise",
+      "label" : "4049275-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4037220-0",
-      "label" : "Malerei",
+      "label" : "4037220-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4129601-1",
-      "label" : "Ausstellung",
+      "label" : "4129601-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -70,7 +70,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4139307-7",
-      "label" : "CD-ROM",
+      "label" : "4139307-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -78,38 +78,38 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Kussmaul, Yvonne | Mozart, Wolfgang Amadeus | Reise | Malerei | Ausstellung | Reichenhall / 2007 | CD-ROM",
+    "label" : "136596061 | 118584596 | 4049275-8 | 4037220-0 | 4129601-1 | Reichenhall / 2007 | 4139307-7",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/136596061",
-      "label" : "Kussmaul, Yvonne",
+      "label" : "136596061",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/118584596",
-      "label" : "Mozart, Wolfgang Amadeus",
+      "label" : "118584596",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4049275-8",
-      "label" : "Reise",
+      "label" : "4049275-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4037220-0",
-      "label" : "Malerei",
+      "label" : "4037220-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4129601-1",
-      "label" : "Ausstellung",
+      "label" : "4129601-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -123,7 +123,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4139307-7",
-      "label" : "CD-ROM",
+      "label" : "4139307-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -142,7 +142,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/136595545",
-      "label" : "Kussmaul, Heiner",
+      "label" : "136595545",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-64.json
+++ b/etl/output/test-output-64.json
@@ -25,31 +25,31 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Kussmaul, Heiner | Wied-Gebiet | Malerei | Ausstellung | Neuwied / 2007 | CD-ROM",
+    "label" : "136595545 | 4491668-1 | 4037220-0 | 4129601-1 | Neuwied / 2007 | 4139307-7",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/136595545",
-      "label" : "Kussmaul, Heiner",
+      "label" : "136595545",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4491668-1",
-      "label" : "Wied-Gebiet",
+      "label" : "4491668-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4037220-0",
-      "label" : "Malerei",
+      "label" : "4037220-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4129601-1",
-      "label" : "Ausstellung",
+      "label" : "4129601-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -63,7 +63,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4139307-7",
-      "label" : "CD-ROM",
+      "label" : "4139307-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -71,31 +71,31 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Kussmaul, Yvonne | Wied-Gebiet | Malerei | Ausstellung | Neuwied / 2007 | CD-ROM",
+    "label" : "136596061 | 4491668-1 | 4037220-0 | 4129601-1 | Neuwied / 2007 | 4139307-7",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/136596061",
-      "label" : "Kussmaul, Yvonne",
+      "label" : "136596061",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4491668-1",
-      "label" : "Wied-Gebiet",
+      "label" : "4491668-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4037220-0",
-      "label" : "Malerei",
+      "label" : "4037220-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4129601-1",
-      "label" : "Ausstellung",
+      "label" : "4129601-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -109,7 +109,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4139307-7",
-      "label" : "CD-ROM",
+      "label" : "4139307-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -128,7 +128,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/136595545",
-      "label" : "Kussmaul, Heiner",
+      "label" : "136595545",
       "type" : [ "Person" ]
     },
     "role" : {
@@ -139,7 +139,7 @@
   }, {
     "agent" : {
       "id" : "https://d-nb.info/gnd/136596061",
-      "label" : "Kussmaul, Yvonne",
+      "label" : "136596061",
       "type" : [ "Person" ]
     },
     "role" : {
@@ -150,7 +150,7 @@
   }, {
     "agent" : {
       "id" : "https://d-nb.info/gnd/10344831-7",
-      "label" : "Bilderausstellung Von der Wied an den Rhein (2007 : Neuwied)",
+      "label" : "10344831-7",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-65.json
+++ b/etl/output/test-output-65.json
@@ -23,10 +23,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Sport-Club 1957 (Wassenach) | Geschichte 1957-2007 | Chronik",
+    "label" : "10179791-6 | Geschichte 1957-2007 | 4127914-1",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/10179791-6",
-      "label" : "Sport-Club 1957 (Wassenach)",
+      "label" : "10179791-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -40,7 +40,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4127914-1",
-      "label" : "Chronik",
+      "label" : "4127914-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -59,7 +59,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/10179791-6",
-      "label" : "Sport-Club 1957 (Wassenach)",
+      "label" : "10179791-6",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-66.json
+++ b/etl/output/test-output-66.json
@@ -26,10 +26,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Alten- und Pflegeheim St. Barbara (Koblenz) | Geschichte 1908-2008",
+    "label" : "10360311-6 | Geschichte 1908-2008",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/10360311-6",
-      "label" : "Alten- und Pflegeheim St. Barbara (Koblenz)",
+      "label" : "10360311-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -66,7 +66,7 @@
   }, {
     "agent" : {
       "id" : "https://d-nb.info/gnd/10360311-6",
-      "label" : "Alten- und Pflegeheim St. Barbara (Koblenz)",
+      "label" : "10360311-6",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-67.json
+++ b/etl/output/test-output-67.json
@@ -25,10 +25,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Volksbank Kirn-Sobernheim | Geschichte 1908-2008 | Chronik",
+    "label" : "10360357-8 | Geschichte 1908-2008 | 4127914-1",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/10360357-8",
-      "label" : "Volksbank Kirn-Sobernheim",
+      "label" : "10360357-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -42,7 +42,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4127914-1",
-      "label" : "Chronik",
+      "label" : "4127914-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -61,7 +61,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/10360357-8",
-      "label" : "Volksbank Kirn-Sobernheim",
+      "label" : "10360357-8",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-68.json
+++ b/etl/output/test-output-68.json
@@ -37,17 +37,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Römisches Reich | Staatsgrenze",
+    "label" : "4076778-4 | 4077781-9",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4076778-4",
-      "label" : "Römisches Reich",
+      "label" : "4076778-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4077781-9",
-      "label" : "Staatsgrenze",
+      "label" : "4077781-9",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -55,10 +55,10 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Limes",
+    "label" : "4035758-2",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4035758-2",
-      "label" : "Limes",
+      "label" : "4035758-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -99,7 +99,7 @@
   }, {
     "agent" : {
       "id" : "https://d-nb.info/gnd/122161289",
-      "label" : "Thiel, Andreas",
+      "label" : "122161289",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-69.json
+++ b/etl/output/test-output-69.json
@@ -32,10 +32,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Deutsches Rotes Kreuz. Ortsverein Adenau | Geschichte 1883-2008",
+    "label" : "10361782-6 | Geschichte 1883-2008",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/10361782-6",
-      "label" : "Deutsches Rotes Kreuz. Ortsverein Adenau",
+      "label" : "10361782-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -61,7 +61,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/10361782-6",
-      "label" : "Deutsches Rotes Kreuz. Ortsverein Adenau",
+      "label" : "10361782-6",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-7.json
+++ b/etl/output/test-output-7.json
@@ -28,59 +28,59 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Scheuren, Caspar | Illustration | Farblithografie | Rhein | Lyrik | Anthologie | Pressendruck | Online-Ressource",
+    "label" : "118607359 | 4123412-1 | 4279198-4 | 4049739-2 | 4036774-5 | 4002214-6 | 4159043-0 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/118607359",
-      "label" : "Scheuren, Caspar",
+      "label" : "118607359",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4123412-1",
-      "label" : "Illustration",
+      "label" : "4123412-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4279198-4",
-      "label" : "Farblithografie",
+      "label" : "4279198-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4049739-2",
-      "label" : "Rhein",
+      "label" : "4049739-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4036774-5",
-      "label" : "Lyrik",
+      "label" : "4036774-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4002214-6",
-      "label" : "Anthologie",
+      "label" : "4002214-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4159043-0",
-      "label" : "Pressendruck",
+      "label" : "4159043-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -99,7 +99,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/118607359",
-      "label" : "Scheuren, Caspar",
+      "label" : "118607359",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-70.json
+++ b/etl/output/test-output-70.json
@@ -32,17 +32,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Sankt Nikolaus (Koblenz) | DVD-ROM",
+    "label" : "4515647-5 | 4585131-1",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4515647-5",
-      "label" : "Sankt Nikolaus (Koblenz)",
+      "label" : "4515647-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4585131-1",
-      "label" : "DVD-ROM",
+      "label" : "4585131-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-71.json
+++ b/etl/output/test-output-71.json
@@ -31,24 +31,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Moseltal | Weinbau | Preisentwicklung",
+    "label" : "4102224-5 | 4065136-8 | 4125931-2",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4102224-5",
-      "label" : "Moseltal",
+      "label" : "4102224-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4065136-8",
-      "label" : "Weinbau",
+      "label" : "4065136-8",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4125931-2",
-      "label" : "Preisentwicklung",
+      "label" : "4125931-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -78,7 +78,7 @@
   }, {
     "agent" : {
       "id" : "https://d-nb.info/gnd/105115975X",
-      "label" : "Stein, Ulrich",
+      "label" : "105115975X",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-72.json
+++ b/etl/output/test-output-72.json
@@ -37,17 +37,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Ferdinand Pieroth, Weingut - Weinkellerei | Vermarktung",
+    "label" : "2075606-9 | 4121857-7",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/2075606-9",
-      "label" : "Ferdinand Pieroth, Weingut - Weinkellerei",
+      "label" : "2075606-9",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4121857-7",
-      "label" : "Vermarktung",
+      "label" : "4121857-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-73.json
+++ b/etl/output/test-output-73.json
@@ -34,7 +34,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/1044265310",
-      "label" : "Hörter, Peter",
+      "label" : "1044265310",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-74.json
+++ b/etl/output/test-output-74.json
@@ -55,7 +55,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/122882679",
-      "label" : "Keil, Hartmut",
+      "label" : "122882679",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-77.json
+++ b/etl/output/test-output-77.json
@@ -45,7 +45,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/2038546-8",
-      "label" : "Landkreis Daun",
+      "label" : "2038546-8",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-79.json
+++ b/etl/output/test-output-79.json
@@ -13,52 +13,52 @@
   "responsibilityStatement" : [ "Aus f39x: Geisenheim: Ges. zur Förderung der Forschungsanst. Geisenheim 2013." ],
   "subject" : [ {
     "type" : [ "ComplexSubject" ],
-    "label" : "Most | Lebensmittelverarbeitung | Riesling | Chemie | Wein | Weinlese | Lebensmittelqualität",
+    "label" : "4040354-3 | 4167045-0 | 4138434-9 | 4009816-3 | 4065133-2 | 4432509-5 | 4343361-3",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4040354-3",
-      "label" : "Most",
+      "label" : "4040354-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4167045-0",
-      "label" : "Lebensmittelverarbeitung",
+      "label" : "4167045-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4138434-9",
-      "label" : "Riesling",
+      "label" : "4138434-9",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4009816-3",
-      "label" : "Chemie",
+      "label" : "4009816-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4065133-2",
-      "label" : "Wein",
+      "label" : "4065133-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4432509-5",
-      "label" : "Weinlese",
+      "label" : "4432509-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4343361-3",
-      "label" : "Lebensmittelqualität",
+      "label" : "4343361-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-8.json
+++ b/etl/output/test-output-8.json
@@ -28,59 +28,59 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Scheuren, Caspar | Illustration | Farblithografie | Rhein | Lyrik | Anthologie | Pressendruck | Online-Ressource",
+    "label" : "118607359 | 4123412-1 | 4279198-4 | 4049739-2 | 4036774-5 | 4002214-6 | 4159043-0 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/118607359",
-      "label" : "Scheuren, Caspar",
+      "label" : "118607359",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4123412-1",
-      "label" : "Illustration",
+      "label" : "4123412-1",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4279198-4",
-      "label" : "Farblithografie",
+      "label" : "4279198-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4049739-2",
-      "label" : "Rhein",
+      "label" : "4049739-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4036774-5",
-      "label" : "Lyrik",
+      "label" : "4036774-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4002214-6",
-      "label" : "Anthologie",
+      "label" : "4002214-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4159043-0",
-      "label" : "Pressendruck",
+      "label" : "4159043-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -99,7 +99,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/118607359",
-      "label" : "Scheuren, Caspar",
+      "label" : "118607359",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-80.json
+++ b/etl/output/test-output-80.json
@@ -26,7 +26,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/132394235",
-      "label" : "Gensicke, Hellmuth",
+      "label" : "132394235",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-81.json
+++ b/etl/output/test-output-81.json
@@ -29,10 +29,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Magdalena, Mutter | Geschichte 1800-",
+    "label" : "119067552 | Geschichte 1800-",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/119067552",
-      "label" : "Magdalena, Mutter",
+      "label" : "119067552",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-82.json
+++ b/etl/output/test-output-82.json
@@ -27,7 +27,7 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Geschichte 1945- | Bericht",
+    "label" : "Geschichte 1945- | 4128022-2",
     "componentList" : [ {
       "id" : "http://rpb.lobid.org/sw/z64",
       "label" : "Geschichte 1945-",
@@ -37,7 +37,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4128022-2",
-      "label" : "Bericht",
+      "label" : "4128022-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-83.json
+++ b/etl/output/test-output-83.json
@@ -24,7 +24,7 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Wiedweg | Führer",
+    "label" : "Wiedweg | 4155569-7",
     "componentList" : [ {
       "id" : "http://rpb.lobid.org/sw/929n110124",
       "label" : "Wiedweg",
@@ -34,7 +34,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4155569-7",
-      "label" : "Führer",
+      "label" : "4155569-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-84.json
+++ b/etl/output/test-output-84.json
@@ -28,17 +28,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Laukhard, Friedrich Christian | Biografie",
+    "label" : "118726692 | 4006804-3",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/118726692",
-      "label" : "Laukhard, Friedrich Christian",
+      "label" : "118726692",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4006804-3",
-      "label" : "Biografie",
+      "label" : "4006804-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-85.json
+++ b/etl/output/test-output-85.json
@@ -36,24 +36,24 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Rheinsteig | Rhein-Burgen-Wanderweg | Wandern",
+    "label" : "7501137-2 | 7500776-9 | 4064532-0",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/7501137-2",
-      "label" : "Rheinsteig",
+      "label" : "7501137-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/7500776-9",
-      "label" : "Rhein-Burgen-Wanderweg",
+      "label" : "7500776-9",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4064532-0",
-      "label" : "Wandern",
+      "label" : "4064532-0",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -62,7 +62,7 @@
   } ],
   "spatial" : [ {
     "id" : "https://d-nb.info/gnd/4126432-0",
-    "label" : "Mittelrheintal",
+    "label" : "4126432-0",
     "type" : [ "PlaceOrGeographicName" ],
     "source" : {
       "id" : "https://d-nb.info/gnd/7749153-1",
@@ -72,7 +72,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/124591736",
-      "label" : "Böckling, Manfred",
+      "label" : "124591736",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-86.json
+++ b/etl/output/test-output-86.json
@@ -26,17 +26,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Freiwillige Feuerwehr Neuwied | Innenstadt | Geschichte 1867-2008",
+    "label" : "5094678-X | 4072821-3 | Geschichte 1867-2008",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/5094678nX",
-      "label" : "Freiwillige Feuerwehr Neuwied",
+      "label" : "5094678-X",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4072821-3",
-      "label" : "Innenstadt",
+      "label" : "4072821-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -51,17 +51,17 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Freiwillige Feuerwehr Neuwied | Stadtviertel | Geschichte 1600-2008",
+    "label" : "5094678-X | 4077814-9 | Geschichte 1600-2008",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/5094678nX",
-      "label" : "Freiwillige Feuerwehr Neuwied",
+      "label" : "5094678-X",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4077814-9",
-      "label" : "Stadtviertel",
+      "label" : "4077814-9",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -87,7 +87,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/132532336",
-      "label" : "Dietz, Wolfgang",
+      "label" : "132532336",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-88.json
+++ b/etl/output/test-output-88.json
@@ -24,7 +24,7 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Verein für Pfälzische Kirchengeschichte / Hauptversammlung / 1925 | Online-Ressource",
+    "label" : "Verein für Pfälzische Kirchengeschichte / Hauptversammlung / 1925 | 4511937-5",
     "componentList" : [ {
       "id" : "http://rpb.lobid.org/sw/00Sn01s167281807a",
       "label" : "Verein für Pfälzische Kirchengeschichte / Hauptversammlung / 1925",
@@ -35,7 +35,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-89.json
+++ b/etl/output/test-output-89.json
@@ -28,31 +28,31 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Mayen (Region) | Mühlstein | Steinbruch | Laacher See (Region) | Geschichte 1828",
+    "label" : "4038114-6 | 4327809-7 | 4057145-2 | 4033914-2 | Geschichte 1828",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4038114-6",
-      "label" : "Mayen (Region)",
+      "label" : "4038114-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4327809-7",
-      "label" : "Mühlstein",
+      "label" : "4327809-7",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4057145-2",
-      "label" : "Steinbruch",
+      "label" : "4057145-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4033914-2",
-      "label" : "Laacher See (Region)",
+      "label" : "4033914-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -68,7 +68,7 @@
   } ],
   "spatial" : [ {
     "id" : "https://d-nb.info/gnd/4038114-6",
-    "label" : "Mayen (Region)",
+    "label" : "4038114-6",
     "type" : [ "PlaceOrGeographicName" ],
     "source" : {
       "id" : "https://d-nb.info/gnd/7749153-1",

--- a/etl/output/test-output-9.json
+++ b/etl/output/test-output-9.json
@@ -28,31 +28,31 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Rheinland | Literatur | Anthologie | Online-Ressource",
+    "label" : "4049788-4 | 4035964-5 | 4002214-6 | 4511937-5",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4049788-4",
-      "label" : "Rheinland",
+      "label" : "4049788-4",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4035964-5",
-      "label" : "Literatur",
+      "label" : "4035964-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4002214-6",
-      "label" : "Anthologie",
+      "label" : "4002214-6",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4511937-5",
-      "label" : "Online-Ressource",
+      "label" : "4511937-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -82,7 +82,7 @@
   }, {
     "agent" : {
       "id" : "https://d-nb.info/gnd/119468808",
-      "label" : "White, Charles",
+      "label" : "119468808",
       "type" : [ "Person" ]
     },
     "role" : {

--- a/etl/output/test-output-90.json
+++ b/etl/output/test-output-90.json
@@ -135,7 +135,7 @@
   }, {
     "agent" : {
       "id" : "https://d-nb.info/gnd/5270920-6",
-      "label" : "Stiftung Stadt Wittlich",
+      "label" : "5270920-6",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-91.json
+++ b/etl/output/test-output-91.json
@@ -34,10 +34,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Bad Ems | Geschichte 1896 | Adressbuch",
+    "label" : "4014614-5 | Geschichte 1896 | 4141451-2",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/4014614-5",
-      "label" : "Bad Ems",
+      "label" : "4014614-5",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
@@ -51,7 +51,7 @@
       }
     }, {
       "id" : "https://d-nb.info/gnd/4141451-2",
-      "label" : "Adressbuch",
+      "label" : "4141451-2",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/output/test-output-95.json
+++ b/etl/output/test-output-95.json
@@ -18,7 +18,7 @@
   "contribution" : [ {
     "agent" : {
       "id" : "https://d-nb.info/gnd/4487276-8",
-      "label" : "Bonefeld",
+      "label" : "4487276-8",
       "type" : [ "CorporateBody" ]
     },
     "role" : {

--- a/etl/output/test-output-96.json
+++ b/etl/output/test-output-96.json
@@ -35,17 +35,17 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Wunderlich, Fritz | Biografie",
+    "label" : "11893869X | 4006804-3",
     "componentList" : [ {
       "id" : "https://d-nb.info/gnd/11893869X",
-      "label" : "Wunderlich, Fritz",
+      "label" : "11893869X",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"
       }
     }, {
       "id" : "https://d-nb.info/gnd/4006804-3",
-      "label" : "Biografie",
+      "label" : "4006804-3",
       "source" : {
         "id" : "https://d-nb.info/gnd/7749153-1",
         "label" : "Gemeinsame Normdatei (GND)"

--- a/etl/rpb-test-titel-to-lobid.flux
+++ b/etl/rpb-test-titel-to-lobid.flux
@@ -1,8 +1,10 @@
+default dynamicMapPath ="./maps/test/";
+
 FLUX_DIR + "output/test-output-strapi.json"
 | open-file
 | as-lines
 | decode-json
-| fix(FLUX_DIR + "rpb-titel-to-lobid.fix")
+| fix(FLUX_DIR + "rpb-titel-to-lobid.fix",*)
 | batch-reset(batchsize="1")
 | encode-json(prettyPrinting="true")
 | write(FLUX_DIR + "output/test-output-${i}.json")

--- a/etl/rpb-titel-single-strapi-to-lobid.flux
+++ b/etl/rpb-titel-single-strapi-to-lobid.flux
@@ -1,8 +1,10 @@
+default dynamicMapPath ="./maps/";
+
 FLUX_DIR + "output/single-strapi-to-lobid-input.json"
 | open-file
 | as-lines
 | decode-json
-| fix(FLUX_DIR + "rpb-titel-to-lobid.fix")
+| fix(FLUX_DIR + "rpb-titel-to-lobid.fix",*)
 | batch-reset(batchsize="1")
 | encode-json(prettyPrinting="true")
 | write(FLUX_DIR + "output/single-strapi-to-lobid-output.json")

--- a/etl/rpb-titel-to-lobid.fix
+++ b/etl/rpb-titel-to-lobid.fix
@@ -4,8 +4,8 @@ vacuum()
 
 #-------- maps --------
 do once("map")
-  put_rdfmap("https://raw.githubusercontent.com/hbz/lbz-vocabs/main/rpb-spatial.ttl", "spatial_map", target:"skos:prefLabel", select_language:"de")
-  put_rdfmap("https://raw.githubusercontent.com/hbz/lbz-vocabs/main/rpb.ttl", "subject_map", target:"skos:prefLabel", select_language:"de")
+  put_rdfmap("$[dynamicMapPath]rpb-spatial.ttl", "spatial_map", target:"skos:prefLabel", select_language:"de")
+  put_rdfmap("$[dynamicMapPath]rpb.ttl", "subject_map", target:"skos:prefLabel", select_language:"de")
 
   put_filemap("./RPB-Export_HBZ_SW.tsv", "sw-rpb_map", sep_char: "\t", allow_empty_values: "true", expected_columns:"3", key_column:"0", value_column:"1")
   put_filemap("./RPB-Export_HBZ_SW.tsv", "sw-rpb-variants_map", sep_char: "\t", allow_empty_values: "true", expected_columns:"3", key_column:"0", value_column:"2")

--- a/etl/rpb-titel-to-lobid.fix
+++ b/etl/rpb-titel-to-lobid.fix
@@ -9,7 +9,7 @@ do once("map")
 
   put_filemap("./RPB-Export_HBZ_SW.tsv", "sw-rpb_map", sep_char: "\t", allow_empty_values: "true", expected_columns:"3", key_column:"0", value_column:"1")
   put_filemap("./RPB-Export_HBZ_SW.tsv", "sw-rpb-variants_map", sep_char: "\t", allow_empty_values: "true", expected_columns:"3", key_column:"0", value_column:"2")
-  put_filemap("./maps/gndId-to-label.tsv", "sw-gnd_map", "sep_char": "\t")
+  put_filemap("$[dynamicMapPath]gndId-to-label.tsv", "sw-gnd_map", "sep_char": "\t")
 end
 
 do put_macro("move_here")

--- a/etl/rpb-titel-to-lobid.flux
+++ b/etl/rpb-titel-to-lobid.flux
@@ -1,10 +1,12 @@
 default outfile = "etl/output/bulk/bulk-${i}.ndjson";
 default index = "resources-rpb-test";
+default dynamicMapPath ="./maps/";
+
 "etl/output/output-strapi.ndjson"
 | open-file
 | as-lines
 | decode-json
-| fix(FLUX_DIR + "rpb-titel-to-lobid.fix")
+| fix(FLUX_DIR + "rpb-titel-to-lobid.fix",*)
 | batch-reset(batchsize="1000")
 | encode-json(prettyPrinting="false")
 | json-to-elasticsearch-bulk(idkey="id", type="resource", index=index)

--- a/etl/rppd-test-to-lobid.flux
+++ b/etl/rppd-test-to-lobid.flux
@@ -8,12 +8,13 @@
 
 default IN_FILE = "test-output-rppd.json"; // pass e.g. IN_FILE=test-rppd-export.json
 default RECORD_PATH = ""; // pass e.g. RECORD_PATH=data
+default dynamicMapPath ="./maps/test/";
 
 FLUX_DIR + "output/" + IN_FILE
 | open-file
 | as-lines
 | decode-json(recordPath=RECORD_PATH)
-| fix(FLUX_DIR + "rppd-to-lobid.fix")
+| fix(FLUX_DIR + "rppd-to-lobid.fix",*)
 | batch-reset(batchsize="1")
 | encode-json(prettyPrinting="true")
 | write(FLUX_DIR + "output/test-output-rppd-lobid-${i}.json")

--- a/etl/rppd-to-lobid.fix
+++ b/etl/rppd-to-lobid.fix
@@ -25,7 +25,7 @@ do once("map")
   put_filemap("./RPB-Export_HBZ_SW.tsv", "SW_variants-map", sep_char: "\t", allow_empty_values: "true", expected_columns:"3", key_column:"0", value_column:"2")
   put_filemap("etl/maps/gndId-to-label.tsv", "SW_GND_map", sep_char: "\t")
   put_filemap("etl/RPB-Export_HBZ_SWN.tsv", "SWN_map", sep_char: "\t")
-  put_rdfmap("https://raw.githubusercontent.com/hbz/lbz-vocabs/main/rpb-spatial.ttl", "spatial_map", target:"skos:prefLabel", select_language:"de")
+  put_rdfmap("$[dynamicMapPath]rpb-spatial.ttl", "spatial_map", target:"skos:prefLabel", select_language:"de")
   put_filemap("etl/maps/gndGeographicName.tsv", "gnd_spatial_map", key_column:"0", value_column:"1", sep_char: "\t", expected_columns:"2")
 
   # maps für lookup relatedPerson

--- a/etl/rppd-to-lobid.fix
+++ b/etl/rppd-to-lobid.fix
@@ -23,13 +23,13 @@ end
 do once("map")
   put_filemap("./RPB-Export_HBZ_SW.tsv", "SW_map", sep_char: "\t", allow_empty_values: "true", expected_columns:"3", key_column:"0", value_column:"1")
   put_filemap("./RPB-Export_HBZ_SW.tsv", "SW_variants-map", sep_char: "\t", allow_empty_values: "true", expected_columns:"3", key_column:"0", value_column:"2")
-  put_filemap("etl/maps/gndId-to-label.tsv", "SW_GND_map", sep_char: "\t")
+  put_filemap("$[dynamicMapPath]gndId-to-label.tsv", "SW_GND_map", sep_char: "\t")
   put_filemap("etl/RPB-Export_HBZ_SWN.tsv", "SWN_map", sep_char: "\t")
   put_rdfmap("$[dynamicMapPath]rpb-spatial.ttl", "spatial_map", target:"skos:prefLabel", select_language:"de")
   put_filemap("etl/maps/gndGeographicName.tsv", "gnd_spatial_map", key_column:"0", value_column:"1", sep_char: "\t", expected_columns:"2")
 
   # maps für lookup relatedPerson
-  put_filemap("etl/maps/gndId-to-label.tsv", "gnd_to_label",key_column:"0",value_column:"1", sep_char: "\t", expected_columns:"-1")
+  put_filemap("$[dynamicMapPath]gndId-to-label.tsv", "gnd_to_label",key_column:"0",value_column:"1", sep_char: "\t", expected_columns:"-1")
   put_filemap("etl/maps/rppdId-to-label.tsv", "rppd_to_label",key_column:"0",value_column:"1", sep_char: "\t", expected_columns:"-1")
 
   # maps für depiction

--- a/etl/rppd-to-lobid.flux
+++ b/etl/rppd-to-lobid.flux
@@ -9,11 +9,13 @@
 default IN_FILE = "output-rppd-strapi.ndjson"; // pass e.g. OUT_FILE=output-rppd-export.ndjson
 default RECORD_PATH = ""; // pass e.g. RECORD_PATH=data
 default OUT_FILE = "etl/output/bulk/rppd/bulk-rppd-${i}.jsonl"; // lobid-gnd expects *.jsonl suffix
+default dynamicMapPath ="./maps/";
+
 "etl/output/" + IN_FILE
 | open-file
 | as-lines
 | decode-json(recordPath=RECORD_PATH)
-| fix(FLUX_DIR + "rppd-to-lobid.fix")
+| fix(FLUX_DIR + "rppd-to-lobid.fix",*)
 | batch-reset(batchsize="1000")
 | encode-json(prettyPrinting="false")
 | json-to-elasticsearch-bulk(idkey="id", type="authority", index="gnd-rppd-test")

--- a/etl/test-export-compare-rppd.flux
+++ b/etl/test-export-compare-rppd.flux
@@ -3,6 +3,8 @@
 
 // sbt "runMain rpb.ETL etl/rppd-to-strapi.flux IN_FILE=RPB-Export_HBZ_Bio_Test.txt OUT_FILE=test-output-rppd.json"
 // sbt -mem 2048 "runMain rpb.ETL etl/test-export-compare-rppd.flux"
+default dynamicMapPath ="./maps/test/";
+
 FLUX_DIR + "output/test-output-rppd.json"
 | open-file
 | as-lines
@@ -16,7 +18,7 @@ retain(rppdId)
 | open-http
 | as-records
 | decode-json(recordPath="data.[*].attributes")
-| fix(FLUX_DIR + "rppd-to-lobid.fix")
+| fix(FLUX_DIR + "rppd-to-lobid.fix",*)
 | encode-json
 | write(FLUX_DIR + "output/test-rppd-output-from-strapi.json")
 ;
@@ -26,7 +28,7 @@ FLUX_DIR + "output/test-output-rppd.json"
 | open-file
 | as-lines
 | decode-json
-| fix(FLUX_DIR + "rppd-to-lobid.fix")
+| fix(FLUX_DIR + "rppd-to-lobid.fix",*)
 | encode-json
 | write(FLUX_DIR + "output/test-rppd-output-from-file.json")
 ;

--- a/etl/test-export-compare-strapi.flux
+++ b/etl/test-export-compare-strapi.flux
@@ -1,3 +1,5 @@
+default dynamicMapPath ="./maps/test/";
+
 // Get test data for the specified type; for each record,
 // fetch the entry from Strapi, convert that to lobid, write.
 FLUX_DIR + "output/test-output-strapi.json"
@@ -16,7 +18,7 @@ retain(f00_)
 | open-http
 | as-records
 | decode-json(recordPath="data.[*].attributes")
-| fix(FLUX_DIR + "rpb-titel-to-lobid.fix")
+| fix(FLUX_DIR + "rpb-titel-to-lobid.fix",*)
 | encode-json
 | write(FLUX_DIR + "output/test-lobid-output-from-strapi.json")
 ;
@@ -31,7 +33,7 @@ unless " + PICK + "
   reject()
 end
 ")
-| fix(FLUX_DIR + "rpb-titel-to-lobid.fix")
+| fix(FLUX_DIR + "rpb-titel-to-lobid.fix",*)
 | encode-json
 | write(FLUX_DIR + "output/test-lobid-output-from-file.json")
 ;

--- a/etl/test-export-strapi-to-lobid.flux
+++ b/etl/test-export-strapi-to-lobid.flux
@@ -1,8 +1,10 @@
+default dynamicMapPath ="./maps/test/";
+
 "https://rpb-cms-test.lobid.org/api/articles?populate=*&pagination[pageSize]=5"
 | open-http
 | as-records
 | decode-json(recordPath="data.[*].attributes")
-| fix(FLUX_DIR + "rpb-titel-to-lobid.fix")
+| fix(FLUX_DIR + "rpb-titel-to-lobid.fix",*)
 | batch-reset(batchsize="1")
 | encode-json(prettyPrinting="true")
 | write(FLUX_DIR + "output/test-strapi-to-lobid-output-${i}.json")


### PR DESCRIPTION
See RPB-267

This allows for a local static version of the lookups for tests and for dynamic version for production.

This mechanism is used for rpb.ttl, rpb-spatial.ttl and gndId-to-label.tsv