### PR TITLE
Skip export JSON that doesn't contain passed RECORD_PATH (RPB-362)

### DIFF
--- a/etl/rppd-test-to-lobid.flux
+++ b/etl/rppd-test-to-lobid.flux
@@ -13,6 +13,7 @@ default dynamicMapPath ="./maps/test/";
 FLUX_DIR + "output/" + IN_FILE
 | open-file
 | as-lines
+| filter-strings(RECORD_PATH)
 | decode-json(recordPath=RECORD_PATH)
 | fix(FLUX_DIR + "rppd-to-lobid.fix",*)
 | batch-reset(batchsize="1")

--- a/etl/rppd-to-lobid.flux
+++ b/etl/rppd-to-lobid.flux
@@ -14,6 +14,7 @@ default dynamicMapPath ="./maps/";
 "etl/output/" + IN_FILE
 | open-file
 | as-lines
+| filter-strings(RECORD_PATH)
 | decode-json(recordPath=RECORD_PATH)
 | fix(FLUX_DIR + "rppd-to-lobid.fix",*)
 | batch-reset(batchsize="1000")


### PR DESCRIPTION
Images in Strapi result in textual relation objects that we skip.

Will resolve https://jira.hbz-nrw.de/browse/RPB-362.