### PR TITLE
Add support for ordering holdings

### DIFF
--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -804,4 +804,13 @@ public class Lobid {
 		return Integer.parseInt(s.replaceAll("\\D", "9"));
 	}
 
+	public static String[] emailAndItem(String id, String doc) {
+		JsonNode resource = id.startsWith("http") ? cachedJsonCall(id) : Json.parse(doc);
+		String item = resource.get("hasItem").elements().next().toString();
+		String ownerId = Json.parse(item).get("heldBy").get("id").asText();
+		JsonNode organisation = cachedJsonCall(ownerId);
+		Optional<String> email = Optional.ofNullable(organisation.findValue("email")).map(JsonNode::asText);
+		return new String[] { email.orElse(ownerId), item };
+	}
+
 }

--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -837,8 +837,9 @@ public class Lobid {
 	}
 
 	private static String titleDetails(JsonNode resourceToOrder) {
-		String titleDetails = String.format("%s (https://rpb.lbz-rlp.de/%s)", resourceToOrder.get("title").asText(),
-				resourceToOrder.get("rpbId").asText());
+		String baseUrl = Application.CONFIG.getString("host");
+		String fullUrl = String.format("%s/%s", baseUrl, resourceToOrder.get("rpbId").asText());
+		String titleDetails = String.format("%s (%s)", resourceToOrder.get("title").asText(), fullUrl);
 		return appendOptional(titleDetails, resourceToOrder, "Quelle", "bibliographicCitation");
 	}
 

--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -804,13 +804,34 @@ public class Lobid {
 		return Integer.parseInt(s.replaceAll("\\D", "9"));
 	}
 
-	public static String[] emailAndItem(String id, String doc) {
-		JsonNode resource = id.startsWith("http") ? cachedJsonCall(id) : Json.parse(doc);
-		String item = resource.get("hasItem").elements().next().toString();
-		String ownerId = Json.parse(item).get("heldBy").get("id").asText();
+	public static String[] emailAndDetails(String doc) {
+		JsonNode resourceToOrder = Json.parse(doc);
+		JsonNode containedIn = resourceToOrder.get("containedIn");
+		JsonNode resourceWithItem = containedIn != null
+				? cachedJsonCall(containedIn.elements().next().get("id").asText())
+				: resourceToOrder;
+		JsonNode item = resourceWithItem.get("hasItem").elements().next();
+		String ownerId = item.get("heldBy").get("id").asText();
 		JsonNode organisation = cachedJsonCall(ownerId);
 		Optional<String> email = Optional.ofNullable(organisation.findValue("email")).map(JsonNode::asText);
-		return new String[] { email.orElse(ownerId), item };
+		return new String[] { email.orElse(ownerId), titleDetails(resourceToOrder), itemDetails(item) };
+	}
+
+	private static String titleDetails(JsonNode resourceToOrder) {
+		String titleDetails = String.format("%s (https://rpb.lbz-rlp.de/%s)", resourceToOrder.get("title").asText(),
+				resourceToOrder.get("rpbId").asText());
+		return appendOptional(titleDetails, resourceToOrder, "Quelle", "bibliographicCitation");
+	}
+
+	private static String itemDetails(JsonNode item) {
+		String itemDetails = String.format("Signatur: %s (%s)", item.get("callNumber").asText(),
+				item.get("id").asText());
+		return appendOptional(itemDetails, item, "Erscheinungsverlauf", "enumerationAndChronology");
+	}
+
+	private static String appendOptional(String itemDetails, JsonNode item, String label, String field) {
+		return item.has(field) ? itemDetails += String.format("\n%s: %s", label, item.get(field).asText())
+				: itemDetails;
 	}
 
 }

--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -82,7 +82,7 @@ public class Lobid {
 			return json;
 		}
 		Logger.debug("Not cached, GET: {}", url);
-		Promise<JsonNode> promise = WS.url(url).get()
+		Promise<JsonNode> promise = WS.url(url).setQueryParameter("format", "json").get()
 				.map(response -> response.getStatus() == Http.Status.OK
 						? response.asJson()
 						: Json.newObject());

--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -17,12 +17,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
 import com.google.common.html.HtmlEscapers;
 import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
