### PR TITLE
Update lobid transformation

### DIFF
--- a/etl/hebisMarc2lobid-transformation/fix/contribution.fix
+++ b/etl/hebisMarc2lobid-transformation/fix/contribution.fix
@@ -17,56 +17,58 @@ add_array("contribution[]")
 do list(path:"100[01] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    call_macro("rolesFromSubfieldE")
-    unless exists("$i.4")
-      if any_match("type[]","ArchivedWebPage|Miscellaneous|Bibliography|Statistics|Legislation|PublishedScore|Game|Image|Map|Standard")
-        add_field("$i.4","cre")
-      elsif any_match("type[]","Periodical|Collection|Series|Newspaper|Journal|PublicationIssue|EditedVolume|Proceedings|Festschrift|ReferenceSource")
-        add_field("$i.4","edt")
-      elsif any_match("type[]","Book|MultiVolumeBook|Article|Thesis|OfficialPublication|Schoolbook|Biography|Report")
-        add_field("$i.4","aut")
-      else
-        add_field("$i.4","cre")
+  if exists("$i.a")
+    unless exists("$i.a.1")
+      call_macro("rolesFromSubfieldE")
+      unless exists("$i.4")
+        if any_match("type[]","ArchivedWebPage|Miscellaneous|Bibliography|Statistics|Legislation|PublishedScore|Game|Image|Map|Standard")
+          add_field("$i.4","cre")
+        elsif any_match("type[]","Periodical|Collection|Series|Newspaper|Journal|PublicationIssue|EditedVolume|Proceedings|Festschrift|ReferenceSource")
+          add_field("$i.4","edt")
+        elsif any_match("type[]","Book|MultiVolumeBook|Article|Thesis|OfficialPublication|Schoolbook|Biography|Report")
+          add_field("$i.4","aut")
+        else
+          add_field("$i.4","cre")
+        end
       end
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
             end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
           end
+          # name
+          call_macro("gndPersonCombinedLabel",field:"$i")
+          copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","Person")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          # dateOfBirthAndDeath #will be split on a later stage
+          unless exists("$i.d.1")
+            copy_field("$i.d","contribution[].$last.agent.dateOfBirthAndDeath")
+          end
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
         end
-        # name
-        call_macro("gndPersonCombinedLabel",field:"$i")
-        copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","Person")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        # dateOfBirthAndDeath #will be split on a later stage
-        unless exists("$i.d.1")
-          copy_field("$i.d","contribution[].$last.agent.dateOfBirthAndDeath")
-        end
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
       end
     end
   end
@@ -79,48 +81,50 @@ end
 do list(path:"700[01] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    call_macro("rolesFromSubfieldE")
-    unless exists("$i.4")
-      add_field("$i.4","ctb")
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
+  if exists("$i.a")
+    unless exists("$i.a.1")
+      call_macro("rolesFromSubfieldE")
+      unless exists("$i.4")
+        add_field("$i.4","ctb")
+      end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
             end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
           end
+          # name
+          call_macro("gndPersonCombinedLabel",field:"$i")
+          copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","Person")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          # dateOfBirthAndDeath #will be split on a later stage
+          unless exists("$i.d.1")
+            copy_field("$i.d","contribution[].$last.agent.dateOfBirthAndDeath")
+          end
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
         end
-        # name
-        call_macro("gndPersonCombinedLabel",field:"$i")
-        copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","Person")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        # dateOfBirthAndDeath #will be split on a later stage
-        unless exists("$i.d.1")
-          copy_field("$i.d","contribution[].$last.agent.dateOfBirthAndDeath")
-        end
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
       end
     end
   end
@@ -135,52 +139,54 @@ end
 do list(path:"110[012] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    call_macro("rolesFromSubfieldE")
-    unless exists("$i.4")
-      if any_match("type[]","ArchivedWebPage|Miscellaneous|Bibliography|Statistics|Legislation|PublishedScore|Game|Image|Map|Standard")
-        add_field("$i.4","cre")
-      elsif any_match("type[]","Periodical|Collection|Series|Newspaper|Journal|PublicationIssue|EditedVolume|Proceedings|Festschrift|ReferenceSource")
-        add_field("$i.4","edt")
-      elsif any_match("type[]","Book|MultiVolumeBook|Article|Thesis|OfficialPublication|Schoolbook|Biography|Report")
-        add_field("$i.4","aut")
-      else
-        add_field("$i.4","cre")
-      end
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
-            end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
-          end
+  if exists("$i.a")
+                unless exists("$i.a.1")
+      call_macro("rolesFromSubfieldE")
+      unless exists("$i.4")
+        if any_match("type[]","ArchivedWebPage|Miscellaneous|Bibliography|Statistics|Legislation|PublishedScore|Game|Image|Map|Standard")
+          add_field("$i.4","cre")
+        elsif any_match("type[]","Periodical|Collection|Series|Newspaper|Journal|PublicationIssue|EditedVolume|Proceedings|Festschrift|ReferenceSource")
+          add_field("$i.4","edt")
+        elsif any_match("type[]","Book|MultiVolumeBook|Article|Thesis|OfficialPublication|Schoolbook|Biography|Report")
+          add_field("$i.4","aut")
+        else
+          add_field("$i.4","cre")
         end
-        # name
-          call_macro("gndOtherCombinedLabel",field:"$i")
-          copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","CorporateBody")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
+      end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
+            end
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
+          end
+          # name
+            call_macro("gndOtherCombinedLabel",field:"$i")
+            copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","CorporateBody")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
+        end
       end
     end
   end
@@ -194,44 +200,46 @@ end
 do list(path:"710[012] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    call_macro("rolesFromSubfieldE")
-    unless exists("$i.4")
-      add_field("$i.4","ctb")
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
+  if exists("$i.a")
+    unless exists("$i.a.1")
+      call_macro("rolesFromSubfieldE")
+      unless exists("$i.4")
+        add_field("$i.4","ctb")
+      end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
             end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
           end
+          # name
+            call_macro("gndOtherCombinedLabel",field:"$i")
+            copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","CorporateBody")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
         end
-        # name
-          call_macro("gndOtherCombinedLabel",field:"$i")
-          copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","CorporateBody")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
       end
     end
   end
@@ -245,43 +253,45 @@ end
 do list(path:"111[012] |711[012] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    unless exists("$i.4")
-      add_field("$i.4","oth")
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
+  if exists("$i.a")
+    unless exists("$i.a.1")
+      unless exists("$i.4")
+        add_field("$i.4","oth")
+      end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
             end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
           end
+          # name
+          call_macro("gndEventCombinedLabel",field:"$i")
+          copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","ConferenceOrEvent")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
         end
-        # name
-        call_macro("gndEventCombinedLabel",field:"$i")
-        copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","ConferenceOrEvent")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
       end
     end
   end
@@ -341,7 +351,11 @@ do list (path: "contribution[]", "var": "$i")
   remove_field("$i.agent.@gndIdn")
 
   copy_field("$i.role.id", "$i.role.label")
-  lookup("$i.role.label","marcRel")
+  lookup("$i.role.label","marc-relators","default":"NichtÜbersetzt" )
+  if all_equal("$i.role.label","NichtÜbersetzt") # Use english label as fallback when DNB did not provide any translation
+    copy_field("$i.role.id", "$i.role.label")
+    lookup("$i.role.label","marc-relators-english")
+  end
 
   replace_all("$i.agent.label","<<|>>","")
   uniq("$i.agent.altLabel[]")

--- a/etl/hebisMarc2lobid-transformation/fix/identifiers.fix
+++ b/etl/hebisMarc2lobid-transformation/fix/identifiers.fix
@@ -15,8 +15,8 @@ do list(path: "0247?", "var": "$i")
     elsif any_match("$i.a",".*urn:nbn:de.*")
       replace_all("$i.a","^.*(urn:nbn:de.*)$","$1")
       copy_field("$i.a","urn[].$append")
-    elsif any_match("$i.a",".*doi.*((10\\.(\\d)+/(\\S)+).*)")
-      replace_all("$i.a",".*doi.*(10\\.(\\d)+/(\\S)+).*","$1")
+    elsif any_match("$i.a",".*doi.*((10\\.(\\d){4,9}/(\\S)+).*)")
+      replace_all("$i.a",".*doi.*(10\\.(\\d){4,9}/(\\S)+).*","$1")
       copy_field("$i.a","@doiInUrn")
     end
   end
@@ -102,9 +102,11 @@ add_array("doi[]")
 do list(path:"0247?", "var":"$i")
   if all_equal("$i.2","doi")
     if none_contain("$i.a","http")
-      copy_field("$i.a","doi[].$append")
-    elsif any_match("$i.a",".*doi.*((10\\.(\\d)+/(\\S)+).*)")
-      replace_all("$i.a",".*doi.*(10\\.(\\d)+/(\\S)+).*","$1")
+      if any_match("$i.a","(10\\.(\\d){4,9}/(\\S)+)")
+        copy_field("$i.a","doi[].$append")
+      end
+    elsif any_match("$i.a",".*doi.*((10\\.(\\d){4,9}/(\\S)+).*)")
+      replace_all("$i.a",".*doi.*(10\\.(\\d){4,9}/(\\S)+).*","$1")
       copy_field("$i.a","doi[].$append")
     end
   end
@@ -116,11 +118,11 @@ copy_field("@doiInUrn", "doi[].$append")
 # 856 - Electronic Location and Access (R) - Subfield: $u (R) $3 (NR)
 # 1. Indicator: 4 = HTTP
 do list(path:"856??", "var":"$i")
-  if all_match("$i.u", ".*doi.org.*(10\\.(\\d)+/(\\S)+).*") # Volltext
+  if all_match("$i.u", ".*doi.org.*(10\\.(\\d){4,9}/(\\S)+).*") # Volltext
     copy_field("$i.u", "doi[].$append")
   end
 end
-replace_all("doi[].*", ".*doi.org.*(10\\.(\\d)+/(\\S)+).*", "$1")
+replace_all("doi[].*", ".*doi.org.*(10\\.(\\d){4,9}/(\\S)+).*", "$1")
 uniq("doi[]")
 
 # 035 - System Control Number (R) - Subfield: $a (NR)
@@ -133,6 +135,55 @@ do list(path:"035  ", "var":"$i")
 end
 replace_all("oclcNumber[].*", "\\(OCoLC\\)","")
 
+# 035 - System Control Number (R) - Subfield: $a (NR)
+do list(path:"035  ", "var":"$i")
+  unless exists("zdbId")
+    if all_match("$i.a", "\\(DE-600\\)(.+)")
+      copy_field("$i.a", "zdbId")
+    end
+  end
+  unless exists("dnbId")
+    if all_match("$i.a", "\\(DE-101\\)(\\d{8,9}[X\\d]?)")
+      copy_field("$i.a", "dnbId")
+    end
+  end
+  unless exists("bszId")
+    if all_match("$i.a", "\\(DE-576\\).*?")
+      copy_field("$i.a", "bszId")
+    end
+  end
+  unless exists("gbvId")
+    if all_match("$i.a", "\\(DE-601\\).*?")
+      copy_field("$i.a", "gbvId")
+    end
+  end
+  unless exists("kobvId")
+    if all_match("$i.a", "\\(DE-602\\).*?")
+      copy_field("$i.a", "kobvId")
+    end
+  end
+  unless exists("k10PlusId")
+    if all_match("$i.a", "\\(DE-627\\)\\d{8,9}[0-9X]")
+      copy_field("$i.a", "k10PlusId")
+    end
+  end
+  unless exists("bvbId")
+    if all_match("$i.a", "\\((DE-604)\\)BV\\d{9}")
+      copy_field("$i.a", "bvbId")
+    end
+  end
+  unless exists("hebisId")
+    if all_match("$i.a", "\\((DE-603)\\)\\d{9,10}")
+      copy_field("$i.a", "hebisId")
+    end
+  end
+  unless exists("obvId")
+    if all_match("$i.a", "\\((AT-OBV)\\)AC[\\d]{8}")
+      copy_field("$i.a", "obvId")
+    end
+  end
+end
+
 #160 - 016 - National Bibliographic Agency Control Number (R)
 do list(path:"0167 ", "var":"$i")
   unless exists("zdbId")
@@ -142,24 +193,65 @@ do list(path:"0167 ", "var":"$i")
   end
 
 # dnbId
-  if any_match("$i.2","DE-101")
-    copy_field("$i.a","dnbId")
-  end
-end
-
-# 035 - System Control Number (R) - Subfield: $a (NR)
-do list(path:"035  ", "var":"$i")
-  unless exists("zdbId")
-    if all_match("$i.a", "\\(DE-600\\)(.+)")
-      copy_field("$i.a", "zdbId")
+  unless exists("dnbId")
+    if any_match("$i.2","DE-101")
+      if any_match("$i.a","\\d{8,9}[X\\d]?")
+        copy_field("$i.a","dnbId")
+      end
     end
   end
 end
 
-# clean up ZDB
+# DE-599 as fallback
+do list(path:"035  ", "var":"$i")
+  if all_match("$i.a", "\\(DE-599\\)BSZ.*?")
+    unless exists("bszId")
+      copy_field("$i.a", "bszId")
+    end
+  elsif all_match("$i.a", "\\(DE-599\\)GBV.*?")
+    unless exists("gbvId")
+      copy_field("$i.a", "gbvID")
+    end
+  elsif all_match("$i.a", "\\(DE-599\\)OBV.*?")
+    unless exists("obvId")
+      copy_field("$i.a", "obvId")
+    end
+  elsif all_match("$i.a", "\\(DE-599\\)HEB.*?")
+    unless exists("hebisId")
+      copy_field("$i.a", "hebisId")
+    end
+  elsif all_match("$i.a", "\\(DE-599\\)BVB.*?")
+    unless exists("bvbId")
+      copy_field("$i.a", "bvbId")
+    end
+  elsif all_match("$i.a", "\\(DE-599\\)KXP.*?")
+    unless exists("k10PlusId")
+      copy_field("$i.a", "k10PlusId")
+    end
+  end
+end
+
+# clean up ZDB & DNB id & unioncatalogie ids
 replace_all("zdbId", "\\(DE-600\\)","")
 replace_all("zdbId", "\\(DE-599\\)ZDB","")
 replace_all("zdbId", "(\\d{1,7})-* ?-*([Xx\\d])","$1-$2") # CZ entries have incorrect whitespaces sometimes in the zdbId, we need to adjust them so only one "-" separates the first group of numbers from the last number.
+unless any_match("zdbId","\\d{1,7}-[Xx\\d]")
+  remove_field("zdbId")
+end
+replace_all("dnbId", "\\(DE-101\\)","")
+replace_all("gbvId", "\\(DE-601\\)","")
+replace_all("gbvId", "\\(DE-599\\)GBV","")
+replace_all("bszId", "\\(DE-576\\)","")
+replace_all("bszId", "\\(DE-599\\)BSZ","")
+replace_all("bvbId", "\\(DE-604\\)","")
+replace_all("bvbId", "\\(DE-599\\)BVB","")
+replace_all("kobvId", "\\(DE-602\\)","")
+replace_all("k10PlusId", "\\(DE-627\\)","")
+replace_all("k10PlusId", "\\(DE-599\\)KXP","")
+replace_all("hebisId", "\\(DE-603\\)","")
+replace_all("hebisId", "\\(DE-599\\)HEB","")
+replace_all("obvId", "\\(AT-OBV\\)","")
+replace_all("obvId", "\\(DE-599\\)OBV","")
 
 
 copy_field("almaMmsId","rpbId")

--- a/etl/hebisMarc2lobid-transformation/fix/macros.fix
+++ b/etl/hebisMarc2lobid-transformation/fix/macros.fix
@@ -447,8 +447,8 @@ do put_macro("schlagwortfolge")
         end
       end
       unless exists("$i.t") # Work/Werktitel should not receive dateOfBirthAndDeath, datesOfBirth or dateOfDeath
-      copy_field("$i.d","subject[].$last.componentList[].$last.dateOfBirthAndDeath") # dates will be differentiated later in the process
-    end
+        copy_field("$i.d","subject[].$last.componentList[].$last.dateOfBirthAndDeath") # dates will be differentiated later in the process
+      end
     end
     join_field("subject[].$last.label"," | ")
   end

--- a/etl/hebisMarc2lobid-transformation/fix/maps.fix
+++ b/etl/hebisMarc2lobid-transformation/fix/maps.fix
@@ -109,8 +109,8 @@ put_rdfmap("./maps/gnd-sc.ttl", "gnd-sc-notationen", target: "skos:prefLabel", s
 # }
 # ----
 # Status: 2025, currently not able to generate this automatically since there are some errors in the data that needs to be cleaned
-put_filemap("./maps/formangabe.tsv","formschlagwort2Gnd", sep_char:"\t",key_column:"0",value_column:"2",expected_columns:"-1")
-put_filemap("./maps/formangabe.tsv","Gnd2formschlagwort", sep_char:"\t",key_column:"2",value_column:"0",expected_columns:"-1")
+put_filemap("./maps/formangabe.tsv","formschlagwort2Gnd", sep_char:"\t",key_column:"0",value_column:"1",expected_columns:"-1")
+put_filemap("./maps/formangabe.tsv","Gnd2formschlagwort", sep_char:"\t",key_column:"1",value_column:"0",expected_columns:"-1")
 
 # Map of almaMmsId -> rpbId
 # dynamic map individually pushed by @fsteeg to server: src/main/resources/alma/maps/almaMmsId2rpbId.tsv
@@ -134,18 +134,18 @@ put_filemap("./maps/isil2opac_issn.tsv","isil2opac_issn", sep_char:"\t")
 put_filemap("./maps/isil2opac_zdbId.tsv","isil2opac_zdbId", sep_char:"\t")
 put_filemap("./maps/isil2opac_almaMmsId.tsv","isil2opac_almaMmsId", sep_char:"\t")
 
-# marcRel map incl. uri, labels and codes
-# TODO: Check if the file needs to be updated.
-# static map: src/main/resources/alma/maps/marcRel.tsv
-# manually generated, based on based on https://www.loc.gov/marc/relators/ loc version has no german language tags
-put_filemap("./maps/marcRel.tsv","marcRel", sep_char:"\t",key_column:"0",value_column:"1",expected_columns:"-1")
+# marc-relators map incl. uri, labels and codes from https://github.com/hbz/lookup-tables/tree/master/data/marc-relators.tsv
+# dynamic map from git submodule: lookup-tables/data/marc-relators.tsv
+# generated, based on based on https://www.loc.gov/marc/relators/ loc version has no german language tags and RDA Arbeitshilfe
+put_filemap("./maps/marcRel.tsv","marc-relators", sep_char:"\t",key_column:"0",value_column:"4",expected_columns:"-1")
+put_filemap("./maps/marcRel.tsv","marc-relators-english", sep_char:"\t",key_column:"0",value_column:"3",expected_columns:"-1")
+
 
 # hbz and alma internal collection labels map
 # static map: src/main/resources/alma/maps/collectionLabels.tsv
 # based on manually created map of collections that are not part of the ZDB/ISIL
 put_filemap("./maps/collectionLabels.tsv","collectionLabels", sep_char:"\t",key_column:"0",value_column:"1",expected_columns:"-1")
 
-# Not needed for RPB
 # Map containing record ids to holdings of DE-Sol1. see: https://github.com/hbz/lobid-extra-holdings/
 # dynamic file from cronjob: src/main/resources/alma/maps/combinedDe-Sol1Holdings.tsv.gz
 # result of https://github.com/hbz/lobid-extra-holdings/blob/main/harvestHoldings_prod.sh
@@ -167,19 +167,23 @@ put_map("rswk-indicator",
 )
 
 put_map("marc-publication-frequency-label",
-  "http://marc21rdf.info/terms/continuingfre#d" : "täglich",
-  "http://marc21rdf.info/terms/continuingfre#i" : "dreimal wöchentlich",
-  "http://marc21rdf.info/terms/continuingfre#c" : "zweimal wöchentlich",
-  "http://marc21rdf.info/terms/continuingfre#w" : "wöchentlich",
-  "http://marc21rdf.info/terms/continuingfre#e" : "vierzehntägig",
-  "http://marc21rdf.info/terms/continuingfre#s" : "halbmonatlich",
-  "http://marc21rdf.info/terms/continuingfre#m" : "monatlich",
-  "http://marc21rdf.info/terms/continuingfre#b" : "alle zwei Monate",
-  "http://marc21rdf.info/terms/continuingfre#q" : "vierteljährlich",
-  "http://marc21rdf.info/terms/continuingfre#f" : "halbjährlich",
   "http://marc21rdf.info/terms/continuingfre#a" : "jährlich",
+  "http://marc21rdf.info/terms/continuingfre#b" : "alle zwei Monate",
+  "http://marc21rdf.info/terms/continuingfre#c" : "zweimal wöchentlich",
+  "http://marc21rdf.info/terms/continuingfre#d" : "täglich",
+  "http://marc21rdf.info/terms/continuingfre#e" : "vierzehntägig",
+  "http://marc21rdf.info/terms/continuingfre#f" : "halbjährlich",
   "http://marc21rdf.info/terms/continuingfre#g" : "alle zwei Jahre",
   "http://marc21rdf.info/terms/continuingfre#h" : "alle drei Jahre",
+  "http://marc21rdf.info/terms/continuingfre#i" : "dreimal wöchentlich",
+  "http://marc21rdf.info/terms/continuingfre#j" : "dreimal monatlich",
+  "http://marc21rdf.info/terms/continuingfre#k" : "kontinuierlich",
+  "http://marc21rdf.info/terms/continuingfre#m" : "monatlich",
+  "http://marc21rdf.info/terms/continuingfre#q" : "vierteljährlich",
+  "http://marc21rdf.info/terms/continuingfre#s" : "halbmonatlich",
+  "http://marc21rdf.info/terms/continuingfre#t" : "dreimal jährlich",
+  "http://marc21rdf.info/terms/continuingfre#u" : "unbekannte Erscheinungsfrequenz",
+  "http://marc21rdf.info/terms/continuingfre#w" : "wöchentlich",
   "http://marc21rdf.info/terms/continuingfre#z" : "unregelmäßig oder sonstige Erscheinungsfrequenz"
 )
 

--- a/etl/hebisMarc2lobid-transformation/fix/mediumAndType.fix
+++ b/etl/hebisMarc2lobid-transformation/fix/mediumAndType.fix
@@ -437,12 +437,14 @@ if any_match("@leaderTyp+008", "Book(.{30})1.*")  # Pos30
   add_field("type[].$append","Festschrift")
 elsif any_match("006", "^[at](.{12})1.*") # Pos00+13
   add_field("type[].$append","Festschrift")
-elsif any_match("title", ".*Festschrift.*") # often Festschrift is not stated as such in Control fields but in the title.
-  add_field("type[].$append","Festschrift")
-elsif any_match("otherTitleInformation[]", ".*Festschrift.*")
-  add_field("type[].$append","Festschrift")
 elsif any_match("natureOfContent[].*.label", ".*Festschrift.*")
   add_field("type[].$append","Festschrift")
+elsif none_match("@leaderPos06-07",".a")
+  if any_match("title", ".*Festschrift.*") # often Festschrift is not stated as such in Control fields but in the title.
+    add_field("type[].$append","Festschrift")
+  elsif any_match("otherTitleInformation[]", ".*Festschrift.*")
+    add_field("type[].$append","Festschrift")
+  end
 end
 
 # type: "image"
@@ -619,7 +621,7 @@ end
 # type: "PublicationIssue"
 
 
-if exists("zdbId")
+if any_contain("isPartOf[].*.hasSuperordinate[].*.id","ZDB")
   if exists("245??.n")
     unless any_contain("245??.n","...")
       add_field("type[].$append", "PublicationIssue")
@@ -628,10 +630,6 @@ if exists("zdbId")
     add_field("type[].$append", "PublicationIssue")
   end
 end
-
-# TODO: HT003176544 transforms but is not PublicationIssue in lobid ALEPH.
-# TODO: Also check if PublicationIssue and Periodical as type are mutual exclusive.
-# TODO: Check if there are other versions of PublicationIssue
 
 
 # type:"ReferenceSource"

--- a/etl/hebisMarc2lobid-transformation/fix/otherFields.fix
+++ b/etl/hebisMarc2lobid-transformation/fix/otherFields.fix
@@ -2,7 +2,10 @@
 # 041 - 041 - Language Code (R)
 
 add_array("@language")
-copy_field("008", "@008-lang")
+unless is_array("008")
+  copy_field("008", "@008-lang")
+end
+
 substring("@008-lang", "35", "3")
 copy_field("@008-lang", "@language.$append.id")
 copy_field("@008-lang", "@language.$last.label")

--- a/etl/hebisMarc2lobid-transformation/fix/relatedRessourcesAndLinks.fix
+++ b/etl/hebisMarc2lobid-transformation/fix/relatedRessourcesAndLinks.fix
@@ -111,17 +111,19 @@ unless any_match("leader", "^.{7}[ad].*")
             end
           end
         end
-      else
-        add_hash("isPartOf[].$append")
-        add_array("isPartOf[].$last.hasSuperordinate[]")
-        add_hash( "isPartOf[].$last.hasSuperordinate[].$append")
-        copy_field("$i.t", "isPartOf[].$last.hasSuperordinate[].$last.label")
-        call_macro("alternateGraphicRepresentationIsPartOf",variable:"$i")
-        copy_field("$i.q", "isPartOf[].$last.numbering")
+      else # Handling of relations without HBZ/ZDB identifier
+        unless exists("isPartOf[].1.hasSuperordinate[].1.id") # This skips the mapping of relations without HBZ/ZDB refrence if already an isPartOf[] Object exists that links to a HBZ/ZDB resource.
+          add_hash("isPartOf[].$append")
+          add_array("isPartOf[].$last.hasSuperordinate[]")
+          add_hash( "isPartOf[].$last.hasSuperordinate[].$append")
+          copy_field("$i.t", "isPartOf[].$last.hasSuperordinate[].$last.label")
+          call_macro("alternateGraphicRepresentationIsPartOf",variable:"$i")
+          copy_field("$i.q", "isPartOf[].$last.numbering")
         replace_all("isPartOf[].$last.numbering", "^\\d","")  # Hebis specific adjustment of Sortierform.
-        add_array("isPartOf[].$last.note[]")
-        do list(path:"$i.i","var":"$k")
-          copy_field("$k","isPartOf[].$last.note[].$append")
+          add_array("isPartOf[].$last.note[]")
+          do list(path:"$i.i","var":"$k")
+            copy_field("$k","isPartOf[].$last.note[].$append")
+          end
         end
       end
     end
@@ -149,6 +151,25 @@ do list(path: "4900?", "var": "$i")
   join_field("isPartOf[].$last.numbering")
 end
 
+unless exists("830??")
+  do list(path: "4901?", "var": "$i")
+    add_hash("isPartOf[].$append")
+    add_array("isPartOf[].$last.hasSuperordinate[]")
+    add_hash( "isPartOf[].$last.hasSuperordinate[].$append")
+    add_array("isPartOf[].$last.hasSuperordinate[].$last.label")
+    do list(path:"$i.a", "var":"$j")
+      copy_field("$j", "isPartOf[].$last.hasSuperordinate[].$last.label.$append")
+    end
+    join_field("isPartOf[].$last.hasSuperordinate[].$last.label", " / ")
+    call_macro("alternateGraphicRepresentationIsPartOf",variable:"$i")
+
+    add_array("isPartOf[].$last.numbering")
+    do list(path:"$i.v", "var":"$j")
+      copy_field("$j", "isPartOf[].$last.numbering.$append")
+    end
+    join_field("isPartOf[].$last.numbering")
+  end
+end
 
 # 830 - Series Added Entry-Uniform Title (R) - Subfield: $w (R), $a (NR), $v (NR)
 # Element can be repeatable with local entries they have subfield $M.
@@ -157,7 +178,7 @@ do list(path: "830??", "var": "$i")
   add_hash("isPartOf[].$append")
   add_array("isPartOf[].$last.hasSuperordinate[]")
   add_hash( "isPartOf[].$last.hasSuperordinate[].$append")
-  if all_match("$i.w", "^\\((?:DE-600|DE-605|DE-603)\\)(.+)$")
+  if all_match("$i.w", "^\\((?:DE-600|DE-605)\\)(.+)$")
     copy_field("$i.w", "isPartOf[].$last.hasSuperordinate[].$last.id")
   end
   do list(path:"$i.a", "var":"$j")
@@ -169,7 +190,7 @@ do list(path: "830??", "var": "$i")
   end
 end
 
-do list(path: "4901?", "var": "$j")
+do list(path: "4901?", "var": "$j") #alternateGraphicRepresentation for 830 is included in 4901?
   call_macro("alternateGraphicRepresentationIsPartOf",variable:"$j")
 end
 
@@ -205,17 +226,19 @@ if any_match("leader", "^.{7}[ad].*")
               end
             end
           end
-        else
-          add_hash("isPartOf[].$append")
-          add_array("isPartOf[].$last.hasSuperordinate[]")
-          add_hash( "isPartOf[].$last.hasSuperordinate[].$append")
-          copy_field("$i.t", "isPartOf[].$last.hasSuperordinate[].$last.label")
-          call_macro("alternateGraphicRepresentationIsPartOf",variable:"$i")
-          copy_field("$i.q", "isPartOf[].$last.numbering")
+        else # Handling of relations without HBZ/ZDB identifier
+          unless exists("isPartOf[].1.hasSuperordinate[].1.id")  # This skips the mapping of relations without HBZ/ZDB refrence if already an isPartOf[] Object exists that links to a HBZ/ZDB resource.
+            add_hash("isPartOf[].$append")
+            add_array("isPartOf[].$last.hasSuperordinate[]")
+            add_hash( "isPartOf[].$last.hasSuperordinate[].$append")
+            copy_field("$i.t", "isPartOf[].$last.hasSuperordinate[].$last.label")
+            call_macro("alternateGraphicRepresentationIsPartOf",variable:"$i")
+            copy_field("$i.q", "isPartOf[].$last.numbering")
           replace_all("isPartOf[].$last.numbering", "^\\d","")  # Hebis specific adjustment of Sortierform.
-          add_array("isPartOf[].$last.note[]")
-          do list(path:"$i.i","var":"$k")
-            copy_field("$k","isPartOf[].$last.note[].$append")
+            add_array("isPartOf[].$last.note[]")
+            do list(path:"$i.i","var":"$k")
+              copy_field("$k","isPartOf[].$last.note[].$append")
+            end
           end
         end
       end
@@ -234,9 +257,17 @@ if any_match("leader", "^.{7}[ad].*")
 end
 
 do list(path: "isPartOf[]","var":"$i")
+  if is_empty("$i.hasSuperordinate[].1")
+    if exists("$i.numbering")
+      add_field("$i.hasSuperordinate[].1.label","") # Add dummi field
+    end
+  end
   unless is_empty("$i.hasSuperordinate[].1")
     do list(path:"$i.hasSuperordinate[]", "var": "$j") ## This is the fallback for isPartOf[].*.hasSuperordinate[].*.label
       unless exists("$j.label")
+        copy_field("@title", "$j.label")
+      end
+      if is_empty("$j.label")
         copy_field("@title", "$j.label")
       end
     end
@@ -347,9 +378,13 @@ add_array("fulltextOnline[]")
 do list(path: "856??", "var":"$i")
   if exists("$i.u")
     unless any_match("$i.u",".*(doi.org|urn=urn:|\\.(org|de)/urn:).*") # This should not skip repository links like: https://sammlungen.ulb.uni-muenster.de/urn/urn:nbn:de:hbz:6-85659520092
-      if all_equal("$i.z", "kostenfrei") # kostenfrei, added Digitalisierung not only Verlag or Agentur as filter
-          if all_match("$i.x", ".*(Verlag|Agentur|Digitalisierung).*")
-            copy_field("$i.x", "fulltextOnline[].$append.label")
+      if any_equal("$i.z", "kostenfrei") # kostenfrei, added more types of resources
+          if any_match("$i.x", ".*(Verlag|Agentur|Digitalisierung|Archivierte Online|EZB|Online-Ausg|Resolving-System|Volltext).*")
+            if exists("$i.x.1")
+              copy_field("$i.x.1", "fulltextOnline[].$append.label")
+            else
+              copy_field("$i.x", "fulltextOnline[].$append.label")
+            end
             copy_field("$i.u", "fulltextOnline[].$last.id")
           else
             unless exists("$i.x") # also map if kostenfrei and no specific link description
@@ -360,12 +395,14 @@ do list(path: "856??", "var":"$i")
       elsif any_equal("$i.7","0") # Open Access Marker
         add_field("fulltextOnline[].$append.label","Online-Ressource")
         copy_field("$i.u", "fulltextOnline[].$last.id")
-      end
-      if all_match("$i.x", ".*(Archivierte Online|EZB|Online-Ausg|Resolving-System|Volltext).*")
-        copy_field("$i.x", "fulltextOnline[].$append.label")
+      elsif any_match("$i.x", ".*(Archivierte Online|EZB|Online-Ausg|Resolving-System|Volltext).*")
+        if exists("$i.x.1")
+          copy_field("$i.x.1", "fulltextOnline[].$append.label")
+        else
+          copy_field("$i.x", "fulltextOnline[].$append.label")
+        end
         copy_field("$i.u", "fulltextOnline[].$last.id")
-      end
-      if all_match("$i.3", "^[vV][oO][lL].*") # Volltext
+      elsif any_match("$i.3", "^[vV][oO][lL].*") # Volltext
         copy_field("$i.3", "fulltextOnline[].$append.label")
         copy_field("$i.u", "fulltextOnline[].$last.id")
       end
@@ -500,6 +537,20 @@ if any_equal("MBD  .M", "49HBZ_NETWORK")
   else
     unless any_match("035  .a", "^\\(EXLCZ\\).+$")
       add_field("@inNZ", "true")
+    end
+  end
+end
+
+# not needed for rpb
+# copy_field("@todaysYear","@todaysYearMinus9")
+# de.hbz.lobid.helper.Minus("@todaysYearMinus9","9")
+# to_var("@todaysYearMinus9","todaysYearMinus9")
+unless is_array("008")
+  if any_match("008","^.{6}[\\|bresticdkmu](\\d{4}).*$")
+    copy_field("008","@008standardPubDate")
+    replace_all("@008standardPubDate","^.{7}(\\d{4}).*$","$1")
+    if any_match("@008standardPubDate",".*?([01]\\d{3}|20\\d{2}).*")
+      copy_field("@008standardPubDate","@standardPubDate")
     end
   end
 end
@@ -828,7 +879,7 @@ prepend("exampleOfWork.language[].*.id", "http://id.loc.gov/vocabulary/iso639-2/
 # 730 - Added Entry-Uniform Title (R)
 
 add_array("containsExampleOfWork[]")
-do list(path:"700?2|710?2|711?2|730?2", "var": "$i")
+do list(path:"700?2|710?2|711?2", "var": "$i")
   add_array("containsExampleOfWork[].$append.label")
   add_array("containsExampleOfWork[].$last.creatorOfWork")
   copy_field("$i.a","containsExampleOfWork[].$last.creatorOfWork.$append")
@@ -854,5 +905,26 @@ do list(path:"700?2|710?2|711?2|730?2", "var": "$i")
   end
 end
 
+do list(path:"730?2", "var": "$i")
+  add_array("containsExampleOfWork[].$append.label")
+  copy_field("$i.a","containsExampleOfWork[].$last.label.$append")
+  copy_field("$i.d","containsExampleOfWork[].$last.label.$append")
+  join_field("containsExampleOfWork[].$last.label", " ")
+  copy_field("$i.n","containsExampleOfWork[].$last.workNumbering")
+  copy_field("$i.r","containsExampleOfWork[].$last.musicalKey")
+  add_array("containsExampleOfWork[].$last.type[]","Work")
+  add_array("containsExampleOfWork[].$last.instrumentation[]")
+  do list(path:"$i.m","var":"$j")
+    copy_field("$j","containsExampleOfWork[].$last.instrumentation[].$append")
+  end
+  do list(path: "$i.0", "var":"$k")
+    if any_match("$k", "^\\(DE-588\\).+$")
+      copy_field("$k", "containsExampleOfWork[].$last.id")
+      replace_all("containsExampleOfWork[].$last.id","^\\(DE-588\\)(.+$)","https://d-nb.info/gnd/$1")
+    end
+  end
+end
+
 replace_all("containsExampleOfWork[].*.label","<<|>>","")
+
 uniq("inCollection[]")

--- a/etl/hebisMarc2lobid-transformation/fix/titleRelatedFields.fix
+++ b/etl/hebisMarc2lobid-transformation/fix/titleRelatedFields.fix
@@ -212,16 +212,18 @@ if exists("publication[].$first")
   copy_field("362??.a","publication[].$first.publicationHistory")
     add_array("publication[].$first.frequency[]")
     if any_match("leader","^.{6}(a[bis]|m[bis]).*$") # checks if continous ressource
-      unless any_match("008","^.{18}[#\\| u].*$") # filters out not matching values and also the value unknown
-        copy_field("008","publication[].$first.frequency[].$append.id")
-        replace_all("publication[].$first.frequency[].$last.id", "^.{18}(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
-        copy_field("publication[].$first.frequency[].$last.id","publication[].$first.frequency[].$last.label")
-        lookup("publication[].$first.frequency[].$last.label","marc-publication-frequency-label")
+      unless is_array("008")
+        if any_match("008","^.{18}[abcdefghijkmqstuwz].*$") # filters out not matching values
+          copy_field("008","publication[].$first.frequency[].$append.id")
+          replace_all("publication[].$first.frequency[].$last.id", "^.{18}(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
+          copy_field("publication[].$first.frequency[].$last.id","publication[].$first.frequency[].$last.label")
+          lookup("publication[].$first.frequency[].$last.label","marc-publication-frequency-label")
+        end
       end
     elsif any_match("006","^s.*$")
       do list(path: "006", "var":"$z")
         if any_match("$z","^s.*$")
-          unless any_match("$z","^.[#\\| u].*$")
+          if any_match("$z","^.[abcdefghijkmqstuwz].*$") # filters out not matching values
             copy_field("$z","publication[].$first.frequency[].$append.id")
             replace_all("publication[].$first.frequency[].$last.id", "^.(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
             copy_field("publication[].$first.frequency[].$last.id","publication[].$first.frequency[].$last.label")
@@ -258,20 +260,24 @@ if exists("publication[].$first")
     end
   end
   unless exists("publication[].$first.startDate")
-    if any_match("008","^.{6}[\\|bresticdkmu](\\d{4}).*$")
-      copy_field("008","@008startDate")
-      replace_all("@008startDate","^.{7}(\\d{4}).*$","$1")
-      if any_match("@008startDate",".*?([01]\\d{3}|20\\d{2}).*")
-      copy_field("@008startDate","publication[].$first.startDate")
+    unless is_array("008")
+      if any_match("008","^.{6}[\\|bresticdkmu](\\d{4}).*$")
+        copy_field("008","@008startDate")
+        replace_all("@008startDate","^.{7}(\\d{4}).*$","$1")
+        if any_match("@008startDate",".*?([01]\\d{3}|20\\d{2}).*")
+          copy_field("@008startDate","publication[].$first.startDate")
+        end
+      end
     end
   end
-  end
   unless exists("publication[].$first.endDate")
-    if any_match("008","^.{6}[cdkmu]\\d{4}(\\d{4}).*$")
-      copy_field("008","@008endDate")
-      replace_all("@008endDate","^.{11}(\\d{4}).*$","$1")
-      unless any_equal("@008endDate","9999")
-        copy_field("@008endDate","publication[].$first.endDate")
+    unless is_array("008")
+      if any_match("008","^.{6}[cdkmu]\\d{4}(\\d{4}).*$")
+        copy_field("008","@008endDate")
+        replace_all("@008endDate","^.{11}(\\d{4}).*$","$1")
+        unless any_equal("@008endDate","9999")
+          copy_field("@008endDate","publication[].$first.endDate")
+        end
       end
     end
   end
@@ -297,23 +303,46 @@ end
 # 533 - Reproduction Note (R)
 
 do list(path:"533  ", "var": "$i")
-  add_hash( "publication[].$append")
-  add_array("publication[].$last.type[]","SecondaryPublicationEvent")
-  add_array("publication[].$last.location[]")
-  do list(path:"$i.b","var":"$j")
-    copy_field("$j", "publication[].$last.location[].$append")
-  end
-  add_array("publication[].$last.description[]")
-  copy_field("$i.a", "publication[].$last.description[].$append")
-  add_array("publication[].$last.publishedBy[]")
-  copy_field("$i.c", "publication[].$last.publishedBy[].$append")
-  do list(path: "$i.d", "var":"$j")
-    call_macro("publicationDateCleaner",date:"$j")
-    unless exists("publication[].$last.startDate")
-      call_macro("publicationStartDate",date:"$j",dateTarget:"publication[].$last.startDate")
+  unless is_array("$i.c") # Check if multiple SecondaryPublication are combined in 533
+    add_hash( "publication[].$append")
+    add_array("publication[].$last.type[]","SecondaryPublicationEvent")
+    add_array("publication[].$last.location[]")
+    do list(path:"$i.b","var":"$j")
+      copy_field("$j", "publication[].$last.location[].$append")
     end
-    unless exists("publication[].$last.endDate")
-      call_macro("publicationEndDate",date:"$j",dateTarget:"publication[].$last.endDate")
+    add_array("publication[].$last.description[]")
+    copy_field("$i.a", "publication[].$last.description[].$append")
+    add_array("publication[].$last.publishedBy[]")
+    copy_field("$i.c", "publication[].$last.publishedBy[].$append")
+    do list(path: "$i.d", "var":"$j")
+      call_macro("publicationDateCleaner",date:"$j")
+      unless exists("publication[].$last.startDate")
+        call_macro("publicationStartDate",date:"$j",dateTarget:"publication[].$last.startDate")
+      end
+      unless exists("publication[].$last.endDate")
+        call_macro("publicationEndDate",date:"$j",dateTarget:"publication[].$last.endDate")
+      end
+    end
+  end
+  if is_array("$i.c")  # Check if multiple SecondaryPublication are combined in 533
+    do list_as($LOCATION:"$i.b",$PUBLISHER:"$i.c")
+      add_hash( "publication[].$append")
+      add_array("publication[].$last.type[]","SecondaryPublicationEvent")
+      add_array("publication[].$last.location[]")
+      copy_field("$LOCATION", "publication[].$last.location[].$append")
+      add_array("publication[].$last.description[]")
+      copy_field("$i.a", "publication[].$last.description[].$append")
+      add_array("publication[].$last.publishedBy[]")
+      copy_field("$PUBLISHER", "publication[].$last.publishedBy[].$append")
+      do list(path: "$i.d", "var":"$j")
+        call_macro("publicationDateCleaner",date:"$j")
+        unless exists("publication[].$last.startDate")
+          call_macro("publicationStartDate",date:"$j",dateTarget:"publication[].$last.startDate")
+        end
+        unless exists("publication[].$last.endDate")
+          call_macro("publicationEndDate",date:"$j",dateTarget:"publication[].$last.endDate")
+        end
+      end
     end
   end
 end
@@ -342,6 +371,7 @@ end
 timestamp("@todaysYear",format:"yyyy")
 to_var("@todaysYear","todaysYear")
 if greater_than("publication[].1.startDate","$[todaysYear]")
+  unless is_array("008")
     copy_field("008","@008startDateTest")
     replace_all("@008startDateTest","^.{7}(\\d{4}).*$","$1")
     if less_than("@008startDateTest","$[todaysYear]")
@@ -349,8 +379,10 @@ if greater_than("publication[].1.startDate","$[todaysYear]")
     elsif any_equal("@008startDateTest","$[todaysYear]")
       copy_field("@008startDateTest","publication[].1.startDate")
     end
+  end
 end
 if greater_than("publication[].1.endDate","$[todaysYear]")
+  unless is_array("008")
     copy_field("008","@008endDateTest")
     replace_all("@008endDateTest","^.{11}(\\d{4}).*$","$1")
     if less_than("@008endDateTest","$[todaysYear]")
@@ -358,6 +390,7 @@ if greater_than("publication[].1.endDate","$[todaysYear]")
     elsif any_equal("@008endDateTest","$[todaysYear]")
       copy_field("@008endDateTest","publication[].1.endDate")
     end
+  end
 end
 
 # 246 - Varying Form of Title (R) - $a - Title proper/short title (NR)

--- a/etl/hebisMarc2lobid-transformation/maps/marcRel.tsv
+++ b/etl/hebisMarc2lobid-transformation/maps/marcRel.tsv
@@ -1,146 +1,311 @@
-uri	label	multiLangLabelDe	multiLangLabelEn
-http://id.loc.gov/vocabulary/relators/abr	Kürzende/r	Kürzende/r	Abridger
-http://id.loc.gov/vocabulary/relators/act	Schauspieler/in	Schauspieler/in	Actor
-http://id.loc.gov/vocabulary/relators/adi	Art Director	Art Director	Art director
-http://id.loc.gov/vocabulary/relators/aft	Verfasser/in eines Nachworts	Verfasser/in eines Nachworts	Writer of afterword
-http://id.loc.gov/vocabulary/relators/anm	Animation	Animation	Animator
-http://id.loc.gov/vocabulary/relators/ann	Annotationen	Annotationen	Annotator
-http://id.loc.gov/vocabulary/relators/ant	Basiert auf einem Werk von	Basiert auf einem Werk von	Bibliographic antecedent
-http://id.loc.gov/vocabulary/relators/ape	Berufungsbeklagte/r / Revisionsbeklagte/r	Berufungsbeklagte/r / Revisionsbeklagte/r	Appellee
-http://id.loc.gov/vocabulary/relators/apl	Berufungskläger/in / Revisionskläger/in	Berufungskläger/in / Revisionskläger/in	Appellant
-http://id.loc.gov/vocabulary/relators/arc	Architekt/in	Architekt/in	Architect
-http://id.loc.gov/vocabulary/relators/arr	Arrangement	Arrangement	Arranger of music
-http://id.loc.gov/vocabulary/relators/art	Künstler/in	Künstler/in	Artist
-http://id.loc.gov/vocabulary/relators/ato	Unterzeichner/in	Unterzeichner/in	Autographer
-http://id.loc.gov/vocabulary/relators/aui	Vorwort	Vorwort	Writer of foreword
-http://id.loc.gov/vocabulary/relators/aus	Drehbuch	Drehbuch	Screenwriter
-http://id.loc.gov/vocabulary/relators/aut	Autor/in	Autor/in	Author
-http://id.loc.gov/vocabulary/relators/bkd	Buchgestaltung	Buchgestaltung	Book designer
-http://id.loc.gov/vocabulary/relators/bnd	Buchbinder/in	Buchbinder/in	Binder
-http://id.loc.gov/vocabulary/relators/brd	Sender	Sender	Broadcaster
-http://id.loc.gov/vocabulary/relators/brl	Brailleprägung	Braillesprägung	Braille embosser
-http://id.loc.gov/vocabulary/relators/cas	Formguß	Formguß	Caster
-http://id.loc.gov/vocabulary/relators/chr	Choreographie	Choreographie	Choreographer
-http://id.loc.gov/vocabulary/relators/clb	Mitarbeit	Mitarbeit	Collaborator
-http://id.loc.gov/vocabulary/relators/cll	Kalligrafie	Kalligrafie	Calligrapher
-http://id.loc.gov/vocabulary/relators/clr	Kolorierung	Kolorierung	Colourist
-http://id.loc.gov/vocabulary/relators/clt	Lichtdruck	Lichtdruck	Collotyper
-http://id.loc.gov/vocabulary/relators/cmm	Kommentar	Kommentar	Commentator
-http://id.loc.gov/vocabulary/relators/cmp	Komposition	Komposition	Composer
-http://id.loc.gov/vocabulary/relators/cnd	Dirigent/in / Leitung	Dirigent/in / Leitung	Conductor
-http://id.loc.gov/vocabulary/relators/cng	Kamera	Kamera	Cinematographer
-http://id.loc.gov/vocabulary/relators/cns	Zensor/in	Zensor/in	Censor
-http://id.loc.gov/vocabulary/relators/col	Sammler/in	Sammler/in	Collector
-http://id.loc.gov/vocabulary/relators/com	Zusammengestellt von	Zusammengestellt von	Compiler
-http://id.loc.gov/vocabulary/relators/cor	Registrar/in	Registrar/in	Collection registrar
-http://id.loc.gov/vocabulary/relators/cou	Durch Verfahrensvorschriften geregeltes Gericht	Durch Verfahrensvorschriften geregeltes Gericht	Court governed
-http://id.loc.gov/vocabulary/relators/cre	Schöpfer/in	Schöpfer/in	Creator
-http://id.loc.gov/vocabulary/relators/crt	Gerichtsstenograf/in	Gerichtsstenograf/in	Court reporter
-http://id.loc.gov/vocabulary/relators/csl	Beratung	Beratung	Consultant
-http://id.loc.gov/vocabulary/relators/cst	Kostümdesign	Kostümdesign	Costume designer
-http://id.loc.gov/vocabulary/relators/ctb	Beitragende/r	Beitragende/r	Contributor
-http://id.loc.gov/vocabulary/relators/ctg	Kartografie	Kartografie	Cartographer
-http://id.loc.gov/vocabulary/relators/ctr	Vertragspartner/in	Vertragspartner/in	Participant in a treaty
-http://id.loc.gov/vocabulary/relators/cur	Kurator/in	Kurator/in	Curator
-http://id.loc.gov/vocabulary/relators/dfd	Angeklagte/r	Angeklagte/r	Defendant
-http://id.loc.gov/vocabulary/relators/dgg	Grad-verleihende Institution	Grad-verleihende Institution	Degree granting institution
-http://id.loc.gov/vocabulary/relators/dgs	Akademische Betreuung	Akademische Betreuung	Degree supervisor
-http://id.loc.gov/vocabulary/relators/dnc	Tänzer/in	Tänzer/in	Dancer
-http://id.loc.gov/vocabulary/relators/dnr	Stifter/in	Stifter/in	Donor
-http://id.loc.gov/vocabulary/relators/dpt	Leihgabe von	Leihgabe von	Depositor
-http://id.loc.gov/vocabulary/relators/drm	Technische Zeichnungen	Technische Zeichnungen	Draftsman
-http://id.loc.gov/vocabulary/relators/drt	Regie	Regie	Director
-http://id.loc.gov/vocabulary/relators/dsr	Design	Design	Designer
-http://id.loc.gov/vocabulary/relators/dst	Vertrieb	Vertrieb	Distributor
-http://id.loc.gov/vocabulary/relators/dte	Gewidmet	Gewidmet	Dedicatee
-http://id.loc.gov/vocabulary/relators/dto	Widmende/r	Widmende/r	Dedicator
-http://id.loc.gov/vocabulary/relators/edm	Schnitt	Schnitt	Editor of moving image work
-http://id.loc.gov/vocabulary/relators/edt	Herausgeber/in	Herausgeber/in	Editor
-http://id.loc.gov/vocabulary/relators/egr	Stecher/in	Stecher/in	Engraver
-http://id.loc.gov/vocabulary/relators/enj	Normerlassende Gebietskörperschaft	Normerlassende Gebietskörperschaft	Enacting jurisdiction
-http://id.loc.gov/vocabulary/relators/etr	Radierer/in	Radierer/in	Etcher
-http://id.loc.gov/vocabulary/relators/fds	Filmvertrieb	Filmvertrieb	Film distributor
-http://id.loc.gov/vocabulary/relators/fmd	Filmregie	Filmregie	Film director
-http://id.loc.gov/vocabulary/relators/fmk	Filmemacher/in	Filmemacher/in	Filmmaker
-http://id.loc.gov/vocabulary/relators/fmo	frühere/r Eigentümer/in	frühere/r Eigentümer/in	Former owner
-http://id.loc.gov/vocabulary/relators/fmp	Filmproduktion	Filmproduktion	Film producer
-http://id.loc.gov/vocabulary/relators/his	Gastgebende Institution	Gastgebende Institution	Host institution
-http://id.loc.gov/vocabulary/relators/hnr	Gefeierte Person	Gefeierte Person	Honouree
-http://id.loc.gov/vocabulary/relators/hst	Gastgeber/in	Gastgeber/in	Host
-http://id.loc.gov/vocabulary/relators/ill	Illustration	Illustration	Illustrator
-http://id.loc.gov/vocabulary/relators/ilu	Illuminator/in	Illuminator/in	Illuminator
-http://id.loc.gov/vocabulary/relators/ins	Beschriftende Person	Beschriftende Person	Inscriber
-http://id.loc.gov/vocabulary/relators/inv	Erfinder/in	Erfinder/in	Inventor
-http://id.loc.gov/vocabulary/relators/isb	Herausgeber/in	Herausgeber/in	Issuing body
-http://id.loc.gov/vocabulary/relators/itr	Instrumentalmusiker/in	Instrumentalmusiker/in	Instrumentalist
-http://id.loc.gov/vocabulary/relators/ive	Interviewte/r	Interviewte/r	Interviewee
-http://id.loc.gov/vocabulary/relators/ivr	Interviewer/in	Interviewer/in	Interviewer
-http://id.loc.gov/vocabulary/relators/jud	Richter/in	Richter/in	Judge
-http://id.loc.gov/vocabulary/relators/jug	Geregelte Gebietskörperschaft	Geregelte Gebietskörperschaft	Jurisdiction governed
-http://id.loc.gov/vocabulary/relators/lbt	Libretto	Libretto	Librettist
-http://id.loc.gov/vocabulary/relators/led	Leitung	Leitung	Lead
-http://id.loc.gov/vocabulary/relators/lgd	Lichtgestaltung	Lichtgestaltung	Lighting designer
-http://id.loc.gov/vocabulary/relators/lsa	Landschaftsarchitekt/in	Landschaftsarchitekt/in	Landscape architect
-http://id.loc.gov/vocabulary/relators/ltg	Lithografie	Lithografie	Lithographer
-http://id.loc.gov/vocabulary/relators/lyr	Textdichter/in	Textdichter/in	Lyricist
-http://id.loc.gov/vocabulary/relators/med	Medium	Medium	Medium
-http://id.loc.gov/vocabulary/relators/mfr	Herstellung	Herstellung	Manufacturer
-http://id.loc.gov/vocabulary/relators/mod	Moderation	Moderation	Moderator
-http://id.loc.gov/vocabulary/relators/msd	Musikalische Leitung	Musikalische Leitung	Musical director
-http://id.loc.gov/vocabulary/relators/mtk	Protokoll	Protokoll	Minute taker
-http://id.loc.gov/vocabulary/relators/mus	Musiker/in	Musiker/in	Musician
-http://id.loc.gov/vocabulary/relators/nrt	Erzähler/in	Erzähler/in	Narrator
-http://id.loc.gov/vocabulary/relators/org	Begründet durch	Begründet durch	Originator
-http://id.loc.gov/vocabulary/relators/orm	Veranstalter/in	Veranstalter/in	Organizer
-http://id.loc.gov/vocabulary/relators/osp	On-Screen-Präsentator/in	On-Screen-Präsentator/in	On-screen presenter
-http://id.loc.gov/vocabulary/relators/oth	Sonstige	Sonstige	Other agent associated with a work
-http://id.loc.gov/vocabulary/relators/own	Eigentümer/in	Eigentümer/in	Owner
-http://id.loc.gov/vocabulary/relators/pan	Diskussionsteilnehmer/in	Diskussionsteilnehmer/in	Panelist
-http://id.loc.gov/vocabulary/relators/pat	Im Auftrag von	Im Auftrag von	Commissioning body
-http://id.loc.gov/vocabulary/relators/pbd	Chefredaktion	Chefredaktion	Editorial director
-http://id.loc.gov/vocabulary/relators/pbl	Verlag	Verlag	Publisher
-http://id.loc.gov/vocabulary/relators/pht	Fotografie	Fotografie	Photographer
-http://id.loc.gov/vocabulary/relators/plt	Druckformherstellung	Druckformherstellung	Platemaker
-http://id.loc.gov/vocabulary/relators/ppm	Papiermacher/in	Papiermacher/in	Papermaker
-http://id.loc.gov/vocabulary/relators/ppt	Puppenspieler/in	Puppenspieler/in	Puppeteer
-http://id.loc.gov/vocabulary/relators/pra	Praeses	Praeses	Praeses
-http://id.loc.gov/vocabulary/relators/pre	Präsentation	Präsentation	Presenter
-http://id.loc.gov/vocabulary/relators/prf	Ausführende/r	Ausführende/r	Performer
-http://id.loc.gov/vocabulary/relators/prg	Programmiererung	Programmiererung	Programmer
-http://id.loc.gov/vocabulary/relators/prm	Druckgrafik	Druckgrafik	Printmaker
-http://id.loc.gov/vocabulary/relators/prn	Produktionsfirma	Produktionsfirma	Production company
-http://id.loc.gov/vocabulary/relators/pro	Produktion	Produktion	Producer
-http://id.loc.gov/vocabulary/relators/prs	Produktionsdesign	Produktionsdesign	Production designer
-http://id.loc.gov/vocabulary/relators/prt	Druck	Druck	Printer
-http://id.loc.gov/vocabulary/relators/ptf	Zivilkläger/in	Zivilkläger/in	Plaintiff
-http://id.loc.gov/vocabulary/relators/rcd	Ton	Ton	Recordist
-http://id.loc.gov/vocabulary/relators/rce	Aufnahmetechniker/in	Aufnahmetechniker/in	Recording engineer
-http://id.loc.gov/vocabulary/relators/rcp	Adressat/in	Adressat/in	Addressee
-http://id.loc.gov/vocabulary/relators/rdd	Hörfunkregisseur/in	Hörfunkregisseur/in	Radio director
-http://id.loc.gov/vocabulary/relators/red	Redaktion	Redaktion	Redaktor
-http://id.loc.gov/vocabulary/relators/res	Forscher/in	Forscher/in	Researcher
-http://id.loc.gov/vocabulary/relators/rpc	Hörfunkproduktion	Hörfunkproduktion	Radio producer
-http://id.loc.gov/vocabulary/relators/rsp	Respondent/in	Respondent/in	Respondent
-http://id.loc.gov/vocabulary/relators/rsr	Restaurator/in	Restaurator/in	Restorationist
-http://id.loc.gov/vocabulary/relators/scl	Bildhauer/in	Bildhauer/in	Sculptor
-http://id.loc.gov/vocabulary/relators/sds	Tongestaltung	Tongestaltung	Sound designer
-http://id.loc.gov/vocabulary/relators/sgd	Bühnenregie	Bühnenregie	Stage director
-http://id.loc.gov/vocabulary/relators/sll	Verkäufer/in	Verkäufer/in	Seller
-http://id.loc.gov/vocabulary/relators/sng	Gesang	Gesang	Singer
-http://id.loc.gov/vocabulary/relators/spk	Redner/in	Redner/in	Speaker
-http://id.loc.gov/vocabulary/relators/spn	Träger/in	Träger/in	Sponsoring body
-http://id.loc.gov/vocabulary/relators/srv	Landvermessung	Landvermessung	Surveyor
-http://id.loc.gov/vocabulary/relators/stl	Geschichtenerzähler/in	Geschichtenerzähler/in	Storyteller
-http://id.loc.gov/vocabulary/relators/tch	Ausbilder/in	Ausbilder/in	Teacher
-http://id.loc.gov/vocabulary/relators/tld	Fernsehregie	Fernsehregie	Television director
-http://id.loc.gov/vocabulary/relators/tlp	Fernsehproduktion	Fernsehproduktion	Television producer
-http://id.loc.gov/vocabulary/relators/trc	Transkription	Transkription	Transcriber
-http://id.loc.gov/vocabulary/relators/trl	Übersetzung	Übersetzung	Translator
-http://id.loc.gov/vocabulary/relators/vac	Synchronsprecher/in	Synchronsprecher/in	Voice actor
-http://id.loc.gov/vocabulary/relators/vdg	Kamera	Kamera	Director of photography
-http://id.loc.gov/vocabulary/relators/wac	Zusätzlicher Kommentar	Zusätzlicher Kommentar	Writer of added commentary
-http://id.loc.gov/vocabulary/relators/wal	Verfasser/in von zusätzlichen Lyrics	Verfasser/in von zusätzlichen Lyrics	Writer of added lyrics
-http://id.loc.gov/vocabulary/relators/wat	Zusätzlicher Text	Zusätzlicher Text	Writer of added text
-http://id.loc.gov/vocabulary/relators/win	Einleitung	Einleitung	Writer of introduction
-http://id.loc.gov/vocabulary/relators/wpr	Vorwort	Vorwort	Writer of preface
-http://id.loc.gov/vocabulary/relators/wst	Verfasser/in von ergänzendem Text	Verfasser/in von ergänzendem Text	Writer of supplementary textual content
+uri	code	term	label@en	label@de
+http://id.loc.gov/vocabulary/relators/abr	abr	abridger	Abridger	Kürzende/r
+http://id.loc.gov/vocabulary/relators/acp	acp	art copyist	Art copyist
+http://id.loc.gov/vocabulary/relators/act	act	actor	Actor	Schauspieler/in
+http://id.loc.gov/vocabulary/relators/adi	adi	art director	Art director	Art Director
+http://id.loc.gov/vocabulary/relators/adp	adp	adapter	Adapter
+http://id.loc.gov/vocabulary/relators/afd	afd	assistant film director	Assistant film director
+http://id.loc.gov/vocabulary/relators/aft	aft	author of afterword, colophon, etc.	Writer of afterword	Verfasser/in eines Nachworts
+http://id.loc.gov/vocabulary/relators/anc	anc	announcer	Announcer
+http://id.loc.gov/vocabulary/relators/anl	anl	analyst	Analyst
+http://id.loc.gov/vocabulary/relators/anm	anm	animator	Animator	Animation
+http://id.loc.gov/vocabulary/relators/ann	ann	annotator	Annotator	Annotationen
+http://id.loc.gov/vocabulary/relators/ant	ant	bibliographic antecedent	Bibliographic antecedent	Basiert auf einem Werk von
+http://id.loc.gov/vocabulary/relators/apb	apb	approbator	Approbator
+http://id.loc.gov/vocabulary/relators/ape	ape	appellee	Appellee	Berufungsbeklagte/r / Revisionsbeklagte/r
+http://id.loc.gov/vocabulary/relators/apl	apl	appellant	Appellant	Berufungskläger/in / Revisionskläger/in
+http://id.loc.gov/vocabulary/relators/app	app	applicant	Applicant
+http://id.loc.gov/vocabulary/relators/aqt	aqt	author in quotations or text abstracts	Author in quotations or text abstracts
+http://id.loc.gov/vocabulary/relators/arc	arc	architect	Architect	Architekt/in
+http://id.loc.gov/vocabulary/relators/ard	ard	artistic director	Artistic director
+http://id.loc.gov/vocabulary/relators/arr	arr	arranger	Arranger of music	Arrangement
+http://id.loc.gov/vocabulary/relators/art	art	artist	Artist	Künstler/in
+http://id.loc.gov/vocabulary/relators/asg	asg	assignee	Assignee
+http://id.loc.gov/vocabulary/relators/asn	asn	associated name	Associated name
+http://id.loc.gov/vocabulary/relators/ato	ato	autographer	Autographer	Unterzeichner/in
+http://id.loc.gov/vocabulary/relators/att	att	attributed name	Attributed name
+http://id.loc.gov/vocabulary/relators/auc	auc	auctioneer	Auctioneer
+http://id.loc.gov/vocabulary/relators/aud	aud	author of dialog	Author of dialog
+http://id.loc.gov/vocabulary/relators/aue	aue	audio engineer	Audio engineer	Tontechniker/in
+http://id.loc.gov/vocabulary/relators/aui	aui	author of introduction, etc.	Writer of foreword	Vorwort
+http://id.loc.gov/vocabulary/relators/aup	aup	audio producer	Audio producer	Produzent/in einer Tonaufnahme
+http://id.loc.gov/vocabulary/relators/aus	aus	screenwriter	Screenwriter	Drehbuch
+http://id.loc.gov/vocabulary/relators/aut	aut	author	Author	Autor/in
+http://id.loc.gov/vocabulary/relators/bdd	bdd	binding designer	Binding designer
+http://id.loc.gov/vocabulary/relators/bjd	bjd	bookjacket designer	Bookjacket designer
+http://id.loc.gov/vocabulary/relators/bka	bka	book artist	Book artist	Buchkünstler/in
+http://id.loc.gov/vocabulary/relators/bkd	bkd	book designer	Book designer	Buchgestaltung
+http://id.loc.gov/vocabulary/relators/bkp	bkp	book producer	Book producer
+http://id.loc.gov/vocabulary/relators/blw	blw	blurb writer	Blurb writer
+http://id.loc.gov/vocabulary/relators/bnd	bnd	binder	Binder	Buchbinder/in
+http://id.loc.gov/vocabulary/relators/bpd	bpd	bookplate designer	Bookplate designer
+http://id.loc.gov/vocabulary/relators/brd	brd	broadcaster	Broadcaster	Sender
+http://id.loc.gov/vocabulary/relators/brl	brl	braille embosser	Braille embosser	Brailleprägung
+http://id.loc.gov/vocabulary/relators/bsl	bsl	bookseller	Bookseller
+http://id.loc.gov/vocabulary/relators/cad	cad	casting director	Casting director	Casting Director
+http://id.loc.gov/vocabulary/relators/cas	cas	caster	Caster	Formguss
+http://id.loc.gov/vocabulary/relators/ccp	ccp	conceptor	Conceptor
+http://id.loc.gov/vocabulary/relators/chr	chr	choreographer	Choreographer	Choreographie
+http://id.loc.gov/vocabulary/relators/clb	clb	collaborator	Collaborator	Mitarbeit
+http://id.loc.gov/vocabulary/relators/cli	cli	client	Client
+http://id.loc.gov/vocabulary/relators/cll	cll	calligrapher	Calligrapher	Kalligrafie
+http://id.loc.gov/vocabulary/relators/clr	clr	colorist	Colourist	Kolorierung
+http://id.loc.gov/vocabulary/relators/clt	clt	collotyper	Collotyper	Lichtdruck
+http://id.loc.gov/vocabulary/relators/cmm	cmm	commentator	Commentator	Kommentar
+http://id.loc.gov/vocabulary/relators/cmp	cmp	composer	Composer	Komposition
+http://id.loc.gov/vocabulary/relators/cmt	cmt	compositor	Compositor
+http://id.loc.gov/vocabulary/relators/cnd	cnd	conductor	Conductor	Dirigent/in / Leitung
+http://id.loc.gov/vocabulary/relators/cng	cng	cinematographer	Cinematographer	Kamera
+http://id.loc.gov/vocabulary/relators/cns	cns	censor	Censor	Zensor/in
+http://id.loc.gov/vocabulary/relators/coe	coe	contestant-appellee	Contestant-appellee
+http://id.loc.gov/vocabulary/relators/col	col	collector	Collector	Sammler/in
+http://id.loc.gov/vocabulary/relators/com	com	compiler	Compiler	Zusammengestellt von
+http://id.loc.gov/vocabulary/relators/con	con	conservator	Conservator
+http://id.loc.gov/vocabulary/relators/cop	cop	camera operator	Camera operator
+http://id.loc.gov/vocabulary/relators/cor	cor	collection registrar	Collection registrar	Registrar/in
+http://id.loc.gov/vocabulary/relators/cos	cos	contestant	Contestant
+http://id.loc.gov/vocabulary/relators/cot	cot	contestant-appellant	Contestant-appellant
+http://id.loc.gov/vocabulary/relators/cou	cou	court governed	Court governed	Durch Verfahrensvorschriften geregeltes Gericht
+http://id.loc.gov/vocabulary/relators/cov	cov	cover designer	Cover designer
+http://id.loc.gov/vocabulary/relators/cpc	cpc	copyright claimant	Copyright claimant
+http://id.loc.gov/vocabulary/relators/cpe	cpe	complainant-appellee	Complainant-appellee
+http://id.loc.gov/vocabulary/relators/cph	cph	copyright holder	Copyright holder
+http://id.loc.gov/vocabulary/relators/cpl	cpl	complainant	Complainant
+http://id.loc.gov/vocabulary/relators/cpt	cpt	complainant-appellant	Complainant-appellant
+http://id.loc.gov/vocabulary/relators/cre	cre	creator	Creator	Schöpfer/in
+http://id.loc.gov/vocabulary/relators/crp	crp	correspondent	Correspondent
+http://id.loc.gov/vocabulary/relators/crr	crr	corrector	Corrector
+http://id.loc.gov/vocabulary/relators/crt	crt	court reporter	Court reporter	Gerichtsstenograf/in
+http://id.loc.gov/vocabulary/relators/csl	csl	consultant	Consultant	Beratung
+http://id.loc.gov/vocabulary/relators/csp	csp	consultant to a project	Consultant to a project
+http://id.loc.gov/vocabulary/relators/cst	cst	costume designer	Costume designer	Kostümdesign
+http://id.loc.gov/vocabulary/relators/ctb	ctb	contributor	Contributor	Beitragende/r
+http://id.loc.gov/vocabulary/relators/cte	cte	contestee-appellee	Contestee-appellee
+http://id.loc.gov/vocabulary/relators/ctg	ctg	cartographer	Cartographer	Kartografie
+http://id.loc.gov/vocabulary/relators/ctr	ctr	contractor	Participant in a treaty	Vertragspartner/in
+http://id.loc.gov/vocabulary/relators/cts	cts	contestee	Contestee
+http://id.loc.gov/vocabulary/relators/ctt	ctt	contestee-appellant	Contestee-appellant
+http://id.loc.gov/vocabulary/relators/cur	cur	curator	Curator	Kurator/in
+http://id.loc.gov/vocabulary/relators/cwt	cwt	commentator for written text	Commentator for written text
+http://id.loc.gov/vocabulary/relators/dbd	dbd	dubbing director	Dubbing director	Synchronregisseur/in
+http://id.loc.gov/vocabulary/relators/dbp	dbp	distribution place	Distribution place
+http://id.loc.gov/vocabulary/relators/dfd	dfd	defendant	Defendant	Angeklagte/r
+http://id.loc.gov/vocabulary/relators/dfe	dfe	defendant-appellee	Defendant-appellee
+http://id.loc.gov/vocabulary/relators/dft	dft	defendant-appellant	Defendant-appellant
+http://id.loc.gov/vocabulary/relators/dgc	dgc	degree committee member	Degree committee member	Mitglied eines Graduierungsausschusses
+http://id.loc.gov/vocabulary/relators/dgg	dgg	degree granting institution	Degree granting institution	Grad-verleihende Institution
+http://id.loc.gov/vocabulary/relators/dgs	dgs	degree supervisor	Degree supervisor	Akademische Betreuung
+http://id.loc.gov/vocabulary/relators/dis	dis	dissertant	Dissertant
+http://id.loc.gov/vocabulary/relators/djo	djo	dj	DJ	DJ
+http://id.loc.gov/vocabulary/relators/dln	dln	delineator	Delineator
+http://id.loc.gov/vocabulary/relators/dnc	dnc	dancer	Dancer	Tänzer/in
+http://id.loc.gov/vocabulary/relators/dnr	dnr	donor	Donor	Stifter/in
+http://id.loc.gov/vocabulary/relators/dpc	dpc	depicted	Depicted
+http://id.loc.gov/vocabulary/relators/dpt	dpt	depositor	Depositor	Leihgabe von
+http://id.loc.gov/vocabulary/relators/drm	drm	draftsman	Draftsman	Technische Zeichnungen
+http://id.loc.gov/vocabulary/relators/drt	drt	director	Director	Regie
+http://id.loc.gov/vocabulary/relators/dsr	dsr	designer	Designer	Design
+http://id.loc.gov/vocabulary/relators/dst	dst	distributor	Distributor	Vertrieb
+http://id.loc.gov/vocabulary/relators/dtc	dtc	data contributor	Data contributor
+http://id.loc.gov/vocabulary/relators/dte	dte	dedicatee	Dedicatee	Gewidmet
+http://id.loc.gov/vocabulary/relators/dtm	dtm	data manager	Data manager
+http://id.loc.gov/vocabulary/relators/dto	dto	dedicator	Dedicator	Widmende/r
+http://id.loc.gov/vocabulary/relators/dub	dub	dubious author	Dubious author
+http://id.loc.gov/vocabulary/relators/edc	edc	editor of compilation	Editor of compilation
+http://id.loc.gov/vocabulary/relators/edd	edd	editorial director	Editorial director	Chefredakteur/in
+http://id.loc.gov/vocabulary/relators/edm	edm	editor of moving image work	Editor of moving image work	Schnitt
+http://id.loc.gov/vocabulary/relators/edt	edt	editor	Editor	Herausgeber/in
+http://id.loc.gov/vocabulary/relators/egr	egr	engraver	Engraver	Stecher/in
+http://id.loc.gov/vocabulary/relators/elg	elg	electrician	Electrician
+http://id.loc.gov/vocabulary/relators/elt	elt	electrotyper	Electrotyper
+http://id.loc.gov/vocabulary/relators/eng	eng	engineer	Engineer
+http://id.loc.gov/vocabulary/relators/enj	enj	enacting jurisdiction	Enacting jurisdiction	Normerlassende Gebietskörperschaft
+http://id.loc.gov/vocabulary/relators/etr	etr	etcher	Etcher	Radierer/in
+http://id.loc.gov/vocabulary/relators/evp	evp	event place	Event place
+http://id.loc.gov/vocabulary/relators/exp	exp	expert	Expert
+http://id.loc.gov/vocabulary/relators/fac	fac	facsimilist	Facsimilist
+http://id.loc.gov/vocabulary/relators/fds	fds	film distributor	Film distributor	Filmvertrieb
+http://id.loc.gov/vocabulary/relators/fld	fld	field director	Field director
+http://id.loc.gov/vocabulary/relators/flm	flm	film editor	Film editor
+http://id.loc.gov/vocabulary/relators/fmd	fmd	film director	Film director	Filmregie
+http://id.loc.gov/vocabulary/relators/fmk	fmk	filmmaker	Filmmaker	Filmemacher/in
+http://id.loc.gov/vocabulary/relators/fmo	fmo	former owner	Former owner	frühere/r Eigentümer/in
+http://id.loc.gov/vocabulary/relators/fmp	fmp	film producer	Film producer	Filmproduktion
+http://id.loc.gov/vocabulary/relators/fnd	fnd	funder	Funder
+http://id.loc.gov/vocabulary/relators/fon	fon	founder	Founder	Begründer/in eines Werks
+http://id.loc.gov/vocabulary/relators/fpy	fpy	first party	First party
+http://id.loc.gov/vocabulary/relators/frg	frg	forger	Forger
+http://id.loc.gov/vocabulary/relators/gdv	gdv	game developer	Game developer
+http://id.loc.gov/vocabulary/relators/gis	gis	geographic information specialist	Geographic information specialist
+http://id.loc.gov/vocabulary/relators/grt	grt	graphic technician	Graphic technician
+http://id.loc.gov/vocabulary/relators/gst	gst	guest	Guest
+http://id.loc.gov/vocabulary/relators/his	his	host institution	Host institution	Gastgebende Institution
+http://id.loc.gov/vocabulary/relators/hnr	hnr	honoree	Honouree	Gefeierte Person
+http://id.loc.gov/vocabulary/relators/hst	hst	host	Host	Gastgeber/in
+http://id.loc.gov/vocabulary/relators/ill	ill	illustrator	Illustrator	Illustration
+http://id.loc.gov/vocabulary/relators/ilu	ilu	illuminator	Illuminator	Illuminator/in
+http://id.loc.gov/vocabulary/relators/ink	ink	inker	Inker
+http://id.loc.gov/vocabulary/relators/ins	ins	inscriber	Inscriber	Beschriftende Person
+http://id.loc.gov/vocabulary/relators/inv	inv	inventor	Inventor	Erfinder/in
+http://id.loc.gov/vocabulary/relators/isb	isb	issuing body	Issuing body	Herausgeber/in
+http://id.loc.gov/vocabulary/relators/itr	itr	instrumentalist	Instrumentalist	Instrumentalmusiker/in
+http://id.loc.gov/vocabulary/relators/ive	ive	interviewee	Interviewee	Interviewte/r
+http://id.loc.gov/vocabulary/relators/ivr	ivr	interviewer	Interviewer	Interviewer/in
+http://id.loc.gov/vocabulary/relators/jud	jud	judge	Judge	Richter/in
+http://id.loc.gov/vocabulary/relators/jug	jug	jurisdiction governed	Jurisdiction governed	Geregelte Gebietskörperschaft
+http://id.loc.gov/vocabulary/relators/lbr	lbr	laboratory	Laboratory
+http://id.loc.gov/vocabulary/relators/lbt	lbt	librettist	Librettist	Libretto
+http://id.loc.gov/vocabulary/relators/ldr	ldr	laboratory director	Laboratory director
+http://id.loc.gov/vocabulary/relators/led	led	lead	Lead	Leitung
+http://id.loc.gov/vocabulary/relators/lee	lee	libelee-appellee	Libelee-appellee
+http://id.loc.gov/vocabulary/relators/lel	lel	libelee	Libelee
+http://id.loc.gov/vocabulary/relators/len	len	lender	Lender
+http://id.loc.gov/vocabulary/relators/let	let	libelee-appellant	Libelee-appellant
+http://id.loc.gov/vocabulary/relators/lgd	lgd	lighting designer	Lighting designer	Lichtgestaltung
+http://id.loc.gov/vocabulary/relators/lie	lie	libelant-appellee	Libelant-appellee
+http://id.loc.gov/vocabulary/relators/lil	lil	libelant	Libelant
+http://id.loc.gov/vocabulary/relators/lit	lit	libelant-appellant	Libelant-appellant
+http://id.loc.gov/vocabulary/relators/lsa	lsa	landscape architect	Landscape architect	Landschaftsarchitekt/in
+http://id.loc.gov/vocabulary/relators/lse	lse	licensee	Licensee
+http://id.loc.gov/vocabulary/relators/lso	lso	licensor	Licensor
+http://id.loc.gov/vocabulary/relators/ltg	ltg	lithographer	Lithographer	Lithografie
+http://id.loc.gov/vocabulary/relators/ltr	ltr	letterer	Letterer	Letterer
+http://id.loc.gov/vocabulary/relators/lyr	lyr	lyricist	Lyricist	Textdichter/in
+http://id.loc.gov/vocabulary/relators/mcp	mcp	music copyist	Music copyist
+http://id.loc.gov/vocabulary/relators/mdc	mdc	metadata contact	Metadata contact
+http://id.loc.gov/vocabulary/relators/med	med	medium	Medium	Medium
+http://id.loc.gov/vocabulary/relators/mfp	mfp	manufacture place	Manufacture place
+http://id.loc.gov/vocabulary/relators/mfr	mfr	manufacturer	Manufacturer	Herstellung
+http://id.loc.gov/vocabulary/relators/mka	mka	makeup artist	Makeup artist	Maskenbildner/in
+http://id.loc.gov/vocabulary/relators/mod	mod	moderator	Moderator	Moderation
+http://id.loc.gov/vocabulary/relators/mon	mon	monitor	Monitor
+http://id.loc.gov/vocabulary/relators/mrb	mrb	marbler	Marbler
+http://id.loc.gov/vocabulary/relators/mrk	mrk	markup editor	Markup editor
+http://id.loc.gov/vocabulary/relators/msd	msd	musical director	Musical director	Musikalische Leitung
+http://id.loc.gov/vocabulary/relators/mte	mte	metal engraver	Metal engraver
+http://id.loc.gov/vocabulary/relators/mtk	mtk	minute taker	Minute taker	Protokoll
+http://id.loc.gov/vocabulary/relators/mup	mup	music programmer	Music programmer	Musik-Programmierer/in
+http://id.loc.gov/vocabulary/relators/mus	mus	musician	Musician	Musiker/in
+http://id.loc.gov/vocabulary/relators/mxe	mxe	mixing engineer	Mixing engineer	Mischtontechniker/in
+http://id.loc.gov/vocabulary/relators/nan	nan	news anchor	News anchor
+http://id.loc.gov/vocabulary/relators/nrt	nrt	narrator	Narrator	Erzähler/in
+http://id.loc.gov/vocabulary/relators/onp	onp	onscreen participant	Onscreen participant	On-Screen-Teilnehmer/in
+http://id.loc.gov/vocabulary/relators/opn	opn	opponent	Opponent
+http://id.loc.gov/vocabulary/relators/org	org	originator	Originator	Begründet durch
+http://id.loc.gov/vocabulary/relators/orm	orm	organizer	Organizer	Veranstalter/in
+http://id.loc.gov/vocabulary/relators/osp	osp	onscreen presenter	On-screen presenter	On-Screen-Präsentator/in
+http://id.loc.gov/vocabulary/relators/oth	oth	other	Other agent associated with a work	Sonstige
+http://id.loc.gov/vocabulary/relators/own	own	owner	Owner	Eigentümer/in
+http://id.loc.gov/vocabulary/relators/pad	pad	place of address	Place of address
+http://id.loc.gov/vocabulary/relators/pan	pan	panelist	Panelist	Diskussionsteilnehmer/in
+http://id.loc.gov/vocabulary/relators/pat	pat	patron	Commissioning body	Im Auftrag von
+http://id.loc.gov/vocabulary/relators/pbd	pbd	publisher director	Editorial director	Chefredaktion
+http://id.loc.gov/vocabulary/relators/pbl	pbl	publisher	Publisher	Verlag
+http://id.loc.gov/vocabulary/relators/pdr	pdr	project director	Project director
+http://id.loc.gov/vocabulary/relators/pfr	pfr	proofreader	Proofreader
+http://id.loc.gov/vocabulary/relators/pht	pht	photographer	Photographer	Fotografie
+http://id.loc.gov/vocabulary/relators/plt	plt	platemaker	Platemaker	Druckformherstellung
+http://id.loc.gov/vocabulary/relators/pma	pma	permitting agency	Permitting agency
+http://id.loc.gov/vocabulary/relators/pmn	pmn	production manager	Production manager
+http://id.loc.gov/vocabulary/relators/pnc	pnc	penciller	Penciller
+http://id.loc.gov/vocabulary/relators/pop	pop	printer of plates	Printer of plates
+http://id.loc.gov/vocabulary/relators/ppm	ppm	papermaker	Papermaker	Papiermacher/in
+http://id.loc.gov/vocabulary/relators/ppt	ppt	puppeteer	Puppeteer	Puppenspieler/in
+http://id.loc.gov/vocabulary/relators/pra	pra	praeses	Praeses	Praeses
+http://id.loc.gov/vocabulary/relators/prc	prc	process contact	Process contact
+http://id.loc.gov/vocabulary/relators/prd	prd	production personnel	Production personnel
+http://id.loc.gov/vocabulary/relators/pre	pre	presenter	Presenter	Präsentation
+http://id.loc.gov/vocabulary/relators/prf	prf	performer	Performer	Ausführende/r
+http://id.loc.gov/vocabulary/relators/prg	prg	programmer	Programmer	Programmierung
+http://id.loc.gov/vocabulary/relators/prm	prm	printmaker	Printmaker	Druckgrafik
+http://id.loc.gov/vocabulary/relators/prn	prn	production company	Production company	Produktionsfirma
+http://id.loc.gov/vocabulary/relators/pro	pro	producer	Producer	Produktion
+http://id.loc.gov/vocabulary/relators/prp	prp	production place	Production place
+http://id.loc.gov/vocabulary/relators/prs	prs	production designer	Production designer	Produktionsdesign
+http://id.loc.gov/vocabulary/relators/prt	prt	printer	Printer	Druck
+http://id.loc.gov/vocabulary/relators/prv	prv	provider	Provider
+http://id.loc.gov/vocabulary/relators/pta	pta	patent applicant	Patent applicant
+http://id.loc.gov/vocabulary/relators/pte	pte	plaintiff-appellee	Plaintiff-appellee
+http://id.loc.gov/vocabulary/relators/ptf	ptf	plaintiff	Plaintiff	Zivilkläger/in
+http://id.loc.gov/vocabulary/relators/pth	pth	patent holder	Patent holder
+http://id.loc.gov/vocabulary/relators/ptt	ptt	plaintiff-appellant	Plaintiff-appellant
+http://id.loc.gov/vocabulary/relators/pup	pup	publication place	Publication place
+http://id.loc.gov/vocabulary/relators/rap	rap	rapporteur	Rapporteur	Berichterstatter/in
+http://id.loc.gov/vocabulary/relators/rbr	rbr	rubricator	Rubricator
+http://id.loc.gov/vocabulary/relators/rcd	rcd	recordist	Recordist	Ton
+http://id.loc.gov/vocabulary/relators/rce	rce	recording engineer	Recording engineer	Aufnahmetechniker/in
+http://id.loc.gov/vocabulary/relators/rcp	rcp	addressee	Addressee	Adressat/in
+http://id.loc.gov/vocabulary/relators/rdd	rdd	radio director	Radio director	Hörfunkregisseur/in
+http://id.loc.gov/vocabulary/relators/red	red	redaktor	Redaktor	Redaktion
+http://id.loc.gov/vocabulary/relators/ren	ren	renderer	Renderer
+http://id.loc.gov/vocabulary/relators/res	res	researcher	Researcher	Forscher/in
+http://id.loc.gov/vocabulary/relators/rev	rev	reviewer	Reviewer
+http://id.loc.gov/vocabulary/relators/rpc	rpc	radio producer	Radio producer	Hörfunkproduktion
+http://id.loc.gov/vocabulary/relators/rps	rps	repository	Repository
+http://id.loc.gov/vocabulary/relators/rpt	rpt	reporter	Reporter
+http://id.loc.gov/vocabulary/relators/rpy	rpy	responsible party	Responsible party
+http://id.loc.gov/vocabulary/relators/rse	rse	respondent-appellee	Respondent-appellee
+http://id.loc.gov/vocabulary/relators/rsg	rsg	restager	Restager
+http://id.loc.gov/vocabulary/relators/rsp	rsp	respondent	Respondent	Respondent/in
+http://id.loc.gov/vocabulary/relators/rsr	rsr	restorationist	Restorationist	Restaurator/in
+http://id.loc.gov/vocabulary/relators/rst	rst	respondent-appellant	Respondent-appellant
+http://id.loc.gov/vocabulary/relators/rth	rth	research team head	Research team head
+http://id.loc.gov/vocabulary/relators/rtm	rtm	research team member	Research team member
+http://id.loc.gov/vocabulary/relators/rxa	rxa	remix artist	Remix artist	Remix Artist
+http://id.loc.gov/vocabulary/relators/sad	sad	scientific advisor	Scientific advisor
+http://id.loc.gov/vocabulary/relators/sce	sce	scenarist	Scenarist
+http://id.loc.gov/vocabulary/relators/scl	scl	sculptor	Sculptor	Bildhauer/in
+http://id.loc.gov/vocabulary/relators/scr	scr	scribe	Scribe
+http://id.loc.gov/vocabulary/relators/sde	sde	sound engineer	Sound engineer
+http://id.loc.gov/vocabulary/relators/sds	sds	sound designer	Sound designer	Tongestaltung
+http://id.loc.gov/vocabulary/relators/sec	sec	secretary	Secretary
+http://id.loc.gov/vocabulary/relators/sfx	sfx	special effects provider	Special effects provider	Special-effects-Provider
+http://id.loc.gov/vocabulary/relators/sgd	sgd	stage director	Stage director	Bühnenregie
+http://id.loc.gov/vocabulary/relators/sgn	sgn	signer	Signer
+http://id.loc.gov/vocabulary/relators/sht	sht	supporting host	Supporting host
+http://id.loc.gov/vocabulary/relators/sll	sll	seller	Seller	Verkäufer/in
+http://id.loc.gov/vocabulary/relators/sng	sng	singer	Singer	Gesang
+http://id.loc.gov/vocabulary/relators/spk	spk	speaker	Speaker	Redner/in
+http://id.loc.gov/vocabulary/relators/spn	spn	sponsor	Sponsoring body	Träger/in
+http://id.loc.gov/vocabulary/relators/spy	spy	second party	Second party
+http://id.loc.gov/vocabulary/relators/srv	srv	surveyor	Surveyor	Landvermessung
+http://id.loc.gov/vocabulary/relators/std	std	set designer	Set designer
+http://id.loc.gov/vocabulary/relators/stg	stg	setting	Setting
+http://id.loc.gov/vocabulary/relators/stl	stl	storyteller	Storyteller	Geschichtenerzähler/in
+http://id.loc.gov/vocabulary/relators/stm	stm	stage manager	Stage manager
+http://id.loc.gov/vocabulary/relators/stn	stn	standards body	Standards body
+http://id.loc.gov/vocabulary/relators/str	str	stereotyper	Stereotyper
+http://id.loc.gov/vocabulary/relators/swd	swd	software developer	Software developer	Softwareentwickler/in
+http://id.loc.gov/vocabulary/relators/tad	tad	technical advisor	Technical advisor
+http://id.loc.gov/vocabulary/relators/tau	tau	television writer	Television writer
+http://id.loc.gov/vocabulary/relators/tcd	tcd	technical director	Technical director
+http://id.loc.gov/vocabulary/relators/tch	tch	teacher	Teacher	Ausbilder/in
+http://id.loc.gov/vocabulary/relators/ths	ths	thesis advisor	Thesis advisor
+http://id.loc.gov/vocabulary/relators/tld	tld	television director	Television director	Fernsehregie
+http://id.loc.gov/vocabulary/relators/tlg	tlg	television guest	Television guest
+http://id.loc.gov/vocabulary/relators/tlh	tlh	television host	Television host
+http://id.loc.gov/vocabulary/relators/tlp	tlp	television producer	Television producer	Fernsehproduktion
+http://id.loc.gov/vocabulary/relators/trc	trc	transcriber	Transcriber	Transkription
+http://id.loc.gov/vocabulary/relators/trl	trl	translator	Translator	Übersetzung
+http://id.loc.gov/vocabulary/relators/tyd	tyd	type designer	Type designer
+http://id.loc.gov/vocabulary/relators/tyg	tyg	typographer	Typographer
+http://id.loc.gov/vocabulary/relators/uvp	uvp	university place	University place
+http://id.loc.gov/vocabulary/relators/vac	vac	voice actor	Voice actor	Synchronsprecher/in
+http://id.loc.gov/vocabulary/relators/vdg	vdg	videographer	Director of photography	Kamera
+http://id.loc.gov/vocabulary/relators/vfx	vfx	visual effects provider	Visual effects provider	Visual-effects-Provider
+http://id.loc.gov/vocabulary/relators/voc	voc	vocalist	Vocalist
+http://id.loc.gov/vocabulary/relators/wac	wac	writer of added commentary	Writer of added commentary	Zusätzlicher Kommentar
+http://id.loc.gov/vocabulary/relators/wal	wal	writer of added lyrics	Writer of added lyrics	Verfasser/in von zusätzlichen Lyrics
+http://id.loc.gov/vocabulary/relators/wam	wam	writer of accompanying material	Writer of accompanying material
+http://id.loc.gov/vocabulary/relators/wat	wat	writer of added text	Writer of added text	Zusätzlicher Text
+http://id.loc.gov/vocabulary/relators/waw	waw	writer of afterword	Writer of afterword	Verfasser/in eines Nachworts
+http://id.loc.gov/vocabulary/relators/wdc	wdc	woodcutter	Woodcutter
+http://id.loc.gov/vocabulary/relators/wde	wde	wood engraver	Wood engraver
+http://id.loc.gov/vocabulary/relators/wfs	wfs	writer of film story	Writer of film story
+http://id.loc.gov/vocabulary/relators/wft	wft	writer of intertitles	Writer of intertitles
+http://id.loc.gov/vocabulary/relators/wfw	wfw	writer of foreword	Writer of foreword	Verfasser/in eines Geleitworts
+http://id.loc.gov/vocabulary/relators/win	win	writer of introduction	Writer of introduction	Einleitung
+http://id.loc.gov/vocabulary/relators/wit	wit	witness	Witness
+http://id.loc.gov/vocabulary/relators/wpr	wpr	writer of preface	Writer of preface	Vorwort
+http://id.loc.gov/vocabulary/relators/wst	wst	writer of supplementary textual content	Writer of supplementary textual content	Verfasser/in von ergänzendem Text
+http://id.loc.gov/vocabulary/relators/wts	wts	writer of television story	Writer of television story

--- a/etl/hebisMarc2lobid-transformation/marcToLobid.fix
+++ b/etl/hebisMarc2lobid-transformation/marcToLobid.fix
@@ -14,8 +14,8 @@ add_field("@context","http://lobid.org/resources/context.jsonld")
 
 # Set empty elements to manipulate the order winthin the record.
 add_field("id","")
-set_array("type[]")
-set_array("medium[]")
+add_array("type[]")
+add_array("medium[]")
 add_field("title","")
 add_field("rpbId","")
 
@@ -28,31 +28,49 @@ do list(path:"880??","var":"$i")
   replace_all("$i.@script.label","(\\d{3}-\\d{2})/(.*)","$2")
   lookup("$i.@script.label","ISO15924-to-script")
 end
-set_array("alternateGraphicRepresentation[]")
+add_array("alternateGraphicRepresentation[]")
+
+if any_match("leader",".{6}(a[bis]|m[bis]).*")
+  add_field("@ContinuingResources","true")
+elsif any_match("006", "^[s]")
+  add_field("@ContinuingResources","true")
+end
 
 include ("./fix/identifiers.fix")
 include ("./fix/titleRelatedFields.fix")
 include ("./fix/describedBy.fix")
+include ("./fix/subjects.fix")
+include ("./fix/item.fix")
 # identifiers.fix and titleRelatedFields.fix are needed ahead of relatedRessourcesAndLinks.fix because of dependencies
 include ("./fix/relatedRessourcesAndLinks.fix")
 include ("./fix/otherFields.fix")
-include ("./fix/subjects.fix")
-include ("./fix/item.fix")
 include ("./fix/mediumAndType.fix")
 # mediumAndType.fix is needed ahead of contribution.fix because of dependencies
 include ("./fix/contribution.fix")
+
+do list(path:"alternateGraphicRepresentation[]","var":"$i")
+  unless any_match("$i.script.id","https://unicode.org/iso15924/iso15924.txt#.+")
+    add_field("$i.script.id","https://unicode.org/iso15924/iso15924.txt#Zzzz")
+    add_field("$i.script.label","Kein Schriftcode vergeben")
+  end
+end
 
 vacuum()
 retain(
   "@context",
   "abstract[]",
+  "accessRights",
   "almaMmsId",
   "alternateGraphicRepresentation[]",
   "alternativeTitle[]",
   "bibliographicCitation",
   "bibliographicLevel",
+  "bszId",
+  "bvbId",
   "describedBy",
   "description[]",
+  "disambiguatingDescription[]",
+  "conditionsOfAccess",
   "containedIn[]",
   "containsExampleOfWork[]",
   "contribution[]",
@@ -63,8 +81,10 @@ retain(
   "edition[]",
   "exampleOfWork",
   "fulltextOnline[]",
+  "gbvId",
   "hasItem[]",
   "secondaryForm[]",
+  "hebisId",
   "hbzId",
   "id",
   "inCollection[]",
@@ -72,6 +92,8 @@ retain(
   "issn[]",
   "ismn[]",
   "isPartOf[]",
+  "k10PlusId",
+  "kobvId",
   "language[]",
   "langNote[]",
   "license[]",
@@ -79,6 +101,7 @@ retain(
   "medium[]",
   "natureOfContent[]",
   "note[]",
+  "obvId",
   "oclcNumber[]",
   "otherTitleInformation[]",
   "publication[]",

--- a/etl/output/test-hebis-to-lobid-output-0.json
+++ b/etl/output/test-hebis-to-lobid-output-0.json
@@ -9,6 +9,7 @@
   "title" : "Wie wir wurden was wir sind - 10-jähriges Jubiläum des Mehrgenerationenhauses Ingelheim",
   "almaMmsId" : "514226781",
   "oclcNumber" : [ "1415743560" ],
+  "hebisId" : "514226781",
   "publication" : [ {
     "dateStatement" : "[2019?]",
     "startDate" : "2019",
@@ -23,18 +24,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1415743560",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=514226781#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "62 Seiten : Illustrationen",
   "natureOfContent" : [ {
     "label" : "Festschrift",
     "id" : "https://d-nb.info/gnd/4016928-5"
@@ -49,6 +38,18 @@
     },
     "id" : "http://lobid.org/items/514226781:DE-36:K+2023+Q+152#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1415743560",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=514226781#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "62 Seiten : Illustrationen",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-1.json
+++ b/etl/output/test-hebis-to-lobid-output-1.json
@@ -9,6 +9,7 @@
   "title" : "Alter Dom St. Johannis",
   "almaMmsId" : "512839662",
   "oclcNumber" : [ "1407066536" ],
+  "hebisId" : "512839662",
   "otherTitleInformation" : [ "1500 Jahre Geschichte im Herzen von Mainz" ],
   "publication" : [ {
     "dateStatement" : "[2023?]",
@@ -24,22 +25,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1407066536",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=512839662#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "related" : [ {
-    "note" : [ "Parallele Sprachausgabe englisch" ],
-    "label" : "The ancient cathedral St. John"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "1 gefaltetes Blatt ( 16 Seiten) : Illustrationen",
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -59,6 +44,22 @@
     },
     "id" : "http://lobid.org/items/512839662:DE-36:Mog+m+7188%2C+2.+Ex.#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1407066536",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=512839662#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "related" : [ {
+    "note" : [ "Parallele Sprachausgabe englisch" ],
+    "label" : "The ancient cathedral St. John"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "1 gefaltetes Blatt ( 16 Seiten) : Illustrationen",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-10.json
+++ b/etl/output/test-hebis-to-lobid-output-10.json
@@ -11,6 +11,7 @@
   "isbn" : [ "3874394883", "9783874394888" ],
   "oclcNumber" : [ "76115483" ],
   "dnbId" : "958853371",
+  "hebisId" : "090358163",
   "otherTitleInformation" : [ "2000 Jahre einer Stadt ; [Stadtbegleiter]" ],
   "publication" : [ {
     "dateStatement" : "[ca. 2000]",
@@ -26,21 +27,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/76115483",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/958853371",
-    "label" : "DNB-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=090358163#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "127 Seiten : Illustrationen, Karten",
   "natureOfContent" : [ {
     "label" : "Führer",
     "id" : "https://d-nb.info/gnd/4155569-7"
@@ -91,6 +77,21 @@
     },
     "id" : "http://lobid.org/items/090358163:DE-36:Mog+3537#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/76115483",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/958853371",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=090358163#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "127 Seiten : Illustrationen, Karten",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-11.json
+++ b/etl/output/test-hebis-to-lobid-output-11.json
@@ -11,6 +11,7 @@
   "isbn" : [ "3874395340", "9783874395342" ],
   "oclcNumber" : [ "57680814" ],
   "dnbId" : "958645337",
+  "hebisId" : "090363000",
   "otherTitleInformation" : [ "2000 years of a city ; [city guide]" ],
   "publication" : [ {
     "dateStatement" : "[2000]",
@@ -26,21 +27,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/57680814",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/958645337",
-    "label" : "DNB-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=090363000#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
-    "label" : "Englisch"
-  } ],
-  "extent" : "127 Seiten : Illustrationen, Diagramme, Karten",
   "natureOfContent" : [ {
     "label" : "Führer",
     "id" : "https://d-nb.info/gnd/4155569-7"
@@ -82,6 +68,21 @@
     },
     "id" : "http://lobid.org/items/090363000:DE-36:Mog+2727#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/57680814",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/958645337",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=090363000#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
+    "label" : "Englisch"
+  } ],
+  "extent" : "127 Seiten : Illustrationen, Diagramme, Karten",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-12.json
+++ b/etl/output/test-hebis-to-lobid-output-12.json
@@ -29,29 +29,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1403376624",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/1271796821",
-    "label" : "DNB-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=508037980#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "tableOfContents" : [ {
-    "label" : "Inhaltsverzeichnis",
-    "id" : "https://d-nb.info/1271796821/04"
-  } ],
-  "related" : [ {
-    "note" : [ "Online-Ausgabe" ],
-    "label" : "Auszeiten für die Seele im Rhein-Main-Gebiet"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "191 Seiten : Illustrationen, Karten ; 20 cm, 520 g",
   "natureOfContent" : [ {
     "label" : "Führer",
     "id" : "https://d-nb.info/gnd/4155569-7"
@@ -177,6 +154,29 @@
     },
     "id" : "http://lobid.org/items/508037980:DE-36:2023%2F589#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1403376624",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/1271796821",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=508037980#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "tableOfContents" : [ {
+    "label" : "Inhaltsverzeichnis",
+    "id" : "https://d-nb.info/1271796821/04"
+  } ],
+  "related" : [ {
+    "note" : [ "Online-Ausgabe" ],
+    "label" : "Auszeiten für die Seele im Rhein-Main-Gebiet"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "191 Seiten : Illustrationen, Karten ; 20 cm, 520 g",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-13.json
+++ b/etl/output/test-hebis-to-lobid-output-13.json
@@ -26,26 +26,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1282186376",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/1244538620",
-    "label" : "DNB-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=487803779#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "tableOfContents" : [ {
-    "label" : "Inhaltsverzeichnis",
-    "id" : "https://d-nb.info/1244538620/04"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "175 Seiten : Illustrationen ; 23.5 cm x 13.5 cm",
-  "note" : [ "Quellen- und Literaturverzeichnis Seite 172-175" ],
   "subject" : [ {
     "type" : [ "Concept" ],
     "source" : {
@@ -186,6 +166,26 @@
     },
     "id" : "http://lobid.org/items/487803779:DE-36:Mog+3175#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1282186376",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/1244538620",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=487803779#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "tableOfContents" : [ {
+    "label" : "Inhaltsverzeichnis",
+    "id" : "https://d-nb.info/1244538620/04"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "175 Seiten : Illustrationen ; 23.5 cm x 13.5 cm",
+  "note" : [ "Quellen- und Literaturverzeichnis Seite 172-175" ],
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-14.json
+++ b/etl/output/test-hebis-to-lobid-output-14.json
@@ -25,37 +25,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1512396052",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/1361254696",
-    "label" : "DNB-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=528269186#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "isPartOf" : [ {
-    "hasSuperordinate" : [ {
-      "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=457093552#!",
-      "label" : "Mainzer Stadtspaziergänge"
-    } ],
-    "numbering" : "12",
-    "type" : [ "IsPartOfRelation" ]
-  } ],
-  "tableOfContents" : [ {
-    "label" : "Inhaltsverzeichnis",
-    "id" : "http://scans.hebis.de/HEBCGI/show.pl?52826918_toc.pdf"
-  } ],
-  "description" : [ {
-    "label" : "Inhaltstext",
-    "id" : "https://deposit.dnb.de/cgi-bin/dokserv?id=c5a29e7bbe3f4bd19f58cc452828594f"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "160 Seiten : Illustrationen ; 27 cm",
   "subject" : [ {
     "notation" : "943",
     "type" : [ "Concept" ],
@@ -100,6 +69,37 @@
     },
     "id" : "http://lobid.org/items/528269186:DE-36:Mog%3A4%C2%B0+%2F1776#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1512396052",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/1361254696",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=528269186#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=457093552#!",
+      "label" : "Mainzer Stadtspaziergänge"
+    } ],
+    "numbering" : "12",
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "tableOfContents" : [ {
+    "label" : "Inhaltsverzeichnis",
+    "id" : "http://scans.hebis.de/HEBCGI/show.pl?52826918_toc.pdf"
+  } ],
+  "description" : [ {
+    "label" : "Inhaltstext",
+    "id" : "https://deposit.dnb.de/cgi-bin/dokserv?id=c5a29e7bbe3f4bd19f58cc452828594f"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "160 Seiten : Illustrationen ; 27 cm",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-15.json
+++ b/etl/output/test-hebis-to-lobid-output-15.json
@@ -9,6 +9,7 @@
   "title" : "Mainzer Stadtspaziergänge",
   "almaMmsId" : "457093552",
   "dnbId" : "1203676662",
+  "hebisId" : "457093552",
   "publication" : [ {
     "dateStatement" : "Dezember 2019-",
     "startDate" : "2019",
@@ -29,17 +30,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "https://d-nb.info/1203676662",
-    "label" : "DNB-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=457093552#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
   "subject" : [ {
     "notation" : "943",
     "type" : [ "Concept" ],
@@ -81,6 +71,17 @@
       "label" : "Wissenschaftliche Stadtbibliothek Mainz"
     },
     "id" : "http://lobid.org/items/457093552:DE-36:Zur+Fortsetzung+bestellt#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://d-nb.info/1203676662",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=457093552#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
   } ],
   "bibliographicLevel" : {
     "label" : "Monograph/Item",

--- a/etl/output/test-hebis-to-lobid-output-16.json
+++ b/etl/output/test-hebis-to-lobid-output-16.json
@@ -11,6 +11,7 @@
   "isbn" : [ "3960310609", "9783960310600" ],
   "oclcNumber" : [ "1463358932" ],
   "dnbId" : "1343856876",
+  "hebisId" : "522434258",
   "publication" : [ {
     "dateStatement" : "[Herbst 2024]",
     "startDate" : "2024",
@@ -25,34 +26,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1463358932",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/1343856876",
-    "label" : "DNB-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=522434258#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "isPartOf" : [ {
-    "hasSuperordinate" : [ {
-      "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=457093552#!",
-      "label" : "Mainzer Stadtspaziergänge"
-    } ],
-    "numbering" : "11",
-    "type" : [ "IsPartOfRelation" ]
-  } ],
-  "tableOfContents" : [ {
-    "label" : "Inhaltsverzeichnis",
-    "id" : "http://scans.hebis.de/HEBCGI/show.pl?52243425_toc.pdf"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "152 Seiten : Illustrationen ; 27 cm x 20.5 cm, 440 g",
-  "note" : [ "Literaturverzeichnis Seite 152" ],
   "subject" : [ {
     "notation" : "943",
     "type" : [ "Concept" ],
@@ -97,6 +70,34 @@
     },
     "id" : "http://lobid.org/items/522434258:DE-36:Mog%3A4%C2%B0+%2F1752#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1463358932",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/1343856876",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=522434258#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=457093552#!",
+      "label" : "Mainzer Stadtspaziergänge"
+    } ],
+    "numbering" : "11",
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "tableOfContents" : [ {
+    "label" : "Inhaltsverzeichnis",
+    "id" : "http://scans.hebis.de/HEBCGI/show.pl?52243425_toc.pdf"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "152 Seiten : Illustrationen ; 27 cm x 20.5 cm, 440 g",
+  "note" : [ "Literaturverzeichnis Seite 152" ],
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-17.json
+++ b/etl/output/test-hebis-to-lobid-output-17.json
@@ -9,6 +9,7 @@
   "title" : "Die Alzeyer Kleinknechts, Band 2: Die @Alzeyer Kleinknechts ab der 5. Generation sowie ihre Verwandten und Vorfahren Schlink, Zollitsch und Becker",
   "almaMmsId" : "527546313",
   "oclcNumber" : [ "1501056568" ],
+  "hebisId" : "527546313",
   "otherTitleInformation" : [ "von 1795 bis 1969" ],
   "edition" : [ "Erweiterte Fassung" ],
   "publication" : [ {
@@ -25,6 +26,16 @@
       }
     }
   },
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "2025 Q 27",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Wissenschaftliche Stadtbibliothek Mainz"
+    },
+    "id" : "http://lobid.org/items/527546313:DE-36:2025+Q+27#!"
+  } ],
   "sameAs" : [ {
     "id" : "http://worldcat.org/oclc/1501056568",
     "label" : "OCLC-Ressource"
@@ -43,16 +54,6 @@
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"
-  } ],
-  "hasItem" : [ {
-    "label" : "lobid Bestandsressource",
-    "type" : [ "Item", "PhysicalObject" ],
-    "callNumber" : "2025 Q 27",
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-36#!",
-      "label" : "Wissenschaftliche Stadtbibliothek Mainz"
-    },
-    "id" : "http://lobid.org/items/527546313:DE-36:2025+Q+27#!"
   } ],
   "bibliographicLevel" : {
     "label" : "Monograph/Item",

--- a/etl/output/test-hebis-to-lobid-output-2.json
+++ b/etl/output/test-hebis-to-lobid-output-2.json
@@ -9,6 +9,7 @@
   "title" : "Miteinander für Integration - Das Ehrenamtsbündnis für Flüchtlingsarbeit stellt sich vor",
   "almaMmsId" : "512013683",
   "oclcNumber" : [ "1404835958" ],
+  "hebisId" : "512013683",
   "alternativeTitle" : [ "Miteinander für Integration in Mainz - Ehrenamtsbündnis für Flüchtlingsarbeit" ],
   "otherTitleInformation" : [ "eine Präsentation der vielfältigen und vielseitigen Angebotslandschaft ehrenamtlich engagierter Initiativen, Institutionen und Vereine in der Mainzer Flüchtlingsarbeit" ],
   "publication" : [ {
@@ -25,18 +26,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1404835958",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=512013683#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "24 Seiten : Illustrationen",
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -56,6 +45,18 @@
     },
     "id" : "http://lobid.org/items/512013683:DE-36:Mog+m%3A4%C2%B0+%2F3602%2C+2.+Ex.#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1404835958",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=512013683#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "24 Seiten : Illustrationen",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-3.json
+++ b/etl/output/test-hebis-to-lobid-output-3.json
@@ -9,6 +9,7 @@
   "title" : "Findet Hadi - Lernorte in der Ausstellung Der charismatische Ort - Stationen der reisenden Könige im Mittelalter",
   "almaMmsId" : "512849919",
   "oclcNumber" : [ "1407112396" ],
+  "hebisId" : "512849919",
   "otherTitleInformation" : [ "Rätselheft für Kinder und Erwachsene" ],
   "publication" : [ {
     "dateStatement" : "[2019]",
@@ -24,18 +25,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1407112396",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=512849919#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "12 Seiten : Illustrationen",
   "natureOfContent" : [ {
     "label" : "Kindersachbuch",
     "id" : "https://d-nb.info/gnd/4163854-2"
@@ -53,6 +42,18 @@
     },
     "id" : "http://lobid.org/items/512849919:DE-36:K+2023+Q+140#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1407112396",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=512849919#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "12 Seiten : Illustrationen",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-4.json
+++ b/etl/output/test-hebis-to-lobid-output-4.json
@@ -9,6 +9,7 @@
   "title" : "Sportwoche Ingelheim am Rhein vom 10.-18. September 1977",
   "almaMmsId" : "516707701",
   "oclcNumber" : [ "1428135055" ],
+  "hebisId" : "516707701",
   "otherTitleInformation" : [ "Programm und Vereinsspiegel der teilnehmenden Vereine :" ],
   "publication" : [ {
     "dateStatement" : "September 1977",
@@ -24,18 +25,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1428135055",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=516707701#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "28 Seiten : Illustrationen",
   "natureOfContent" : [ {
     "label" : "Programmheft",
     "id" : "https://d-nb.info/gnd/4373950-7"
@@ -50,6 +39,18 @@
     },
     "id" : "http://lobid.org/items/516707701:DE-36:K+2024%2F20#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1428135055",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=516707701#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "28 Seiten : Illustrationen",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-5.json
+++ b/etl/output/test-hebis-to-lobid-output-5.json
@@ -8,6 +8,7 @@
   } ],
   "title" : "Liederheft",
   "almaMmsId" : "475390555",
+  "hebisId" : "475390555",
   "publication" : [ {
     "dateStatement" : "2002",
     "startDate" : "2002",
@@ -22,15 +23,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=475390555#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "40 Seiten : Illustrationen",
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -41,6 +33,15 @@
     },
     "id" : "http://lobid.org/items/475390555:DE-36:K+2021%2F46#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=475390555#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "40 Seiten : Illustrationen",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-6.json
+++ b/etl/output/test-hebis-to-lobid-output-6.json
@@ -10,6 +10,7 @@
   "almaMmsId" : "488844266",
   "isbn" : [ "9783739271699", "3739271698" ],
   "oclcNumber" : [ "1288418997" ],
+  "hebisId" : "488844266",
   "otherTitleInformation" : [ "Mörder in USA aus Region Bingen, Alzey" ],
   "publication" : [ {
     "dateStatement" : "[2015]",
@@ -25,6 +26,16 @@
       }
     }
   },
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "2021/1406",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-36#!",
+      "label" : "Wissenschaftliche Stadtbibliothek Mainz"
+    },
+    "id" : "http://lobid.org/items/488844266:DE-36:2021%2F1406#!"
+  } ],
   "sameAs" : [ {
     "id" : "http://worldcat.org/oclc/1288418997",
     "label" : "OCLC-Ressource"
@@ -37,16 +48,6 @@
     "label" : "Deutsch"
   } ],
   "extent" : "271 Seiten : Illustrationen",
-  "hasItem" : [ {
-    "label" : "lobid Bestandsressource",
-    "type" : [ "Item", "PhysicalObject" ],
-    "callNumber" : "2021/1406",
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-36#!",
-      "label" : "Wissenschaftliche Stadtbibliothek Mainz"
-    },
-    "id" : "http://lobid.org/items/488844266:DE-36:2021%2F1406#!"
-  } ],
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-7.json
+++ b/etl/output/test-hebis-to-lobid-output-7.json
@@ -26,26 +26,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1282186376",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/1244538620",
-    "label" : "DNB-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=487803779#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "tableOfContents" : [ {
-    "label" : "Inhaltsverzeichnis",
-    "id" : "https://d-nb.info/1244538620/04"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "175 Seiten : Illustrationen ; 23.5 cm x 13.5 cm",
-  "note" : [ "Quellen- und Literaturverzeichnis Seite 172-175" ],
   "subject" : [ {
     "type" : [ "Concept" ],
     "source" : {
@@ -186,6 +166,26 @@
     },
     "id" : "http://lobid.org/items/487803779:DE-36:Mog+3175#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1282186376",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/1244538620",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=487803779#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "tableOfContents" : [ {
+    "label" : "Inhaltsverzeichnis",
+    "id" : "https://d-nb.info/1244538620/04"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "175 Seiten : Illustrationen ; 23.5 cm x 13.5 cm",
+  "note" : [ "Quellen- und Literaturverzeichnis Seite 172-175" ],
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-8.json
+++ b/etl/output/test-hebis-to-lobid-output-8.json
@@ -10,6 +10,7 @@
   "almaMmsId" : "478607776",
   "oclcNumber" : [ "1196889751" ],
   "dnbId" : "121992976X",
+  "k10PlusId" : "1733109382",
   "alternativeTitle" : [ "Festschrift zur Wiederindienststellung zweitausendzwanzig" ],
   "otherTitleInformation" : [ "Festschrift zur Wiederindienststellung 2020" ],
   "publication" : [ {
@@ -31,25 +32,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1196889751",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/121992976X",
-    "label" : "DNB-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=478607776#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "tableOfContents" : [ {
-    "label" : "Inhaltsverzeichnis",
-    "id" : "https://d-nb.info/121992976X/04"
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "172 Seiten : Illustrationen ; 30 cm",
   "natureOfContent" : [ {
     "label" : "Festschrift",
     "id" : "https://d-nb.info/gnd/4016928-5"
@@ -99,6 +81,25 @@
     },
     "id" : "http://lobid.org/items/478607776:DE-36:2021+Q+511#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/1196889751",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/121992976X",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=478607776#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "tableOfContents" : [ {
+    "label" : "Inhaltsverzeichnis",
+    "id" : "https://d-nb.info/121992976X/04"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "172 Seiten : Illustrationen ; 30 cm",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"

--- a/etl/output/test-hebis-to-lobid-output-9.json
+++ b/etl/output/test-hebis-to-lobid-output-9.json
@@ -9,6 +9,7 @@
   "title" : "Gau-Algesheim",
   "almaMmsId" : "090680634",
   "oclcNumber" : [ "45021318" ],
+  "hebisId" : "090680634",
   "otherTitleInformation" : [ "mit Kamera und Herz eines Winzers gesehen" ],
   "publication" : [ {
     "dateStatement" : "2000",
@@ -24,25 +25,6 @@
       }
     }
   },
-  "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/45021318",
-    "label" : "OCLC-Ressource"
-  }, {
-    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=090680634#!",
-    "label" : "HEBIS-Ressource"
-  } ],
-  "isPartOf" : [ {
-    "hasSuperordinate" : [ {
-      "label" : "Beiträge zur Geschichte des Gau-Algesheimer Raumes"
-    } ],
-    "numbering" : "42",
-    "type" : [ "IsPartOfRelation" ]
-  } ],
-  "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
-    "label" : "Deutsch"
-  } ],
-  "extent" : "72 Seiten : Illustrationen",
   "natureOfContent" : [ {
     "label" : "Bildband",
     "id" : "https://d-nb.info/gnd/4145395-5"
@@ -68,6 +50,25 @@
     },
     "id" : "http://lobid.org/items/090680634:DE-36:2000%2F38#!"
   } ],
+  "sameAs" : [ {
+    "id" : "http://worldcat.org/oclc/45021318",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "http://cbsopac.rz.uni-frankfurt.de/DB=2.1/PPNSET?PPN=090680634#!",
+    "label" : "HEBIS-Ressource"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "label" : "Beiträge zur Geschichte des Gau-Algesheimer Raumes"
+    } ],
+    "numbering" : "42",
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "72 Seiten : Illustrationen",
   "bibliographicLevel" : {
     "label" : "Monograph/Item",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"


### PR DESCRIPTION
to current [lobid-resources master ](https://github.com/hbz/lobid-resources/commit/711cc95b4eed3d756e71e5c790beb2c3547cd5f5) while keeping the specifics for rpb/hebis.

@fsteeg I am not sure if the included `hebisId` could cause some problems since it will be added later by strapi.

@acka47 said that we should update since LBZ reported missing marc relator labels: https://github.com/hbz/lobid-resources/issues/2385