### PR TITLE
Ergänze Script zum Checken und analysieren von `hbzId` in der rpb RPB-257

### DIFF
--- a/etl/rpbRecordsWithHbzId/README.md
+++ b/etl/rpbRecordsWithHbzId/README.md
@@ -1,0 +1,4 @@
+Zwei MF-Scripte, um RPB/Bibliovino-Datensätze sowie ihre korrespondierenden Datensätze mit HT-Nummer aus lobid/NZ zu holen und die Ergebnisse zu analysieren.
+
+1) Aus dem hbz-Netz `rpbRecordsWithHbzId/collectRpbRecordsWithHbzIdAndTestIfInLobid.flux` laufen lassen
+2) `rpbRecordsWithHbzId/analyse.flux` lässt Analysen laufen, die nicht Dublette hbz-Ids, nicht existente hbz ids, sowie Mapping rpbId <-> zdbId.

--- a/etl/rpbRecordsWithHbzId/analyse.flux
+++ b/etl/rpbRecordsWithHbzId/analyse.flux
@@ -1,0 +1,63 @@
+default rpbFile = FLUX_DIR + "rpbWithHT.tsv";
+default lobidFile = FLUX_DIR + "rpbLobidMappingWithHT.tsv";
+
+
+// Check for duplicates
+
+rpbFile
+| open-file
+| as-lines
+| decode-csv(separator="\t", hasHeader="true")
+| fix(FLUX_DIR + "rpbId.fix")
+| stream-to-triples(redirect="true")
+| sort-triples(by="all")
+| collect-triples
+| fix(FLUX_DIR + "rpbId2.fix")
+| encode-csv(includeHeader="TRUE", separator="\t", noQuotes="true")
+| write(FLUX_DIR + "duplicateHbzIdInRpb.tsv")
+;
+
+// Check for not existing hbzIds
+
+rpbFile
+| open-file
+| as-lines
+| decode-csv(separator="\t", hasHeader="true")
+| fix(FLUX_DIR + "keepHbzIdsWithoutNZRecord.fix",*)
+| encode-csv(includeHeader="TRUE", separator="\t", noQuotes="true")
+| write(FLUX_DIR + "nonExistingHbzIdInRpb.tsv")
+;
+
+// Create map for all rpbIds with with non duplicate entries
+
+rpbFile
+| open-file
+| as-lines
+| decode-csv(separator="\t", hasHeader="true")
+| fix(FLUX_DIR + "rpbId.fix")
+| stream-to-triples(redirect="true")
+| sort-triples(by="all")
+| collect-triples
+| fix(FLUX_DIR + "rpbIdSingeEntry.fix")
+| fix(FLUX_DIR + "keepHbzIdsWithNZRecord.fix",*)
+| encode-csv(includeHeader="TRUE", separator="\t", noQuotes="true")
+| write(FLUX_DIR + "trueRpbIdNZMapping.tsv")
+;
+
+//// Create map for biblioVinoRevords with with non duplicate entries
+//
+//FLUX_DIR + "trueRpbIdNZMapping.tsv"
+//| open-file
+//| as-lines
+//| filter-strings("RPB.*?t",passmatches="true")
+//| write(FLUX_DIR + "trueRpbIdNZMapping_onlyRpb.tsv")
+//;
+//
+//// Create map for rpb records with with non duplicate entries
+//
+//FLUX_DIR + "trueRpbIdNZMapping.tsv"
+//| open-file
+//| as-lines
+//| filter-strings("RPB.*?w",passmatches="true")
+//| write(FLUX_DIR + "trueRpbIdNZMapping_onlyWein.tsv")
+//;