@@ -810,11 +812,17 @@ public class Lobid {
 		JsonNode resourceWithItem = containedIn != null
 				? cachedJsonCall(containedIn.elements().next().get("id").asText())
 				: resourceToOrder;
-		JsonNode item = resourceWithItem.get("hasItem").elements().next();
+		JsonNode item = findRpbItem(resourceWithItem);
 		String ownerId = item.get("heldBy").get("id").asText();
 		JsonNode organisation = cachedJsonCall(ownerId);
 		Optional<String> email = Optional.ofNullable(organisation.findValue("email")).map(JsonNode::asText);
 		return new String[] { email.orElse(ownerId), titleDetails(resourceToOrder), itemDetails(item) };
+	}
+
+	private static JsonNode findRpbItem(JsonNode resourceWithItem) {
+		List<String> rpbIsils = Arrays.asList("DE-929", "DE-107", "DE-Zw1", "DE-121", "DE-36");
+		Stream<JsonNode> items = Streams.stream(resourceWithItem.get("hasItem").elements());
+		return items.filter(item -> rpbIsils.contains(item.get("heldBy").get("isil").asText())).findFirst().get();
 	}
 
 	private static String titleDetails(JsonNode resourceToOrder) {

--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -809,20 +810,30 @@ public class Lobid {
 	public static String[] emailAndDetails(String doc) {
 		JsonNode resourceToOrder = Json.parse(doc);
 		JsonNode containedIn = resourceToOrder.get("containedIn");
-		JsonNode resourceWithItem = containedIn != null
-				? cachedJsonCall(containedIn.elements().next().get("id").asText())
-				: resourceToOrder;
-		JsonNode item = findRpbItem(resourceWithItem);
-		String ownerId = item.get("heldBy").get("id").asText();
-		JsonNode organisation = cachedJsonCall(ownerId);
-		Optional<String> email = Optional.ofNullable(organisation.findValue("email")).map(JsonNode::asText);
-		return new String[] { email.orElse(ownerId), titleDetails(resourceToOrder), itemDetails(item) };
+		JsonNode resourceWithItem = containedIn == null ? resourceToOrder
+				: cachedJsonCall(containedIn.elements().next().get("id").asText());
+		JsonNode item = findRpbItem(resourceWithItem.get("hasItem"));
+		return new String[] { email(item), titleDetails(resourceToOrder), itemDetails(item) };
 	}
 
-	private static JsonNode findRpbItem(JsonNode resourceWithItem) {
+	private static JsonNode findRpbItem(JsonNode itemsNode) {
+		if (itemsNode == null) {
+			return null;
+		}
 		List<String> rpbIsils = Arrays.asList("DE-929", "DE-107", "DE-Zw1", "DE-121", "DE-36");
-		Stream<JsonNode> items = Streams.stream(resourceWithItem.get("hasItem").elements());
-		return items.filter(item -> rpbIsils.contains(item.get("heldBy").get("isil").asText())).findFirst().get();
+		Stream<JsonNode> items = Streams.stream(itemsNode.elements());
+		Function<String, String> isilFromUri = uri -> uri.replaceAll("https?://lobid.org/organisations/(.+)#!", "$1");
+		return items.filter(item -> rpbIsils.contains(isilFromUri.apply(item.get("heldBy").get("id").asText())))
+				.findFirst().orElse(null);
+	}
+
+	private static String email(JsonNode itemNode) {
+		if (itemNode == null) {
+			return null;
+		}
+		JsonNode organisation = cachedJsonCall(itemNode.get("heldBy").get("id").asText());
+		Optional<String> email = Optional.ofNullable(organisation.findValue("email")).map(JsonNode::asText);
+		return email.orElse(null);
 	}
 
 	private static String titleDetails(JsonNode resourceToOrder) {
@@ -832,6 +843,9 @@ public class Lobid {
 	}
 
 	private static String itemDetails(JsonNode item) {
+		if (item == null || !item.has("callNumber")) {
+			return null;
+		}
 		String itemDetails = String.format("Signatur: %s (%s)", item.get("callNumber").asText(),
 				item.get("id").asText());
 		return appendOptional(itemDetails, item, "Erscheinungsverlauf", "enumerationAndChronology");

--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -809,10 +809,7 @@ public class Lobid {
 
 	public static String[] emailAndDetails(String doc) {
 		JsonNode resourceToOrder = Json.parse(doc);
-		JsonNode containedIn = resourceToOrder.get("containedIn");
-		JsonNode resourceWithItem = containedIn == null ? resourceToOrder
-				: cachedJsonCall(containedIn.elements().next().get("id").asText());
-		JsonNode item = findRpbItem(resourceWithItem.get("hasItem"));
+		JsonNode item = findRpbItem(resourceToOrder.get("hasItem"));
 		return new String[] { email(item), titleDetails(resourceToOrder), itemDetails(item) };
 	}
 

--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -847,8 +847,8 @@ public class Lobid {
 		if (item == null || !item.has("callNumber")) {
 			return null;
 		}
-		String itemDetails = String.format("Signatur: %s (%s)", item.get("callNumber").asText(),
-				item.get("id").asText());
+		String itemDetails = String.format("Signatur: %s (interne ID: %s)", item.get("callNumber").asText(),
+				item.get("id").asText().replace("http://rpb.lobid.org/items/", "").replace("#!", ""));
 		return appendOptional(itemDetails, item, "Erscheinungsverlauf", "enumerationAndChronology");
 	}
 

--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -833,7 +833,12 @@ public class Lobid {
 				"DE-107", "fernleihe.plb@lbz.rlp.de", //
 				"DE-36", "stb.rpb@stadt.mainz.de", //
 				"DE-121", "fernleiheweba@trier.de") //
-				.get(itemNode.get("heldBy").get("isil").asText());
+				.get(getIsil(itemNode));
+	}
+
+	private static String getIsil(JsonNode itemNode) {
+		String[] segments = itemNode.get("heldBy").get("id").asText().split("/");
+		return segments[segments.length-1].replace("#!", "");
 	}
 
 	private static String titleDetails(JsonNode resourceToOrder) {

--- a/app/controllers/rpb/Lobid.java
+++ b/app/controllers/rpb/Lobid.java
@@ -828,9 +828,12 @@ public class Lobid {
 		if (itemNode == null) {
 			return null;
 		}
-		JsonNode organisation = cachedJsonCall(itemNode.get("heldBy").get("id").asText());
-		Optional<String> email = Optional.ofNullable(organisation.findValue("email")).map(JsonNode::asText);
-		return email.orElse(null);
+		return ImmutableMap.of(//
+				"DE-929", "info.rlb@lbz-rlp.de", //
+				"DE-107", "fernleihe.plb@lbz.rlp.de", //
+				"DE-36", "stb.rpb@stadt.mainz.de", //
+				"DE-121", "fernleiheweba@trier.de") //
+				.get(itemNode.get("heldBy").get("isil").asText());
 	}
 
 	private static String titleDetails(JsonNode resourceToOrder) {

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -108,8 +108,8 @@ Mit freundlichen Grüßen
         }
       }
       <div class="row" id="title-details">
-      @defining((Lobid.items(doc.toString), Lobid.itemDetails(doc.toString))) { case (items, itemDetails) =>
-        @defining(items.isEmpty && !(doc\\"containedIn").isEmpty && (doc\"type").toString.contains("Article")){superordination =>
+      @defining((Lobid.items(doc.toString), Lobid.itemDetails(doc.toString), (doc\"type").toString.contains("Article"))) { case (items, itemDetails, isArticle) =>
+        @defining(items.isEmpty && !(doc\\"containedIn").isEmpty && isArticle){superordination =>
           <div class="col-md-@if(items.isEmpty && !doc.toString.contains("fulltextOnline") && !superordination){12} else {8}">
             <dl>
             @defining((doc\"rpbId").asOpt[String].getOrElse(q)){ id =>
@@ -159,7 +159,7 @@ Mit freundlichen Grüßen
              <dd>@tags.items_map(items, itemDetails)</dd>
             }
             </dl>
-            @for(emailAndDetails <- Seq(Lobid.emailAndDetails(doc.toString)) ; Array(_,_,itemDetails) = emailAndDetails ; if itemDetails) {
+            @for(emailAndDetails <- Seq(Lobid.emailAndDetails(doc.toString)) ; Array(_,_,itemDetails) = emailAndDetails ; if itemDetails && isArticle) {
             <div id="ordering">
               <div>
                 <a target="_blank" href="https://lbz.rlp.de/suche?tx_solr%5Bq%5D=kostentabelle">Kostentabelle für Titelbestellungen</a>

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -67,7 +67,7 @@
           }
         }
       }
-      <div class="row" id="search-results">
+      <div class="row" id="title-details">
       @defining((Lobid.items(doc.toString), Lobid.itemDetails(doc.toString))) { case (items, itemDetails) =>
         @defining(items.isEmpty && !(doc\\"containedIn").isEmpty && (doc\"type").toString.contains("Article")){superordination =>
           <div class="col-md-@if(items.isEmpty && !doc.toString.contains("fulltextOnline") && !superordination){12} else {8}">
@@ -119,6 +119,25 @@
              <dd>@tags.items_map(items, itemDetails)</dd>
             }
             </dl>
+            <div id="ordering">
+              <div>
+                <a href="">Kostentabelle für Titelbestellungen</a>
+              </div>
+              <div class="panel panel-primary rpb-footer">
+                <div class="panel-body">
+                  <a href="">
+                    Diesen Titel zu <b>kommerziellen</b> Zwecken<br/>
+                    <b>kostenpflichtig</b> (siehe Link oben) bestellen.</a>
+                </div>
+              </div>
+              <div class="panel panel-primary rpb-footer">
+                <div class="panel-body">
+                  <a href="">
+                    Diesen Titel zu <b>privaten</b> Zwecken<br/>
+                    <b>kostenpflichtig</b> (siehe Link oben) bestellen.</a>
+                </div>
+              </div>
+            </div>
           </div>
           }
         }

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -33,30 +33,26 @@
 	(json\"rpbId").asOpt[String].getOrElse((json\"id").asOpt[String].map(_.replaceAll("https?://lobid.org/resources/","").replaceAll("#!","")).getOrElse(""))
 }
 
-@orderingPanel(kind: String, id: String, doc: JsValue) = {
+@orderingPanel(kind: String, doc: JsValue) = {
   <div class="panel panel-primary rpb-footer">
     <div class="panel-body">
-      <a href='@mailtoOrdering(kind, id, doc)'>
+      <a href='@mailtoOrdering(kind, doc)'>
         Diesen Titel zu <b>@kind</b> Zwecken<br/>
         <b>kostenpflichtig</b> (siehe Link oben) bestellen.</a>
     </div>
   </div>
 }
 
-@mailtoOrdering(kind: String, id: String, doc: JsValue) = @{
-  val Array(email, item) = Lobid.emailAndItem(id, doc.toString)
-  val itemJson = Json.parse(item)
-  val subject = urlEncode("Bestellung: " + id).replace('+', ' ')
+@mailtoOrdering(kind: String, doc: JsValue) = @{
+  val Array(email, titleDetails, itemDetails) = Lobid.emailAndDetails(doc.toString)
+  val subject = urlEncode("Bestellung: " + (doc \ "rpbId").as[String]).replace('+', ' ')
   val body = urlEncode(s"""Guten Tag,
 
 ich würde gerne zu $kind Zwecken folgenden Titel bestellen:
 
-${(doc \ "title").as[String]}
-Titel-ID: $id
+$titleDetails
 
-Signatur: ${(itemJson\"callNumber").asOpt[String].getOrElse("--")}
-Erscheinungsverlauf: ${(itemJson\"enumerationAndChronology").asOpt[String].getOrElse("--")}
-Bestands-ID: ${(itemJson\"id").as[String]}
+$itemDetails
 
 Mit freundlichen Grüßen
 
@@ -151,16 +147,14 @@ Mit freundlichen Grüßen
              <dd>@tags.items_map(items, itemDetails)</dd>
             }
             </dl>
-            @if(!doc.toString.contains("fulltextOnline")){
-              @defining(if(superordination){((doc\"containedIn").as[Seq[JsValue]].head\"id").as[String]} else {(doc\"rpbId").as[String]}) { id =>
+            @if(!doc.toString.contains("fulltextOnline") && (superordination || doc.toString.contains("callNumber"))){
               <div id="ordering">
                 <div>
                   <a target="_blank" href="https://lbz.rlp.de/suche?tx_solr%5Bq%5D=kostentabelle">Kostentabelle für Titelbestellungen</a>
                 </div>
-                @orderingPanel("kommerziellen", id, doc)
-                @orderingPanel("privaten", id, doc)
+                @orderingPanel("kommerziellen", doc)
+                @orderingPanel("privaten", doc)
               </div>
-              }
             }
           </div>
           }

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -54,6 +54,18 @@ $titleDetails
 
 $itemDetails
 
+Kontaktdaten (bitte ergänzen):
+
+Name, Vorname:
+
+Straße, Hausnummer:
+
+Postleitzahl:
+
+Ort:
+
+Land (bei Ausland):
+
 Mit freundlichen Grüßen
 
 """).replace('+', ' ')

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -33,18 +33,18 @@
 	(json\"rpbId").asOpt[String].getOrElse((json\"id").asOpt[String].map(_.replaceAll("https?://lobid.org/resources/","").replaceAll("#!","")).getOrElse(""))
 }
 
-@orderingPanel(kind: String, doc: JsValue) = {
+@orderingPanel(kind: String, doc: JsValue, emailAndDetails: Array[String]) = {
   <div class="panel panel-primary rpb-footer">
     <div class="panel-body">
-      <a href='@mailtoOrdering(kind, doc)'>
+      <a href='@mailtoOrdering(kind, doc, emailAndDetails)'>
         Diesen Titel zu <b>@kind</b> Zwecken<br/>
         <b>kostenpflichtig</b> (siehe Link oben) bestellen.</a>
     </div>
   </div>
 }
 
-@mailtoOrdering(kind: String, doc: JsValue) = @{
-  val Array(email, titleDetails, itemDetails) = Lobid.emailAndDetails(doc.toString)
+@mailtoOrdering(kind: String, doc: JsValue, emailAndDetails: Array[String]) = @{
+  val Array(email, titleDetails, itemDetails) = emailAndDetails
   val subject = urlEncode("Bestellung: " + (doc \ "rpbId").as[String]).replace('+', ' ')
   val body = urlEncode(s"""Guten Tag,
 
@@ -147,14 +147,14 @@ Mit freundlichen Grüßen
              <dd>@tags.items_map(items, itemDetails)</dd>
             }
             </dl>
-            @if(!doc.toString.contains("fulltextOnline") && (superordination || doc.toString.contains("callNumber"))){
-              <div id="ordering">
-                <div>
-                  <a target="_blank" href="https://lbz.rlp.de/suche?tx_solr%5Bq%5D=kostentabelle">Kostentabelle für Titelbestellungen</a>
-                </div>
-                @orderingPanel("kommerziellen", doc)
-                @orderingPanel("privaten", doc)
+            @for(emailAndDetails <- Seq(Lobid.emailAndDetails(doc.toString)) ; Array(_,_,itemDetails) = emailAndDetails ; if itemDetails) {
+            <div id="ordering">
+              <div>
+                <a target="_blank" href="https://lbz.rlp.de/suche?tx_solr%5Bq%5D=kostentabelle">Kostentabelle für Titelbestellungen</a>
               </div>
+              @orderingPanel("kommerziellen", doc, emailAndDetails)
+              @orderingPanel("privaten", doc, emailAndDetails)
+            </div>
             }
           </div>
           }

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -11,6 +11,7 @@
 @import play.api.libs.json.JsValue
 @import play.api.libs.json.JsArray
 @import play.mvc.Controller.session
+@import play.api.libs.json.jackson.JacksonJson
 @import play.cache.Cache
 
 @idAndLabelLink(e: JsValue) = {
@@ -30,6 +31,37 @@
 
 @shortId(json: JsValue) = @{
 	(json\"rpbId").asOpt[String].getOrElse((json\"id").asOpt[String].map(_.replaceAll("https?://lobid.org/resources/","").replaceAll("#!","")).getOrElse(""))
+}
+
+@orderingPanel(kind: String, id: String, doc: JsValue) = {
+  <div class="panel panel-primary rpb-footer">
+    <div class="panel-body">
+      <a href='@mailtoOrdering(kind, id, doc)'>
+        Diesen Titel zu <b>@kind</b> Zwecken<br/>
+        <b>kostenpflichtig</b> (siehe Link oben) bestellen.</a>
+    </div>
+  </div>
+}
+
+@mailtoOrdering(kind: String, id: String, doc: JsValue) = @{
+  val Array(email, item) = Lobid.emailAndItem(id, doc.toString)
+  val itemJson = Json.parse(item)
+  val subject = urlEncode("Bestellung: " + id).replace('+', ' ')
+  val body = urlEncode(s"""Guten Tag,
+
+ich würde gerne zu $kind Zwecken folgenden Titel bestellen:
+
+${(doc \ "title").as[String]}
+Titel-ID: $id
+
+Signatur: ${(itemJson\"callNumber").asOpt[String].getOrElse("--")}
+Erscheinungsverlauf: ${(itemJson\"enumerationAndChronology").asOpt[String].getOrElse("--")}
+Bestands-ID: ${(itemJson\"id").as[String]}
+
+Mit freundlichen Grüßen
+
+""").replace('+', ' ')
+  s"mailto:$email?cc=lobid-admin@hbz-nrw.de&subject=$subject&body=$body"
 }
 
 @if(docJson.isEmpty){
@@ -119,25 +151,17 @@
              <dd>@tags.items_map(items, itemDetails)</dd>
             }
             </dl>
-            <div id="ordering">
-              <div>
-                <a href="">Kostentabelle für Titelbestellungen</a>
-              </div>
-              <div class="panel panel-primary rpb-footer">
-                <div class="panel-body">
-                  <a href="">
-                    Diesen Titel zu <b>kommerziellen</b> Zwecken<br/>
-                    <b>kostenpflichtig</b> (siehe Link oben) bestellen.</a>
+            @if(!doc.toString.contains("fulltextOnline")){
+              @defining(if(superordination){((doc\"containedIn").as[Seq[JsValue]].head\"id").as[String]} else {(doc\"rpbId").as[String]}) { id =>
+              <div id="ordering">
+                <div>
+                  <a target="_blank" href="https://lbz.rlp.de/suche?tx_solr%5Bq%5D=kostentabelle">Kostentabelle für Titelbestellungen</a>
                 </div>
+                @orderingPanel("kommerziellen", id, doc)
+                @orderingPanel("privaten", id, doc)
               </div>
-              <div class="panel panel-primary rpb-footer">
-                <div class="panel-body">
-                  <a href="">
-                    Diesen Titel zu <b>privaten</b> Zwecken<br/>
-                    <b>kostenpflichtig</b> (siehe Link oben) bestellen.</a>
-                </div>
-              </div>
-            </div>
+              }
+            }
           </div>
           }
         }

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -46,6 +46,7 @@
 @mailtoOrdering(kind: String, doc: JsValue, emailAndDetails: Array[String]) = @{
   val Array(email, titleDetails, itemDetails) = emailAndDetails
   val subject = urlEncode("Bestellung: " + (doc \ "rpbId").as[String]).replace('+', ' ')
+  val contact = if(kind=="privaten") "Name, Vorname:" else "Firma / Institution:\n\nAnsprechpartner (Name, Vorname):"
   val body = urlEncode(s"""Guten Tag,
 
 ich würde gerne zu $kind Zwecken folgenden Titel bestellen:
@@ -56,7 +57,7 @@ $itemDetails
 
 Kontaktdaten (bitte ergänzen):
 
-Name, Vorname:
+$contact
 
 Straße, Hausnummer:
 

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -137,7 +137,7 @@ Mit freundlichen Grüßen
             </table>
             </dd>
             }
-            @if(superordination){
+            @if(superordination && items.isEmpty){
             <dt>Bestandsangaben:</dt>
             <dd>
             <table class="table table-striped table-condensed">

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -162,7 +162,9 @@ Mit freundlichen Grüßen
             @for(emailAndDetails <- Seq(Lobid.emailAndDetails(doc.toString)) ; Array(_,_,itemDetails) = emailAndDetails ; if itemDetails && isArticle) {
             <div id="ordering">
               <div>
-                <a target="_blank" href="https://lbz.rlp.de/suche?tx_solr%5Bq%5D=kostentabelle">Kostentabelle für Titelbestellungen</a>
+                <a target="_blank" href="https://lbz.rlp.de/landeskunde-und-kulturgut/landeskunde/rheinland-pfaelzische-bibliographie-infotext#c131809">
+                  Kostenübersicht für Bestellungen
+                </a>
               </div>
               @orderingPanel("kommerziellen", doc, emailAndDetails)
               @orderingPanel("privaten", doc, emailAndDetails)

--- a/conf/rpb.conf
+++ b/conf/rpb.conf
@@ -1,5 +1,5 @@
-rpb.api="http://quaoar1:1990/resources/search"
-indexUrlFormat="http://quaoar1:1990/resources/search?q=rpbId:%s&format=json"
+rpb.api="http://rpb1:1990/resources/search"
+indexUrlFormat="http://rpb1:1990/resources/search?q=rpbId:%s&format=json"
 item.api="http://lobid.org/items"
 hbz01.api="http://lobid.org/hbz01"
 orgs.api="http://lobid.org/organisations"

--- a/etl/output/test-output-10.json
+++ b/etl/output/test-output-10.json
@@ -26,5 +26,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimat am Mittelrhein. - 8 (1963), Nr. 6"
+  "bibliographicCitation" : "Heimat am Mittelrhein. - 8 (1963), Nr. 6",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121512:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-11.json
+++ b/etl/output/test-output-11.json
@@ -26,5 +26,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimat am Mittelrhein. - 2 (1957), Nr. 6"
+  "bibliographicCitation" : "Heimat am Mittelrhein. - 2 (1957), Nr. 6",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121513:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-12.json
+++ b/etl/output/test-output-12.json
@@ -26,5 +26,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimat am Mittelrhein. - 3 (1958), Nr. 11"
+  "bibliographicCitation" : "Heimat am Mittelrhein. - 3 (1958), Nr. 11",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121514:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-13.json
+++ b/etl/output/test-output-13.json
@@ -26,5 +26,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimat am Mittelrhein. - 8 (1963), Nr. 1"
+  "bibliographicCitation" : "Heimat am Mittelrhein. - 8 (1963), Nr. 1",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121515:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-14.json
+++ b/etl/output/test-output-14.json
@@ -35,5 +35,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Landkreis Bingen: Heimat-Jahrbuch. - 1967, S. 23-26"
+  "bibliographicCitation" : "Landkreis Bingen: Heimat-Jahrbuch. - 1967, S. 23-26",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 29/1077,1967",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121516:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-15.json
+++ b/etl/output/test-output-15.json
@@ -26,5 +26,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimat am Mittelrhein. - 4 (1959), Nr. 1"
+  "bibliographicCitation" : "Heimat am Mittelrhein. - 4 (1959), Nr. 1",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 25:2°/2,1959",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121517:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-16.json
+++ b/etl/output/test-output-16.json
@@ -26,5 +26,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimat am Mittelrhein. - 10 (1965), Nr. 2 und Heimat am Mittelrhein 1965, S. 10"
+  "bibliographicCitation" : "Heimat am Mittelrhein. - 10 (1965), Nr. 2 und Heimat am Mittelrhein 1965, S. 10",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 25:2°/2,1965",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121518:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-17.json
+++ b/etl/output/test-output-17.json
@@ -26,5 +26,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimat am Mittelrhein. - 8 (1963), Nr. 12"
+  "bibliographicCitation" : "Heimat am Mittelrhein. - 8 (1963), Nr. 12",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121519:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-18.json
+++ b/etl/output/test-output-18.json
@@ -26,5 +26,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimat am Mittelrhein. - 1983, H. 2"
+  "bibliographicCitation" : "Heimat am Mittelrhein. - 1983, H. 2",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 25:2°/2,1983",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121520:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-19.json
+++ b/etl/output/test-output-19.json
@@ -26,5 +26,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimat am Mittelrhein. - 2 (1957), Nr. 12"
+  "bibliographicCitation" : "Heimat am Mittelrhein. - 2 (1957), Nr. 12",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0121521:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-20.json
+++ b/etl/output/test-output-20.json
@@ -73,5 +73,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Archiv für mittelrheinische Kirchengeschichte. - 36 (1984), S. 47-63"
+  "bibliographicCitation" : "Archiv für mittelrheinische Kirchengeschichte. - 36 (1984), S. 47-63",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 2823/36.1984;Per. 2792/36.1984 HBL",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147869:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-21.json
+++ b/etl/output/test-output-21.json
@@ -71,5 +71,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Historischer Verein der Pfalz: Mitteilungen des Historischen Vereins der Pfalz. - 81 (1983), S. 229-271"
+  "bibliographicCitation" : "Historischer Verein der Pfalz: Mitteilungen des Historischen Vereins der Pfalz. - 81 (1983), S. 229-271",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "HV 522/81.1983 HbL;B 1100/81.1983;BM 31/81.1983;25.3291/81.1983;Palat. 743/81.1983",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147870:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-22.json
+++ b/etl/output/test-output-22.json
@@ -46,5 +46,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Pfälzer Heimat. - 34 (1983), S. 156-167"
+  "bibliographicCitation" : "Pfälzer Heimat. - 34 (1983), S. 156-167",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Palat. 1540/34.1983;Palat. 1229/34.1983 HBL;Palat. 1230/34.1983",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147871:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-23.json
+++ b/etl/output/test-output-23.json
@@ -73,5 +73,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "In: Landkreis Südliche Weinstraße: Heimat-Jahrbuch .... - 5 (1983), Seite 29-36. -"
+  "bibliographicCitation" : "In: Landkreis Südliche Weinstraße: Heimat-Jahrbuch .... - 5 (1983), Seite 29-36. -",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 9476/5.1983",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147872:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-24.json
+++ b/etl/output/test-output-24.json
@@ -64,5 +64,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Ärzteblatt Rheinland-Pfalz. 35. 1982, 560, 563-65"
+  "bibliographicCitation" : "Ärzteblatt Rheinland-Pfalz. 35. 1982, 560, 563-65",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147873:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-25.json
+++ b/etl/output/test-output-25.json
@@ -64,5 +64,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Historischer Verein der Pfalz: Mitteilungen des Historischen Vereins der Pfalz. - 80 (1982), S. 199-240"
+  "bibliographicCitation" : "Historischer Verein der Pfalz: Mitteilungen des Historischen Vereins der Pfalz. - 80 (1982), S. 199-240",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "HV 522/80.1982 HbL;B 1100/80.1982;BM 31/80.1982;25.3291/80.1982;Palat. 743/80.1982",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147874:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-26.json
+++ b/etl/output/test-output-26.json
@@ -81,5 +81,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Stimme der Pfalz. - 32 (1981), 1, S. 9-11"
+  "bibliographicCitation" : "Stimme der Pfalz. - 32 (1981), 1, S. 9-11",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Palat. 1224/32.1981",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147875:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-27.json
+++ b/etl/output/test-output-27.json
@@ -61,5 +61,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "edition" : [ "Nachdr. der Original-Ausg." ]
+  "edition" : [ "Nachdr. der Original-Ausg." ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147876:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-28.json
+++ b/etl/output/test-output-28.json
@@ -44,5 +44,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Die Rheinpfalz <Ludwigshafen> / Mittelhaardter Rundschau v. 17.5.1982"
+  "bibliographicCitation" : "Die Rheinpfalz <Ludwigshafen> / Mittelhaardter Rundschau v. 17.5.1982",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147877:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-29.json
+++ b/etl/output/test-output-29.json
@@ -70,5 +70,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Die Pfalz am Rhein <Neustadt, Weinstraße>. - 55 (1982), S. 175-180"
+  "bibliographicCitation" : "Die Pfalz am Rhein <Neustadt, Weinstraße>. - 55 (1982), S. 175-180",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Palat. 24/55.1982;Palat. 25/55.1982/HBL",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01147878:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-30.json
+++ b/etl/output/test-output-30.json
@@ -81,5 +81,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Handbuch Medien: Offene Kanäle / Bundeszentrale für Politische Bildung. Hrsg.: Ulrich Kamp. - Bonn, 1997. - ISBN 3-89331-303-6. - S. 102-106"
+  "bibliographicCitation" : "Handbuch Medien: Offene Kanäle / Bundeszentrale für Politische Bildung. Hrsg.: Ulrich Kamp. - Bonn, 1997. - ISBN 3-89331-303-6. - S. 102-106",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "3a 5094",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982370:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-31.json
+++ b/etl/output/test-output-31.json
@@ -135,5 +135,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Handbuch Medien: Offene Kanäle / Bundeszentrale für Politische Bildung. Hrsg.: Ulrich Kamp. - Bonn, 1997. - ISBN 3-89331-303-6. - S. 119-123"
+  "bibliographicCitation" : "Handbuch Medien: Offene Kanäle / Bundeszentrale für Politische Bildung. Hrsg.: Ulrich Kamp. - Bonn, 1997. - ISBN 3-89331-303-6. - S. 119-123",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "3a 5094",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982371:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-32.json
+++ b/etl/output/test-output-32.json
@@ -99,5 +99,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Handbuch Medien: Offene Kanäle / Bundeszentrale für Politische Bildung. Hrsg.: Ulrich Kamp. - Bonn, 1997. - ISBN 3-89331-303-6. - S. 124-144"
+  "bibliographicCitation" : "Handbuch Medien: Offene Kanäle / Bundeszentrale für Politische Bildung. Hrsg.: Ulrich Kamp. - Bonn, 1997. - ISBN 3-89331-303-6. - S. 124-144",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "3a 5094",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982372:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-33.json
+++ b/etl/output/test-output-33.json
@@ -75,5 +75,15 @@
       "label" : "Geistiger Schöpfer"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15621",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982373:DE-107:#!"
   } ]
 }

--- a/etl/output/test-output-34.json
+++ b/etl/output/test-output-34.json
@@ -16,5 +16,15 @@
     "type" : [ "Collection" ],
     "label" : "Rheinland-Pfälzische Bibliographie"
   } ],
-  "title" : "SWR-3-Clubmagazin : 1998,1(Sept.) -"
+  "title" : "SWR-3-Clubmagazin : 1998,1(Sept.) -",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15621/1998-",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982373b1:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-35.json
+++ b/etl/output/test-output-35.json
@@ -75,5 +75,15 @@
       "label" : "Herausgebendes Organ"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 14726",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982374:DE-107:#!"
   } ]
 }

--- a/etl/output/test-output-36.json
+++ b/etl/output/test-output-36.json
@@ -17,5 +17,15 @@
     "label" : "Rheinland-Pfälzische Bibliographie"
   } ],
   "title" : "On : SWF 3, das Magazin : 1992 - 1998,2",
-  "note" : [ "Damit Erscheinen eingest. - Forts. u.d.T.: SWR-3-Clubmagazin" ]
+  "note" : [ "Damit Erscheinen eingest. - Forts. u.d.T.: SWR-3-Clubmagazin" ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 14726/1995-1998,2",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982374b1:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-37.json
+++ b/etl/output/test-output-37.json
@@ -67,5 +67,15 @@
       "label" : "Geistiger Schöpfer"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15620",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982375:DE-107:#!"
   } ]
 }

--- a/etl/output/test-output-38.json
+++ b/etl/output/test-output-38.json
@@ -17,5 +17,15 @@
     "label" : "Rheinland-Pfälzische Bibliographie"
   } ],
   "title" : "Die Zeitschrift : der Südwestrundfunk und seine Programme. Rheinland-Pfalz : 1998,1(Sept.) - 2001,9(Sept.)",
-  "note" : [ "Forts. u.d.T.: Doppelpfeil" ]
+  "note" : [ "Forts. u.d.T.: Doppelpfeil" ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15620/1998,1-2001,9",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982375b1:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-39.json
+++ b/etl/output/test-output-39.json
@@ -74,5 +74,15 @@
       "label" : "Herausgebendes Organ"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15655",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982376:DE-107:#!"
   } ]
 }

