### PR TITLE
Filter GND mapping to only include IDs used in RPB & RPPD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ bin
 .settings/org.eclipse.core.resources.prefs
 .settings/org.scala-ide.sdt.core.prefs
 /etl/maps/beacons/*.tsv
-/etl/maps/gndId-to-label.tsv
+/etl/maps/gndId-to-label.tsv*
 /etl/output/*
 !/etl/output/test*.json
 !/etl/output/rpb-50*

--- a/etl/map-gnd-to-label.flux
+++ b/etl/map-gnd-to-label.flux
@@ -4,5 +4,5 @@
 | decode-json
 | fix("retain(gndIdentifier, preferredName)")
 | encode-csv(includeHeader="true", noQuotes="true", separator="\t")
-| write(FLUX_DIR + "maps/gndId-to-label.tsv")
+| write(FLUX_DIR + "maps/gndId-to-label.tsv.all")
 ;

--- a/filterGndMapping.sh
+++ b/filterGndMapping.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# The data to be filtered
+output="etl/maps/gndId-to-label.tsv"
+tsv="${output}.all"
+
+# The RPB and RPPD data files to search for GND IDs
+data_files=(
+  "etl/output/rppd-export.jsonl"
+  "etl/output/output-strapi.ndjson"
+  "etl/output/output-strapi-external.ndjson"
+)
+
+# See https://www.wikidata.org/wiki/Property:P227
+# adapted to handle both `-` and `n` (used in RPB)
+gnd_regex='1[0123]?[0-9]{7}[0-9X]|[47][0-9]{6}[n-][0-9]|[1-9][0-9]{0,7}[n-][0-9X]|3[0-9]{7}[0-9X]'
+
+# Extract GND IDs used in current RPB and RPPD data
+ids_file=$(mktemp)
+for file in "${data_files[@]}"; do
+  egrep -o "$gnd_regex" "$file"
+done | sort -u > "$ids_file"
+
+# Add IDs with '-' replaced by 'n'
+awk '{print; gsub("-", "n"); print}' "$ids_file" | sort -u > "${ids_file}.all"
+
+# Filter TSV: build `ids` set from IDs file, print TSV lines where $1 (GND ID) is in `ids`
+awk -F'\t' 'NR==FNR{ids[$1]; next} ($1 in ids){print}' "${ids_file}.all" "$tsv" > "$output"
+
+# Clean up IDs files
+rm "$ids_file" "${ids_file}.all"

--- a/transformExternalData.sh
+++ b/transformExternalData.sh
@@ -5,6 +5,7 @@ export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 # Full GND via lobid-gnd bulk API, used for labels in RPB and RPPD:
 sbt --java-home $JAVA_HOME "runMain rpb.ETL etl/map-gnd-to-label.flux"
+bash filterGndMapping.sh # Filter GND mapping to only include IDs used in RPB and RPPD
 
 # Individual beacon files, used for sameAs links in RPPD:
 sbt --java-home $JAVA_HOME "runMain rpb.ETL etl/rppd-beacon-to-tsv.flux IN=https://persondata.toolforge.org/beacon/dewiki.txt OUT=etl/maps/beacons/gndId-to-dewiki.tsv"


### PR DESCRIPTION
To reduce memory usage. See https://jira.hbz-nrw.de/browse/RPB-303.