--- a/etl/rpbRecordsWithHbzId/collectRpbRecordsWithHbzIdAndTestIfInLobid.flux
+++ b/etl/rpbRecordsWithHbzId/collectRpbRecordsWithHbzIdAndTestIfInLobid.flux
@@ -1,0 +1,42 @@
+default rpbHarvest = FLUX_DIR + "rpbHarvest.jsonl";
+
+"Start harvesting rpb."
+| print;
+
+"http://rpb1.hbz-nrw.de:1990/resources/search?q=_exists_%3AhbzId+AND+NOT+rpbId%3Af*"
+| open-http(header="User-Agent: hbz/rpb-checker", accept="application/x-jsonlines")
+| as-lines
+| object-batch-log("RPB API records processed: ${totalRecords}", batchSize="100")
+| write(rpbHarvest)
+;
+
+rpbHarvest
+| open-file
+| as-lines
+| decode-json
+| fix(FLUX_DIR + "getHbzIdFromLobid.fix")
+| encode-csv(includeHeader="TRUE", separator="\t", noQuotes="true")
+| object-batch-log("PRB2CSV records processed: ${totalRecords}", batchSize="100")
+| write(FLUX_DIR + "rpbWithHT.tsv")
+;
+
+"Done harvesting rpb. Start sending requests to lobid."
+| print;
+
+rpbHarvest
+| open-file
+| as-lines
+| decode-json
+| fix("replace_all('hbzId','^(.*)$','https://lobid.org/resources/search?q=hbzId%3A$1&format=jsonl')
+retain('hbzId')")
+| literal-to-object
+| object-batch-log("HbzId2Url records processed: ${totalRecords}", batchSize="100")
+| open-http(accept="application/json",header="User-Agent: hbz/rpb-checker")
+| as-lines
+| catch-object-exception
+| decode-json
+| fix(FLUX_DIR + "getHbzIdFromLobid.fix")
+| encode-csv(includeHeader="TRUE", separator="\t", noQuotes="true")
+| object-batch-log("Lobid Harvest records processed: ${totalRecords}", batchSize="100")
+| write(FLUX_DIR + "rpbLobidMappingWithHT.tsv")
+;

--- a/etl/rpbRecordsWithHbzId/getHbzIdFromLobid.fix
+++ b/etl/rpbRecordsWithHbzId/getHbzIdFromLobid.fix
@@ -1,0 +1,19 @@
+move_field("rpbId","@rpbId")
+move_field("@rpbId","rpbId")
+prepend("rpbId","RPB")
+unless exists("rpbId")
+	add_field("rpbId","")
+end
+move_field("hbzId","@hbzId")
+move_field("@hbzId","hbzId")
+unless exists("hbzId")
+	add_field("hbzId","")
+end
+move_field("zdbId","@zdbId")
+move_field("@zdbId","zdbId")
+unless exists("zdbId")
+	add_field("zdbId","")
+end
+copy_field("inCollection[].*.label", "page.$append")
+join_field("page", "; ")
+retain("almaMmsId","rpbId","hbzId","zdbId","page")

--- a/etl/rpbRecordsWithHbzId/keepHbzIdsWithNZRecord.fix
+++ b/etl/rpbRecordsWithHbzId/keepHbzIdsWithNZRecord.fix
@@ -1,0 +1,11 @@
+do once("maps")
+  put_filemap("$[lobidFile]", "lobidLookupHbzId2Alma", sep_char:"\t", key_column:"2", value_column:"0", expected_columns:"-1")
+end
+
+copy_field("hbzId","almaMmsId")
+
+lookup("almaMmsId","lobidLookupHbzId2Alma",delete:"true")
+
+unless exists("almaMmsId")
+    reject()
+end

--- a/etl/rpbRecordsWithHbzId/keepHbzIdsWithoutNZRecord.fix
+++ b/etl/rpbRecordsWithHbzId/keepHbzIdsWithoutNZRecord.fix
@@ -1,0 +1,21 @@
+do once("maps")
+  put_filemap("$[lobidFile]", "lobidLookupHbzId2Alma", sep_char:"\t", key_column:"2", value_column:"0", expected_columns:"-1")
+end
+
+copy_field("hbzId","almaMmsId")
+
+lookup("almaMmsId","lobidLookupHbzId2Alma",delete:"true")
+
+if any_match("hbzId","[BCHT]T\\d+")
+  add_field("status","strukturell hbzId, aber nicht existent")
+elsif any_match("hbzId","\\d{8,9}[X\\d]?")
+  add_field("status","dnbId statt hbzId")
+else
+  add_field("status","andere ID, keine hbzId")
+end
+
+remove_field("zdbId")
+
+if exists("almaMmsId")
+    reject()
+end

--- a/etl/rpbRecordsWithHbzId/rpbHbzId.fix
+++ b/etl/rpbRecordsWithHbzId/rpbHbzId.fix
@@ -1,0 +1,1 @@
+retain("rpbId","hbzId")

--- a/etl/rpbRecordsWithHbzId/rpbId.fix
+++ b/etl/rpbRecordsWithHbzId/rpbId.fix
@@ -1,0 +1,2 @@
+copy_field("hbzId","_id")
+retain("rpbId","_id","zdbId","hbzId","rpbId","almaMmsId","page")

--- a/etl/rpbRecordsWithHbzId/rpbId.flux
+++ b/etl/rpbRecordsWithHbzId/rpbId.flux
@@ -1,0 +1,26 @@
+default rpbHarvest = FLUX_DIR + "rpbWithHbzId.jsonl";
+
+// Outcomment to not harvest the data every time.
+
+"Start harvesting rpb."
+| print;
+
+
+"http://rpb1.hbz-nrw.de:1990/resources/search?q=_exists_%3AhbzId+AND+NOT+rpbId%3Af*"
+| open-http(header="User-Agent: hbz/rpb-hbzId-checker", accept="application/x-jsonlines")
+| as-lines
+| write(rpbHarvest)
+;
+
+"Harvesting done. Start creating rpbId <-> hbzId lookup."
+| print;
+
+
+rpbHarvest
+| open-file
+| as-lines
+| decode-json
+| fix(FLUX_DIR + "rpbHbzId.fix")
+| encode-csv(includeHeader="TRUE", separator="\t", noQuotes="true")
+| write(FLUX_DIR + "rpbHbzId.tsv")
+;

--- a/etl/rpbRecordsWithHbzId/rpbId2.fix
+++ b/etl/rpbRecordsWithHbzId/rpbId2.fix
@@ -1,0 +1,14 @@
+unless exists("hbzId.2")
+	reject()
+end
+uniq("zdbId")
+uniq("almaMmsId")
+uniq("rpbId")
+uniq("hbzId")
+
+join_field("almaMmsId", "; ")
+join_field("hbzId", "; ")
+join_field("zdbId", "; ")
+join_field("rpbId", "; ")
+
+retain("zdbId","almaMmsId","hbzId","rpbId")

--- a/etl/rpbRecordsWithHbzId/rpbIdSingeEntry.fix
+++ b/etl/rpbRecordsWithHbzId/rpbIdSingeEntry.fix
@@ -1,0 +1,14 @@
+if exists("hbzId.2")
+	reject()
+end
+uniq("zdbId")
+uniq("almaMmsId")
+uniq("rpbId")
+uniq("hbzId")
+
+join_field("almaMmsId", "; ")
+join_field("hbzId", "; ")
+join_field("zdbId", "; ")
+join_field("rpbId", "; ")
+
+retain("almaMmsId","hbzId","rpbId", "page")


### PR DESCRIPTION
Um das Script nicht nur bei mir in meinem metafacture-workflows repo liegen zu haben, schlage ich vor das Script hier auch abzulegen.

Das Script holt alle Nicht-Fremddaten-Records von der RPB API und prüft sie gegen lobid, ob die hbzId in der NZ existiert. Ein weiteres Script gibt Listen von drei Listen aus:
- Dubletten
- ein Mapping eindeutiger `hbzId`<->`rpbId`
- nicht-existierende und nicht-konforme `hbzId`s oft `dnbId`