--- a/etl/output/test-output-40.json
+++ b/etl/output/test-output-40.json
@@ -16,5 +16,15 @@
     "type" : [ "Collection" ],
     "label" : "Rheinland-Pfälzische Bibliographie"
   } ],
-  "title" : "Flieg und flatter : Aktuelles aus der Vogelschutzwarte : Ausg. 1.1997(Dez.) -"
+  "title" : "Flieg und flatter : Aktuelles aus der Vogelschutzwarte : Ausg. 1.1997(Dez.) -",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15655/1.1997-",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982376b1:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-41.json
+++ b/etl/output/test-output-41.json
@@ -82,5 +82,15 @@
       "label" : "Herausgebendes Organ"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15748;Per. 17032",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982377:DE-107:#!"
   } ]
 }

--- a/etl/output/test-output-42.json
+++ b/etl/output/test-output-42.json
@@ -17,5 +17,15 @@
     "label" : "Rheinland-Pfälzische Bibliographie"
   } ],
   "title" : "Der Rasenspieler : das Journal zur Saison ... : Nachgewiesen 1998/99(1998) - 2000/01; 2001/02 - 2002/03",
-  "note" : [ "Damit Erscheinen eingest." ]
+  "note" : [ "Damit Erscheinen eingest." ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15748/1998/99-2000/01;Per. 17032/2001/02-2002/03",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982377b1:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-43.json
+++ b/etl/output/test-output-43.json
@@ -65,5 +65,15 @@
       "label" : "Herausgebendes Organ"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15740",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982378:DE-107:#!"
   } ]
 }

--- a/etl/output/test-output-44.json
+++ b/etl/output/test-output-44.json
@@ -17,5 +17,15 @@
     "label" : "Rheinland-Pfälzische Bibliographie"
   } ],
   "title" : "'s Derfsche : Ebertsheim-Rodenbach, das Dorf im Grünen : 1998,Apr.",
-  "note" : [ "Mit dieser Ausg. Erscheinen eingest." ]
+  "note" : [ "Mit dieser Ausg. Erscheinen eingest." ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 15740/1998",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982378b1:DE-107:#!"
+  } ]
 }

--- a/etl/output/test-output-45.json
+++ b/etl/output/test-output-45.json
@@ -75,5 +75,15 @@
       "label" : "Herausgebendes Organ"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 11060",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982379:DE-107:#!"
   } ]
 }

--- a/etl/output/test-output-46.json
+++ b/etl/output/test-output-46.json
@@ -22,5 +22,15 @@
     "dateStatement" : "1995",
     "startDate" : "1995",
     "type" : [ "PublicationEvent" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 11060/ 1994/95",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t982379b1:DE-107:#!"
   } ]
 }

--- a/etl/output/test-output-47.json
+++ b/etl/output/test-output-47.json
@@ -86,5 +86,15 @@
       "label" : "Geistiger Schöpfer"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Kalender = K 2927",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112190:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-48.json
+++ b/etl/output/test-output-48.json
@@ -81,5 +81,15 @@
       "label" : "Verfasser/in"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Kalender = K 2922",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112191:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-49.json
+++ b/etl/output/test-output-49.json
@@ -52,5 +52,15 @@
       "label" : "RPB-Raumsystematik"
     }
   } ],
-  "bibliographicCitation" : "In: KKG Rot-Weiss-Gruen Kowelenzer Schaengelcher: Sessionsheft. - (2011), Seite 23-33. -"
+  "bibliographicCitation" : "In: KKG Rot-Weiss-Gruen Kowelenzer Schaengelcher: Sessionsheft. - (2011), Seite 23-33. -",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 2287:2011",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112192:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-50.json
+++ b/etl/output/test-output-50.json
@@ -68,5 +68,15 @@
       "label" : "Herausgebendes Organ"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "ZA 6062 MAG",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112193:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-52.json
+++ b/etl/output/test-output-52.json
@@ -67,5 +67,15 @@
       "label" : "Geistiger Schöpfer"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "ZA 6063 MAG",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112194:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-54.json
+++ b/etl/output/test-output-54.json
@@ -74,5 +74,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Der Rheinländer : das Heimatmagazin. - 4 (2011), Juni = H. 34, S. 16-18"
+  "bibliographicCitation" : "Der Rheinländer : das Heimatmagazin. - 4 (2011), Juni = H. 34, S. 16-18",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "ZA 5649:2011 MAG",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112195:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-55.json
+++ b/etl/output/test-output-55.json
@@ -96,5 +96,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Der Rheinländer : das Heimatmagazin. - 4 (2011), Juni = H. 34, S. 26-27"
+  "bibliographicCitation" : "Der Rheinländer : das Heimatmagazin. - 4 (2011), Juni = H. 34, S. 26-27",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "ZA 5649:2011 MAG",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112196:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-56.json
+++ b/etl/output/test-output-56.json
@@ -65,5 +65,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "In: Rhein-Zeitung, Ausg. H. - 66 (2011), 126 vom 31.05., Seite 24. -"
+  "bibliographicCitation" : "In: Rhein-Zeitung, Ausg. H. - 66 (2011), 126 vom 31.05., Seite 24. -",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "ZB 151:2011;MZ 52:2011",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112197:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-57.json
+++ b/etl/output/test-output-57.json
@@ -90,5 +90,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "edition" : [ "11. Aufl." ]
+  "edition" : [ "11. Aufl." ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "2011/1822",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112198:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-59.json
+++ b/etl/output/test-output-59.json
@@ -57,5 +57,15 @@
       "id" : "https://rpb.lobid.org/spatial",
       "label" : "RPB-Raumsystematik"
     }
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "ZB 32 MAG",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t111801:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-6.json
+++ b/etl/output/test-output-6.json
@@ -82,5 +82,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Der Rheinländer : das Heimatmagazin. - 4 (2011), Juni = H. 34, S. 32-33"
+  "bibliographicCitation" : "Der Rheinländer : das Heimatmagazin. - 4 (2011), Juni = H. 34, S. 32-33",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "ZA 5649:2011 MAG",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112206:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-61.json
+++ b/etl/output/test-output-61.json
@@ -84,5 +84,15 @@
       "label" : "Sonstige"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "T 2539",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084656:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-62.json
+++ b/etl/output/test-output-62.json
@@ -72,5 +72,15 @@
       "label" : "Herausgebendes Organ"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "T 2478",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084657:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-63.json
+++ b/etl/output/test-output-63.json
@@ -164,5 +164,15 @@
       "label" : "Sonstige"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "T 2946",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084658:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-64.json
+++ b/etl/output/test-output-64.json
@@ -171,5 +171,15 @@
       "label" : "Herausgebendes Organ"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "T 2945",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084659:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-65.json
+++ b/etl/output/test-output-65.json
@@ -71,5 +71,15 @@
       "label" : "Geistiger Schöpfer"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "T 2716",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084660:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-66.json
+++ b/etl/output/test-output-66.json
@@ -76,5 +76,15 @@
       "label" : "Geistiger Schöpfer"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "C2008A/608",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084664:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-67.json
+++ b/etl/output/test-output-67.json
@@ -71,5 +71,15 @@
       "label" : "Geistiger Schöpfer"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "C2008A/615",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084667:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-68.json
+++ b/etl/output/test-output-68.json
@@ -111,5 +111,33 @@
       "label" : "Sonstige"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "71 m 928",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084686:DE-36:#!"
+  }, {
+    "label" : "RPB-Bestand",
+    "callNumber" : "223-101",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084686:DE-107:#!"
+  }, {
+    "label" : "RPB-Bestand",
+    "callNumber" : "C2008/1046",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084686:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-69.json
+++ b/etl/output/test-output-69.json
@@ -73,5 +73,15 @@
       "label" : "Geistiger Schöpfer"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "T 3092",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084695:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-70.json
+++ b/etl/output/test-output-70.json
@@ -72,5 +72,15 @@
       "label" : "Sonstige"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "T 2819",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t084698:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-71.json
+++ b/etl/output/test-output-71.json
@@ -90,5 +90,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "In: Rheinische Heimatpflege. - N.F. 48 (2011), 2, Seite 150-152. -"
+  "bibliographicCitation" : "In: Rheinische Heimatpflege. - N.F. 48 (2011), 2, Seite 150-152. -",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 720:2011",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t112440:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-72.json
+++ b/etl/output/test-output-72.json
@@ -78,5 +78,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "In: Initiativ. - (2018), 3, Seite 20-21. -"
+  "bibliographicCitation" : "In: Initiativ. - (2018), 3, Seite 20-21. -",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "ZA 2245:2018 MAG",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t190565:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-73.json
+++ b/etl/output/test-output-73.json
@@ -44,5 +44,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Coblenzer Zeitung 25.1.1920.; Mayener Volkszeitung. - 26.1.1920.; Mayener Zeitung. - 31.1.1920."
+  "bibliographicCitation" : "Coblenzer Zeitung 25.1.1920.; Mayener Volkszeitung. - 26.1.1920.; Mayener Zeitung. - 31.1.1920.",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vgl. Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t01069600:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-75.json
+++ b/etl/output/test-output-75.json
@@ -22,5 +22,15 @@
     "dateStatement" : "[2016]",
     "startDate" : "2016",
     "type" : [ "PublicationEvent" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "2016/106",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t160240b1:DE-36:#!"
   } ]
 }

--- a/etl/output/test-output-76.json
+++ b/etl/output/test-output-76.json
@@ -22,5 +22,15 @@
     "dateStatement" : "[Dezember 2017]",
     "startDate" : "2017",
     "type" : [ "PublicationEvent" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "2018/23",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t160240b2:DE-36:#!"
   } ]
 }

--- a/etl/output/test-output-77.json
+++ b/etl/output/test-output-77.json
@@ -56,5 +56,15 @@
       "label" : "Geistiger Schöpfer"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 1249",
+    "heldBy" : {
+      "isil" : "DE-121",
+      "id" : "http://lobid.org/organisations/DE-121#!",
+      "label" : "Trier"
+    },
+    "id" : "http://rpb.lobid.org/items/121t0144215:DE-121:#!"
   } ]
 }

--- a/etl/output/test-output-80.json
+++ b/etl/output/test-output-80.json
@@ -37,5 +37,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Der Wormsgau. Bd 3, H. 2 (Okt. 1952), 49-63"
+  "bibliographicCitation" : "Der Wormsgau. Bd 3, H. 2 (Okt. 1952), 49-63",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vergleiche Bibliotheks-Katalog",
+    "heldBy" : {
+      "isil" : "DE-36",
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Mainz"
+    },
+    "id" : "http://rpb.lobid.org/items/036t0115179:DE-36:#!"
+  } ]
 }

--- a/etl/output/test-output-81.json
+++ b/etl/output/test-output-81.json
@@ -111,5 +111,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "edition" : [ "2. dt. Ausg." ]
+  "edition" : [ "2. dt. Ausg." ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "93/5378",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t930040:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-82.json
+++ b/etl/output/test-output-82.json
@@ -66,5 +66,15 @@
       "label" : "Verfasser/in"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "92A/173",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t920749:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-83.json
+++ b/etl/output/test-output-83.json
@@ -60,5 +60,15 @@
       "label" : "RPB-Raumsystematik"
     }
   } ],
-  "bibliographicCitation" : "In: Die Eifel. - 118 (2023), 3, Seite 48-52. -"
+  "bibliographicCitation" : "In: Die Eifel. - 118 (2023), 3, Seite 48-52. -",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 1666-118(2023)",
+    "heldBy" : {
+      "isil" : "DE-121",
+      "id" : "http://lobid.org/organisations/DE-121#!",
+      "label" : "Trier"
+    },
+    "id" : "http://rpb.lobid.org/items/121t231109:DE-121:#!"
+  } ]
 }

--- a/etl/output/test-output-84.json
+++ b/etl/output/test-output-84.json
@@ -76,5 +76,24 @@
   }, {
     "id" : "https://www.hsozkult.de/publicationreview/id/reb-22111",
     "label" : "https://www.hsozkult.de/publicationreview/id/reb-22111"
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "117-3134",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t182053:DE-107:#!"
+  }, {
+    "label" : "RPB-Bestand",
+    "callNumber" : "2020/1429",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/107t182053:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-85.json
+++ b/etl/output/test-output-85.json
@@ -88,5 +88,15 @@
     "id" : "http://d-nb.info/1069609889/04",
     "label" : "http://d-nb.info/1069609889/04"
   } ],
-  "edition" : [ "4., aktualisierte Auflage" ]
+  "edition" : [ "4., aktualisierte Auflage" ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "2016/311",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t160199:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-86.json
+++ b/etl/output/test-output-86.json
@@ -98,5 +98,24 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Landkreis Neuwied: Heimatjahrbuch des Landkreises Neuwied. - 2009, S. 383-392 (1. Teil: Innenstadt); 2010, S. 287-305 (2. Teil: Stadtteile)"
+  "bibliographicCitation" : "Landkreis Neuwied: Heimatjahrbuch des Landkreises Neuwied. - 2009, S. 383-392 (1. Teil: Innenstadt); 2010, S. 287-305 (2. Teil: Stadtteile)",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Per. 5998/2009-2010",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/929t091078:DE-107:#!"
+  }, {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 37",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t091078:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-87.json
+++ b/etl/output/test-output-87.json
@@ -46,5 +46,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "bibliographicCitation" : "Heimatkalender Landkreis Bitburg-Prüm. - 1990, S. 74 - 78"
+  "bibliographicCitation" : "Heimatkalender Landkreis Bitburg-Prüm. - 1990, S. 74 - 78",
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Z 1184;Z 1184",
+    "heldBy" : {
+      "isil" : "DE-121",
+      "id" : "http://lobid.org/organisations/DE-121#!",
+      "label" : "Trier"
+    },
+    "id" : "http://rpb.lobid.org/items/121t0146618:DE-121:#!"
+  } ]
 }

--- a/etl/output/test-output-88.json
+++ b/etl/output/test-output-88.json
@@ -69,5 +69,15 @@
   "fulltextOnline" : [ {
     "id" : "https://www.dilibri.de/rlb/periodical/pageview/2495547",
     "label" : "https://www.dilibri.de/rlb/periodical/pageview/2495547"
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Palat. 101/1.1925;Palat. 102/1.1925;Palat. 100/1.1925 HBL",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t01167281:DE-107:#!"
   } ]
 }

--- a/etl/output/test-output-89.json
+++ b/etl/output/test-output-89.json
@@ -100,5 +100,15 @@
       "label" : "Sonstige"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "C2001/210",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t061308:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-90.json
+++ b/etl/output/test-output-90.json
@@ -144,5 +144,15 @@
       "label" : "Herausgebendes Organ"
     },
     "type" : [ "Contribution" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "98 A 102",
+    "heldBy" : {
+      "isil" : "DE-121",
+      "id" : "http://lobid.org/organisations/DE-121#!",
+      "label" : "Trier"
+    },
+    "id" : "http://rpb.lobid.org/items/121t970621:DE-121:#!"
   } ]
 }

--- a/etl/output/test-output-91.json
+++ b/etl/output/test-output-91.json
@@ -70,5 +70,15 @@
       "label" : "RPB-Raumsystematik"
     }
   } ],
-  "edition" : [ "Faks.-Ausg. [d. Ausg.] Ems, Sommer, 1896" ]
+  "edition" : [ "Faks.-Ausg. [d. Ausg.] Ems, Sommer, 1896" ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "Vorhanden",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t163432:DE-929:#!"
+  } ]
 }

--- a/etl/output/test-output-92.json
+++ b/etl/output/test-output-92.json
@@ -28,5 +28,15 @@
     "dateStatement" : "1989",
     "startDate" : "1989",
     "type" : [ "PublicationEvent" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "89/449:1",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t163432b1:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-93.json
+++ b/etl/output/test-output-93.json
@@ -28,5 +28,15 @@
     "dateStatement" : "1989",
     "startDate" : "1989",
     "type" : [ "PublicationEvent" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "89/449:2",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t163432b2:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-94.json
+++ b/etl/output/test-output-94.json
@@ -28,5 +28,15 @@
     "dateStatement" : "1989",
     "startDate" : "1989",
     "type" : [ "PublicationEvent" ]
+  } ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "89/449:3",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Koblenz"
+    },
+    "id" : "http://rpb.lobid.org/items/929t163432b3:DE-929:#!"
   } ]
 }

--- a/etl/output/test-output-96.json
+++ b/etl/output/test-output-96.json
@@ -76,5 +76,15 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "edition" : [ "Überarb. Neuausg., aktualisierte Taschenbuchausg." ]
+  "edition" : [ "Überarb. Neuausg., aktualisierte Taschenbuchausg." ],
+  "hasItem" : [ {
+    "label" : "RPB-Bestand",
+    "callNumber" : "110-5817",
+    "heldBy" : {
+      "isil" : "DE-107",
+      "id" : "http://lobid.org/organisations/DE-107#!",
+      "label" : "Speyer"
+    },
+    "id" : "http://rpb.lobid.org/items/107t110017:DE-107:#!"
+  } ]
 }

--- a/etl/rpb-titel-to-lobid.fix
+++ b/etl/rpb-titel-to-lobid.fix
@@ -397,6 +397,18 @@ end
 
 move_field("edition", "edition[]")
 
+move_field("item[]", "hasItem[]")
+do list_as(item: "hasItem[]")
+  set_field("item.label", "RPB-Bestand")
+  move_field("item.value", "item.callNumber")
+  copy_field("item.type", "item.heldBy.isil")
+  lookup("item.heldBy.isil", KO: "DE-929", SP: "DE-107", MZ: "DE-36", TR: "DE-121")
+  paste("item.heldBy.id", "~http://lobid.org/organisations/", "item.heldBy.isil", "~#!", "join_char": "")
+  move_field("item.type", "item.heldBy.label")
+  lookup("item.heldBy.label", KO: "Koblenz", SP: "Speyer", MZ: "Mainz", TR: "Trier")
+  paste("item.id", "~http://rpb.lobid.org/items/", "rpbId", "~:", "item.heldBy.isil", "~:", "item.id", "~#!", "join_char": "")
+end
+
 retain( "type[]", "contribution[]", "edition[]", "extent", "hasItem[]", "responsibilityStatement[]", "language[]", "medium[]", "subject[]", "title", "hbzId", "hebisId", "oclcNumber[]", "otherTitleInformation[]", "alternativeTitle[]", "titleKeyword[]", "natureOfContent[]", "publication[]", "sameAs[]", "describedBy", "@context", "id", "zdbId", "spatial[]", "inCollection[]", "rpbId", "schoeneNummer", "bibliographicCitation", "isPartOf[]", "note[]", "fulltextOnline[]", "description[]", "isbn[]", "containedIn[]")
 
 vacuum()

--- a/public/stylesheets/rpb.css
+++ b/public/stylesheets/rpb.css
@@ -372,6 +372,10 @@ body, #issued-range {
 	display: flex; flex-direction: column;
 }
 
+#holdings>dl {
+	margin-bottom: 15px;
+}
+
 #ordering {
 	margin-top: auto;
 }

--- a/public/stylesheets/rpb.css
+++ b/public/stylesheets/rpb.css
@@ -7,10 +7,6 @@ a {
 	text-decoration: none;
 }
 
-dd {
-	padding-bottom: 0.5em;
-}
-
 .row div dl {
 	margin-bottom: 0px;
 }
@@ -366,4 +362,16 @@ body, #issued-range {
 .navbar-default .navbar-nav .dropdown-menu>li>a:hover,
 .navbar-default .navbar-nav .dropdown-menu>li>a:focus {
 	color: #BF2313;
+}
+
+#title-details {
+	display: flex; flex-direction: row;
+}
+
+#holdings {
+	display: flex; flex-direction: column;
+}
+
+#ordering {
+	margin-top: auto;
 }

--- a/test/tests/IntegrationTest.java
+++ b/test/tests/IntegrationTest.java
@@ -269,4 +269,29 @@ public class IntegrationTest {
 		});
 	}
 
+	@Test
+	public void orderingHoldingsWithDetails() {
+		running(testServer(3333), () -> {
+			assertThat(itemDetails("f1779")).as("Record `hasItem` itself").isNotNull();
+			assertThat(itemDetails("a4333486")).as("Superordinate `containedIn` record `hasItem`").isNotNull();
+			assertThat(itemDetails("f1570")).as("No `isil`, but using `id` instead").isNotNull();
+		});
+	}
+
+	@Test
+	public void orderingHoldingsNoDetails() {
+		running(testServer(3333), () -> {
+			assertThat(itemDetails("a4329816")).as("No items in superordinate resource").isNull();
+			assertThat(itemDetails("f1482")).as("No `callNumber` in any item").isNull();
+			assertThat(itemDetails("f1375")).as("No `callNumber` in selected item").isNull();
+			assertThat(itemDetails("a4334260")).as("No items `heldBy` RPB owners").isNull();
+		});
+	}
+
+	private String itemDetails(String id) {
+		Result result = route(fakeRequest(GET, String.format("/%s?format=json", id)));
+		String doc = Json.parse(Helpers.contentAsString(result)).get("member").elements().next().toString();
+		return Lobid.emailAndDetails(doc)[2];
+	}
+
 }


### PR DESCRIPTION
Will resolve https://jira.hbz-nrw.de/browse/RPB-39

Adds items in the strapi-to-lobid transformation and UI elements to order items via email.

Deployed to test, see details pages for these records:

https://rpb-test.lobid.org/search?location=&q=hasItem%3A*+AND+type%3AArticle